### PR TITLE
Fix clamping issue

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/binding/PrimitiveBindings.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/binding/PrimitiveBindings.java
@@ -105,13 +105,13 @@ public class PrimitiveBindings extends Bindings {
         final double radiusX, radiusY, radiusZ;
         switch (radii.length) {
             case 1:
-                radiusX = radiusY = radiusZ = Math.max(1, PrimitiveBindings.parseNumericInput(radii[0]));
+                radiusX = radiusY = radiusZ = PrimitiveBindings.parseNumericInput(radii[0]);
                 break;
 
             case 3:
-                radiusX = Math.max(1, PrimitiveBindings.parseNumericInput(radii[0]));
-                radiusY = Math.max(1, PrimitiveBindings.parseNumericInput(radii[1]));
-                radiusZ = Math.max(1, PrimitiveBindings.parseNumericInput(radii[2]));
+                radiusX = PrimitiveBindings.parseNumericInput(radii[0]);
+                radiusY = PrimitiveBindings.parseNumericInput(radii[1]);
+                radiusZ = PrimitiveBindings.parseNumericInput(radii[2]);
                 break;
 
             default:
@@ -135,12 +135,12 @@ public class PrimitiveBindings extends Bindings {
         final double radiusX, radiusZ;
         switch (radii.length) {
             case 1:
-                radiusX = radiusZ = Math.max(1, PrimitiveBindings.parseNumericInput(radii[0]));
+                radiusX = radiusZ = PrimitiveBindings.parseNumericInput(radii[0]);
                 break;
 
             case 2:
-                radiusX = Math.max(1, PrimitiveBindings.parseNumericInput(radii[0]));
-                radiusZ = Math.max(1, PrimitiveBindings.parseNumericInput(radii[1]));
+                radiusX = PrimitiveBindings.parseNumericInput(radii[0]);
+                radiusZ = PrimitiveBindings.parseNumericInput(radii[1]);
                 break;
 
             default:
@@ -163,13 +163,13 @@ public class PrimitiveBindings extends Bindings {
         final double radiusX, radiusY, radiusZ;
         switch (radii.length) {
             case 1:
-                radiusX = radiusY = radiusZ = Math.max(1, PrimitiveBindings.parseNumericInput(radii[0]));
+                radiusX = radiusY = radiusZ = PrimitiveBindings.parseNumericInput(radii[0]);
                 break;
 
             case 3:
-                radiusX = Math.max(1, PrimitiveBindings.parseNumericInput(radii[0]));
-                radiusY = Math.max(1, PrimitiveBindings.parseNumericInput(radii[1]));
-                radiusZ = Math.max(1, PrimitiveBindings.parseNumericInput(radii[2]));
+                radiusX = PrimitiveBindings.parseNumericInput(radii[0]);
+                radiusY = PrimitiveBindings.parseNumericInput(radii[1]);
+                radiusZ = PrimitiveBindings.parseNumericInput(radii[2]);
                 break;
 
             default:
@@ -192,12 +192,12 @@ public class PrimitiveBindings extends Bindings {
         final double radiusX, radiusZ;
         switch (radii.length) {
             case 1:
-                radiusX = radiusZ = Math.max(1, parseNumericInput(radii[0]));
+                radiusX = radiusZ = parseNumericInput(radii[0]);
                 break;
 
             case 2:
-                radiusX = Math.max(1, parseNumericInput(radii[0]));
-                radiusZ = Math.max(1, parseNumericInput(radii[1]));
+                radiusX = parseNumericInput(radii[0]);
+                radiusZ = parseNumericInput(radii[1]);
                 break;
 
             default:


### PR DESCRIPTION
## Overview
Fixes `//pos1`, `//pos2`, and similar commands clamping incorrectly

**Fixes #369**

## Description
Fixes incorrect clamping that lead to `//pos1` and other Vec3 based commands being restricted to strictly positive integers.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
