### PR TITLE
Add warning to config regarding disabling history on disk

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -176,6 +176,7 @@ public class Settings extends Config {
                 " - Persists restarts",
                 " - Unlimited undo",
                 " - Does not affect edit performance if `combine-stages`",
+                "- WARNING: Disabling this may improve performance, but is considered unsafe!",
         })
         public boolean USE_DISK = true;
         @Comment({

--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -176,7 +176,7 @@ public class Settings extends Config {
                 " - Persists restarts",
                 " - Unlimited undo",
                 " - Does not affect edit performance if `combine-stages`",
-                " - WARNING: Disabling this may improve performance, but is considered unsafe!",
+                " - Disabling this may improve performance ",
         })
         public boolean USE_DISK = true;
         @Comment({

--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -176,7 +176,7 @@ public class Settings extends Config {
                 " - Persists restarts",
                 " - Unlimited undo",
                 " - Does not affect edit performance if `combine-stages`",
-                "- WARNING: Disabling this may improve performance, but is considered unsafe!",
+                " - WARNING: Disabling this may improve performance, but is considered unsafe!",
         })
         public boolean USE_DISK = true;
         @Comment({


### PR DESCRIPTION
Because @dordsor21 found out that in the newer version disabling history on disk can improve performance but is generally unsafe.

Because so far this "issue" is only documented in Discord, I think a warning in the config wouldn't hurt