### PR TITLE
Correct JVM Architecture Detection

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/Fawe.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/Fawe.java
@@ -353,10 +353,10 @@ public class Fawe {
                 debug("===============================================");
             }
         }
-        String arch = System.getenv("PROCESSOR_ARCHITECTURE");
-        String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
-        boolean x86OS = arch == null ? true : !(arch.endsWith("64") || wow64Arch != null && wow64Arch.endsWith("64"));
-        boolean x86JVM = System.getProperty("sun.arch.data.model").equals("32");
+
+        // Check Base OS Arch for Mismatching Architectures
+        boolean x86OS = System.getProperty("sun.arch.data.model").contains("32");
+        boolean x86JVM = System.getProperty("os.arch").contains("32");
         if (x86OS != x86JVM) {
             debug("====== UPGRADE TO 64-BIT JAVA ======");
             debug("You are running 32-bit Java on a 64-bit machine");


### PR DESCRIPTION
## Overview
**Fixes #355**

## Description
Correction to FastAsyncWorldEdit's invalid detection of JVM Architecture to System Architecture.

I have tested this for both 32 and 64 bit for Windows JVM and Java 8 Linux JVM environments. Both acted as expected, showing the mismatching architecture error. If any further operating system tests are required, just let me know.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
