### PR TITLE
Negate "hasCollission" for isTranslucent()

### DIFF
--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_14/BlockMaterial_1_14.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_14/BlockMaterial_1_14.java
@@ -27,7 +27,7 @@ public class BlockMaterial_1_14 implements BlockMaterial {
         this.material = defaultState.getMaterial();
         this.craftBlockData = CraftBlockData.fromData(defaultState);
         this.craftMaterial = craftBlockData.getMaterial();
-        this.isTranslucent = ReflectionUtil.getField(Block.class, block, "v");
+        this.isTranslucent = !(boolean) ReflectionUtil.getField(Block.class, block, "v");
     }
 
     public Block getBlock() {

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15/BlockMaterial_1_15.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15/BlockMaterial_1_15.java
@@ -27,7 +27,7 @@ public class BlockMaterial_1_15 implements BlockMaterial {
         this.material = defaultState.getMaterial();
         this.craftBlockData = CraftBlockData.fromData(defaultState);
         this.craftMaterial = craftBlockData.getMaterial();
-        this.isTranslucent = ReflectionUtil.getField(Block.class, block, "v");
+        this.isTranslucent = !(boolean) ReflectionUtil.getField(Block.class, block, "v");
     }
 
     public Block getBlock() {

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15_2/BlockMaterial_1_15_2.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/adapter/mc1_15_2/BlockMaterial_1_15_2.java
@@ -23,7 +23,7 @@ public class BlockMaterial_1_15_2 implements BlockMaterial {
         this.material = defaultState.getMaterial();
         this.craftBlockData = CraftBlockData.fromData(defaultState);
         this.craftMaterial = craftBlockData.getMaterial();
-        this.isTranslucent = ReflectionUtil.getField(Block.class, block, "v");
+        this.isTranslucent = !(boolean) ReflectionUtil.getField(Block.class, block, "v");
     }
 
     public Block getBlock() {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/issues
-->

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes #423 ** and probably other issues as well 

## Description
isTranslucent checks for "hasCollision", but has to be negated to make sense (translucent blocks have no collision)
## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit-1.13/blob/1.15/CONTRIBUTING.md)
