### PR TITLE
Fix special masks issue

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/BlocksMaskParser.java
@@ -56,7 +56,7 @@ public class BlocksMaskParser extends InputParser<Mask> {
                 return null;
             }
             return new BlockMask(context.getExtent(), holders);
-        } catch (NoMatchException e) {
+        } catch (InputParseException e) {
             return null;
         }
     }


### PR DESCRIPTION
## Overview

**Fixes #405**

## Description

This fixes the issue where masks other than SimpleBlock masks (like Offset mask or negate mask) would not work.

The issue was caused by parseFromListInput() who would throw SuggestInputParseException if the input was not a valid block definition.
But as the parser was catching NoMatchException only, this was causing an error and the MaskFactory was broken.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code 
(The code is very complex, and couldn't test every possible interactions. I assume the more global catch could be problematic, but I don't find any scenario for this.)
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
