### PR TITLE
Fixing wrong translation keys

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolCommands.java
@@ -156,7 +156,7 @@ public class ToolCommands {
 
         final ItemType itemType = player.getItemInHand(HandSide.MAIN_HAND).getType();
         session.setTool(player, NavigationWand.INSTANCE);
-        player.printInfo(TranslatableComponent.of("worldedit.tool.navWand.equip", TextComponent.of(itemType.getName())));
+        player.printInfo(TranslatableComponent.of("worldedit.tool.navwand.equip", TextComponent.of(itemType.getName())));
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -705,7 +705,7 @@ public final class PlatformCommandManager {
             }
         } catch (ConditionFailedException e) {
             if (e.getCondition() instanceof PermissionCondition) {
-                actor.printError(Caption.of("fawe.error.no.perm", StringMan.getString(((PermissionCondition) e.getCondition()).getPermissions())));
+                actor.printError(Caption.of("fawe.error.no-perm", StringMan.getString(((PermissionCondition) e.getCondition()).getPermissions())));
             } else {
                 actor.print(e.getRichMessage());
             }


### PR DESCRIPTION
I was referring to the config "strings.json"

`
"fawe.error.no-perm": "You are lacking the permission node: {0}"
`

`
"worldedit.tool.navwand.equip": "Navigation wand bound to {0}."
`