### PR TITLE
Fix tab completion

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -654,6 +654,8 @@ public class WorldEditPlugin extends JavaPlugin { //implements TabCompleter
             int firstSpace = buffer.indexOf(' ');
             if (firstSpace < 0) return;
             String label = buffer.substring(0, firstSpace);
+            // Strip leading slash, if present.
+            label = label.startsWith("/") ? label.substring(1) : label;
             final Optional<org.enginehub.piston.Command> command
                     = WorldEdit.getInstance().getPlatformManager().getPlatformCommandManager().getCommandManager().getCommand(label);
             if (!command.isPresent()) return;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -815,7 +815,10 @@ public final class PlatformCommandManager {
     @Subscribe
     public void handleCommandSuggestion(CommandSuggestionEvent event) {
         try {
-            String arguments = event.getArguments();
+            String rawArgs = event.getArguments();
+            // Increase the resulting positions by 1 if we remove a leading `/`
+            final int posOffset = rawArgs.startsWith("/") ? 1 : 0;
+            String arguments = rawArgs.startsWith("/") ? rawArgs.substring(1) : rawArgs;
             List<Substring> split = parseArgs(arguments).collect(Collectors.toList());
             List<String> argStrings = split.stream()
                 .map(Substring::getSubstring)
@@ -837,11 +840,10 @@ public final class PlatformCommandManager {
                     Substring original = suggestion.getReplacedArgument() == split.size()
                         ? Substring.from(arguments, noSlashLength, noSlashLength)
                         : split.get(suggestion.getReplacedArgument());
-                    // increase original points by 1, for removed `/` in `parseArgs`
                     return Substring.wrap(
                         suggestion.getSuggestion(),
-                        original.getStart() + 1,
-                        original.getEnd() + 1
+                        original.getStart() + posOffset,
+                        original.getEnd() + posOffset
                     );
                 }).collect(Collectors.toList()));
         } catch (ConditionFailedException e) {


### PR DESCRIPTION
## Overview
Fixes tab completion in all commands.

**Fixes #256**

## Description
Prior to this, tab completion was completely broken. It would either do nothing (try `//brush <tab>`), or throw errors (try `/brush <tab>`).

## Checklist
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
