### PR TITLE
Workaround for replacing PlayerChunkMap#visibleChunks field

### DIFF
--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15/BukkitAdapter_1_15.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15/BukkitAdapter_1_15.java
@@ -12,6 +12,9 @@ import com.boydti.fawe.util.TaskManager;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
 import java.util.concurrent.locks.ReentrantLock;
 import net.jpountz.util.UnsafeUtils;
 import net.minecraft.server.v1_15_R1.*;
@@ -40,6 +43,8 @@ public final class BukkitAdapter_1_15 extends NMSAdapter {
     private final static Field fieldDirtyCount;
     private final static Field fieldDirtyBits;
 
+    private final static MethodHandle methodGetVisibleChunk;
+
     private static final int CHUNKSECTION_BASE;
     private static final int CHUNKSECTION_SHIFT;
 
@@ -65,6 +70,10 @@ public final class BukkitAdapter_1_15 extends NMSAdapter {
             fieldDirtyCount.setAccessible(true);
             fieldDirtyBits = PlayerChunk.class.getDeclaredField("r");
             fieldDirtyBits.setAccessible(true);
+
+            Method declaredGetVisibleChunk = PlayerChunkMap.class.getDeclaredMethod("getVisibleChunk", long.class);
+            declaredGetVisibleChunk.setAccessible(true);
+            methodGetVisibleChunk = MethodHandles.lookup().unreflect(declaredGetVisibleChunk);
 
             Field tmp = DataPaletteBlock.class.getDeclaredField("j");
             ReflectionUtils.setAccessibleNonFinal(tmp);
@@ -135,8 +144,11 @@ public final class BukkitAdapter_1_15 extends NMSAdapter {
 
     public static PlayerChunk getPlayerChunk(net.minecraft.server.v1_15_R1.WorldServer nmsWorld, final int cx, final int cz) {
         PlayerChunkMap chunkMap = nmsWorld.getChunkProvider().playerChunkMap;
-        PlayerChunk playerChunk = chunkMap.visibleChunks.get(ChunkCoordIntPair.pair(cx, cz));
-        return playerChunk;
+        try {
+            return (PlayerChunk)methodGetVisibleChunk.invoke(chunkMap, ChunkCoordIntPair.pair(cx, cz));
+        } catch (Throwable thr) {
+            throw new RuntimeException(thr);
+        }
     }
 
     public static void sendChunk(net.minecraft.server.v1_15_R1.WorldServer nmsWorld, int X, int Z, int mask) {


### PR DESCRIPTION
# Overview
**Fixes https://github.com/Spottedleaf/Tuinity/issues/17**
The issue is on my tracker since it's technically my code that's caused this issue, however the fix is simple and compatible with paper and below.

## Description
I run a fork of paper which replaces the visibleChunks and updatingChunks
field for gc performance reasons - visibleChunks is updated via
cloning updatingChunks, and at high chunk counts this causes gc issues
due to the humongous allocation it makes. Unfortunately the only solution is to
not clone the map (cloning is required for the thread-safety of the map) - which is why the field is removed.

Instead of BukkitAdapter_1_15_2#getPlayerChunk using the visibleChunks field,
it now uses a MethodHandle for PlayerChunkMap#getVisibleChunk. This method is
present on spigot & paper (only protected on spigot - which is why reflection is required),
and I preserve the same thread-safety it provides in my fork - so this solution
will not break compatibility with craftbukkit, spigot, or paper and fixes my issue.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
