### PR TITLE
use JavaPlugin.getResource() instead of JarFile.getEntry()

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -438,11 +438,9 @@ public class WorldEditPlugin extends JavaPlugin { //implements TabCompleter
     protected void createDefaultConfiguration(String name) {
         File actual = new File(getDataFolder(), name);
         if (!actual.exists()) {
-            try {
-                try (InputStream stream = getResource("defaults/" + name)) {
-                    if (stream == null) throw new FileNotFoundException();
-                    copyDefaultConfig(stream, actual, name);
-                }
+            try (InputStream stream = getResource("defaults/" + name)) {
+                if (stream == null) throw new FileNotFoundException();
+                copyDefaultConfig(stream, actual, name);
             } catch (IOException e) {
                 getLogger().severe("Unable to read default configuration: " + name);
             }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -91,9 +91,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.jar.JarFile;
 import java.util.logging.Level;
-import java.util.zip.ZipEntry;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.sk89q.worldedit.internal.anvil.ChunkDeleter.DELCHUNKS_FILE_NAME;

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -440,10 +440,10 @@ public class WorldEditPlugin extends JavaPlugin { //implements TabCompleter
     protected void createDefaultConfiguration(String name) {
         File actual = new File(getDataFolder(), name);
         if (!actual.exists()) {
-            try (JarFile file = new JarFile(getFile())) {
-                ZipEntry copy = file.getEntry("defaults/" + name);
-                if (copy == null) throw new FileNotFoundException();
-                copyDefaultConfig(file.getInputStream(copy), actual, name);
+            try {
+                InputStream stream = getResource("defaults/" + name);
+                if (stream == null) throw new FileNotFoundException();
+                copyDefaultConfig(stream, actual, name);
             } catch (IOException e) {
                 getLogger().severe("Unable to read default configuration: " + name);
             }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -439,9 +439,10 @@ public class WorldEditPlugin extends JavaPlugin { //implements TabCompleter
         File actual = new File(getDataFolder(), name);
         if (!actual.exists()) {
             try {
-                InputStream stream = getResource("defaults/" + name);
-                if (stream == null) throw new FileNotFoundException();
-                copyDefaultConfig(stream, actual, name);
+                try (InputStream stream = getResource("defaults/" + name)) {
+                    if (stream == null) throw new FileNotFoundException();
+                    copyDefaultConfig(stream, actual, name);
+                }
             } catch (IOException e) {
                 getLogger().severe("Unable to read default configuration: " + name);
             }


### PR DESCRIPTION
## Overview

## Description

use JavaPlugin.getResource() instead of JarFile.getEntry()

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
