### PR TITLE
Properly remove tile entities in BukkitGetBlocks_1_15_2

### DIFF
--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_14/BukkitGetBlocks_1_14.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_14/BukkitGetBlocks_1_14.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -230,7 +231,7 @@ public class BukkitGetBlocks_1_14 extends CharGetBlocks {
 
             // Remove existing tiles
             {
-                Map<BlockPosition, TileEntity> tiles = nmsChunk.getTileEntities();
+                Map<BlockPosition, TileEntity> tiles = new HashMap<>(nmsChunk.getTileEntities());
                 if (!tiles.isEmpty()) {
                     for (Map.Entry<BlockPosition, TileEntity> entry : tiles.entrySet()) {
                         final BlockPosition pos = entry.getKey();
@@ -243,8 +244,7 @@ public class BukkitGetBlocks_1_14 extends CharGetBlocks {
                         }
                         if (set.getBlock(lx, ly, lz).getOrdinal() != 0) {
                             TileEntity tile = entry.getValue();
-                            tile.n();
-                            tile.invalidateBlockCache();
+                            nmsChunk.removeTileEntity(tile.getPosition());
                         }
                     }
                 }

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15/BukkitGetBlocks_1_15.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15/BukkitGetBlocks_1_15.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -238,7 +239,7 @@ public class BukkitGetBlocks_1_15 extends CharGetBlocks {
 
             // Remove existing tiles
             {
-                Map<BlockPosition, TileEntity> tiles = nmsChunk.getTileEntities();
+                Map<BlockPosition, TileEntity> tiles = new HashMap<>(nmsChunk.getTileEntities());
                 if (!tiles.isEmpty()) {
                     for (Map.Entry<BlockPosition, TileEntity> entry : tiles.entrySet()) {
                         final BlockPosition pos = entry.getKey();
@@ -251,8 +252,7 @@ public class BukkitGetBlocks_1_15 extends CharGetBlocks {
                         }
                         if (set.getBlock(lx, ly, lz).getOrdinal() != 0) {
                             TileEntity tile = entry.getValue();
-                            tile.hasWorld();
-                            tile.invalidateBlockCache();
+                            nmsChunk.removeTileEntity(tile.getPosition());
                         }
                     }
                 }

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15_2/BukkitGetBlocks_1_15_2.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15_2/BukkitGetBlocks_1_15_2.java
@@ -263,7 +263,6 @@ public class BukkitGetBlocks_1_15_2 extends CharGetBlocks {
                         if (ordinal != 0) {
                             TileEntity tile = entry.getValue();
                             nmsChunk.removeTileEntity(tile.getPosition());
-                            nmsChunk.markDirty();
                         }
                     }
                 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/issues
-->

This now makes sure to correctly remove the tile entities in the chunk. The old code did nothing at all and would replace the title entity block without removing the tile entity itself.

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes #415** (probably)

## Description

The tile entity is removed properly ~~and the chunk is marked as dirty~~.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
