### PR TITLE
Don't attempt to set blocks below 0 and above 255

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -820,6 +820,10 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
      * @throws WorldEditException thrown on a set error
      */
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, Stage stage) throws WorldEditException {
+        if (position.getBlockY() < 0 || position.getBlockY() > 255) {
+            return false;
+        }
+
         this.changes++;
         switch (stage) {
             case BEFORE_HISTORY:
@@ -841,6 +845,10 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
      * @return whether the block changed
      */
     public <B extends BlockStateHolder<B>> boolean rawSetBlock(BlockVector3 position, B block) {
+        if (position.getBlockY() < 0 || position.getBlockY() > 255) {
+            return false;
+        }
+
         this.changes++;
         try {
             return bypassAll.setBlock(position, block);
@@ -857,6 +865,10 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
      * @return whether the block changed
      */
     public <B extends BlockStateHolder<B>> boolean smartSetBlock(BlockVector3 position, B block) {
+        if (position.getBlockY() < 0 || position.getBlockY() > 255) {
+            return false;
+        }
+
         this.changes++;
         try {
             return setBlock(position, block, Stage.BEFORE_REORDER);
@@ -867,6 +879,10 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
 
     @Override
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block) throws MaxChangedBlocksException {
+        if (position.getBlockY() < 0 || position.getBlockY() > 255) {
+            return false;
+        }
+
         this.changes++;
         try {
             return this.getExtent().setBlock(position, block);
@@ -879,7 +895,11 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
 
 
     @Override
-    public <B extends BlockStateHolder<B>> boolean setBlock(int x, @Range(from = 0, to = 255) int y, int z, B block) {
+    public <B extends BlockStateHolder<B>> boolean setBlock(int x, int y, int z, B block) {
+        if (y < 0 || y > 255) {
+            return false;
+        }
+
         this.changes++;
         try {
             return this.getExtent().setBlock(x, y, z, block);
@@ -899,6 +919,10 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
     public boolean setBlock(int x, int y, int z, Pattern pattern) {
+        if (y < 0 || y > 255) {
+            return false;
+        }
+
         this.changes++;
         try {
             BlockVector3 bv = mutablebv.setComponents(x, y, z);
@@ -917,6 +941,10 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
      * @throws MaxChangedBlocksException thrown if too many blocks are changed
      */
     public boolean setBlock(BlockVector3 position, Pattern pattern) throws MaxChangedBlocksException {
+        if (position.getBlockY() < 0 || position.getBlockY() > 255) {
+            return false;
+        }
+
         this.changes++;
         try {
             return pattern.apply(this.getExtent(), position, position);


### PR DESCRIPTION
## Overview
**Fixes #307**

## Description
Attempting to set a block below Y: 0 and above Y: 255 results in an out of bounds error which can spam console when pasting or stacking large amount of blocks and delay world edits from completing. This PR will simply skip setting blocks outside of the Y: 0-255 range.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
