### PR TITLE
Start reimplementation of simplex pattern

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/util/StringUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/util/StringUtil.java
@@ -20,6 +20,7 @@
 package com.sk89q.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -330,5 +331,38 @@ public final class StringUtil {
         }
 
         return parsableBlocks;
+    }
+
+    /**
+     * Splits a string respecting enclosing quotes.
+     *
+     * @param input the input to split.
+     * @param delimiter the delimiter to split on.
+     * @param open the opening quote character.
+     * @param close the closing quote character.
+     * @return a list of split strings.
+     */
+    public static List<String> split(String input, char delimiter, char open, char close) {
+        if (input.indexOf(open) == -1 && input.indexOf(close) == -1) {
+            return Arrays.asList(input.split(String.valueOf(delimiter)));
+        }
+        int level = 0;
+        int begin = 0;
+        List<String> split = new ArrayList<>();
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c == delimiter && level == 0) {
+                split.add(input.substring(begin, i));
+                begin = i + 1;
+            } else if (c == open) {
+                level++;
+            } else if (c == close) {
+                level--;
+            }
+        }
+        if (begin < input.length()) {
+            split.add(input.substring(begin));
+        }
+        return split;
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/BlockFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/BlockFactory.java
@@ -58,8 +58,8 @@ public class BlockFactory extends AbstractFactory<BaseBlock> {
      */
     public Set<BaseBlock> parseFromListInput(String input, ParserContext context) throws InputParseException {
         Set<BaseBlock> blocks = new HashSet<>();
-        String[] splits = input.split(",");
-        for (String token : StringUtil.parseListInQuotes(splits, ',', '[', ']', true)) {
+        // String[] splits = input.split(",");
+        for (String token : StringUtil.split(input, ',', '[', ']')) {
             blocks.add(parseFromInput(token, context));
         }
         return blocks;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/PatternFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/PatternFactory.java
@@ -24,6 +24,7 @@ import com.sk89q.worldedit.extension.factory.parser.pattern.BlockCategoryPattern
 import com.sk89q.worldedit.extension.factory.parser.pattern.ClipboardPatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.RandomPatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.RandomStatePatternParser;
+import com.sk89q.worldedit.extension.factory.parser.pattern.SimplexPatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.SingleBlockPatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.TypeOrStateApplyingPatternParser;
 import com.sk89q.worldedit.function.pattern.Pattern;
@@ -45,6 +46,8 @@ public final class PatternFactory extends AbstractFactory<Pattern> {
      */
     public PatternFactory(WorldEdit worldEdit) {
         super(worldEdit, new SingleBlockPatternParser(worldEdit));
+        // FAWE
+        register(new SimplexPatternParser(worldEdit));
 
         // split and parse each sub-pattern
         register(new RandomPatternParser(worldEdit));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/PatternFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/PatternFactory.java
@@ -46,8 +46,6 @@ public final class PatternFactory extends AbstractFactory<Pattern> {
      */
     public PatternFactory(WorldEdit worldEdit) {
         super(worldEdit, new SingleBlockPatternParser(worldEdit));
-        // FAWE
-        register(new SimplexPatternParser(worldEdit));
 
         // split and parse each sub-pattern
         register(new RandomPatternParser(worldEdit));
@@ -57,6 +55,9 @@ public final class PatternFactory extends AbstractFactory<Pattern> {
         register(new TypeOrStateApplyingPatternParser(worldEdit));
         register(new RandomStatePatternParser(worldEdit));
         register(new BlockCategoryPatternParser(worldEdit));
+
+        // FAWE
+        register(new SimplexPatternParser(worldEdit));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/RichParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/RichParser.java
@@ -58,10 +58,6 @@ public abstract class RichParser<E> extends InputParser<E> {
     public E parseFromInput(String input, ParserContext context) throws InputParseException {
         if (!input.startsWith(this.prefix)) return null;
         if (input.length() < this.prefix.length()) return null;
-        // if it's not "atomic", we can't parse it like that
-        if (StringUtil.split(input, ',', '[', ']').size() > 1) return null;
-        // TODO if no arguments -> exception
-        // TODO if not starts with [ and ends with ] -> exception
         String[] arguments = extractArguments(input.substring(prefix.length()), true);
         return parseFromInput(arguments, context);
     }
@@ -78,7 +74,7 @@ public abstract class RichParser<E> extends InputParser<E> {
     /**
      * Parses the already split arguments.
      *
-     * @param arguments the array of arguments that were split.
+     * @param arguments the array of arguments that were split (can be empty).
      * @param context   the context of this parsing process.
      * @return the resulting parsed type.
      * @throws InputParseException if the input couldn't be parsed correctly.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/RichParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/RichParser.java
@@ -1,0 +1,90 @@
+package com.sk89q.worldedit.extension.factory.parser;
+
+import com.sk89q.util.StringUtil;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.input.InputParseException;
+import com.sk89q.worldedit.extension.input.ParserContext;
+import com.sk89q.worldedit.internal.registry.InputParser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.stream.Stream;
+
+public abstract class RichParser<E> extends InputParser<E> {
+    private final String prefix;
+    private final String required;
+
+    protected RichParser(WorldEdit worldEdit, String prefix) {
+        super(worldEdit);
+        this.prefix = prefix;
+        this.required = prefix + "[";
+    }
+
+    @Override
+    public Stream<String> getSuggestions(String input) {
+        // we don't even want to start suggesting if it's not meant to be this parser result
+        if (input.length() >= this.prefix.length() && !input.startsWith(this.required)) {
+            return Stream.empty();
+        }
+        // suggest until the first [ as long as it isn't fully typed
+        if (input.length() < this.required.length() && this.required.startsWith(input)) {
+            return Stream.of(this.required);
+        }
+        // we know that it is at least "<required>"
+        String[] strings = extractArguments(input.substring(this.prefix.length()), false);
+        StringJoiner joiner = new StringJoiner(",");
+        for (int i = 0; i < strings.length - 1; i++) {
+            joiner.add("[" + strings[i] + "]");
+        }
+        String previous = this.prefix + joiner;
+        return getSuggestions(strings[strings.length - 1], strings.length - 1).map(s -> previous + "[" + s + "]");
+    }
+
+    @Override
+    public E parseFromInput(String input, ParserContext context) throws InputParseException {
+        if (!input.startsWith(prefix)) return null;
+        // if it's not "atomic", we can't parse it like that
+        if (StringUtil.split(input, ',', '[', ']').size() > 1) return null;
+        // TODO if no arguments -> exception
+        // TODO if not starts with [ and ends with ] -> exception
+        String[] arguments = extractArguments(input.substring(prefix.length()), true);
+        return parseFromInput(arguments, context);
+    }
+
+    protected abstract Stream<String> getSuggestions(String argument, int index);
+
+    protected abstract E parseFromInput(String[] arguments, ParserContext context);
+
+    /**
+     * Extracts arguments enclosed by {@code []} into an array.
+     * Example: {@code [Hello][World]} results in a list containing {@code Hello} and {@code World}.
+     *
+     * @param input          the input to extract arguments from.
+     * @param requireClosing whether or not the extraction requires valid bracketing.
+     * @return an array of extracted arguments.
+     */
+    protected String[] extractArguments(String input, boolean requireClosing) {
+        int open = 0;
+        int openIndex = 0;
+        int i = 0;
+        List<String> arguments = new ArrayList<>();
+        for (; i < input.length(); i++) {
+            if (input.charAt(i) == '[') {
+                if (open++ == 0) {
+                    openIndex = i;
+                }
+            }
+            if (input.charAt(i) == ']') {
+                if (--open == 0) {
+                    arguments.add(input.substring(openIndex + 1, i));
+                }
+            }
+        }
+        if (!requireClosing && open > 0) {
+            arguments.add(input.substring(openIndex + 1));
+        }
+        // TODO if open != 0 -> exception
+        return arguments.toArray(new String[0]);
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/RichParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/RichParser.java
@@ -24,12 +24,12 @@ public abstract class RichParser<E> extends InputParser<E> {
     @Override
     public Stream<String> getSuggestions(String input) {
         // we don't even want to start suggesting if it's not meant to be this parser result
-        if (input.length() >= this.prefix.length() && !input.startsWith(this.required)) {
+        if (input.length() > this.required.length() && !input.startsWith(this.required)) {
             return Stream.empty();
         }
         // suggest until the first [ as long as it isn't fully typed
-        if (input.length() < this.required.length() && this.required.startsWith(input)) {
-            return Stream.of(this.required);
+        if (input.length() < this.required.length()) {
+            return Stream.of(this.required).filter(s -> s.startsWith(input));
         }
         // we know that it is at least "<required>"
         String[] strings = extractArguments(input.substring(this.prefix.length()), false);
@@ -43,7 +43,8 @@ public abstract class RichParser<E> extends InputParser<E> {
 
     @Override
     public E parseFromInput(String input, ParserContext context) throws InputParseException {
-        if (!input.startsWith(prefix)) return null;
+        if (!input.startsWith(this.prefix)) return null;
+        if (input.length() < this.prefix.length()) return null;
         // if it's not "atomic", we can't parse it like that
         if (StringUtil.split(input, ',', '[', ']').size() > 1) return null;
         // TODO if no arguments -> exception

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
@@ -76,7 +76,7 @@ public class RandomPatternParser extends InputParser<Pattern> {
 
             // Parse special percentage syntax
             if (token.matches("[0-9]+(\\.[0-9]*)?%.*")) {
-                String[] p = token.split("%");
+                String[] p = token.split("%", 2);
 
                 if (p.length < 2) {
                     throw new InputParseException("Missing the type after the % symbol for '" + input + "'");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
@@ -38,8 +38,9 @@ public class RandomPatternParser extends InputParser<Pattern> {
 
     @Override
     public Stream<String> getSuggestions(String input) {
-        String[] splits = input.split(",", -1);
-        List<String> patterns = StringUtil.parseListInQuotes(splits, ',', '[', ']', true);
+        List<String> patterns = StringUtil.split(input, ',', '[', ']');
+        /*String[] splits = input.split(",", -1);
+        List<String> patterns = StringUtil.parseListInQuotes(splits, ',', '[', ']', true);*/
         if (patterns.size() == 1) {
             return Stream.empty();
         }
@@ -63,8 +64,9 @@ public class RandomPatternParser extends InputParser<Pattern> {
     public Pattern parseFromInput(String input, ParserContext context) throws InputParseException {
         RandomPattern randomPattern = new RandomPattern();
 
-        String[] splits = input.split(",", -1);
-        List<String> patterns = StringUtil.parseListInQuotes(splits, ',', '[', ']', true);
+        List<String> patterns = StringUtil.split(input, ',', '[', ']');
+        /*String[] splits = input.split(",", -1);
+        List<String> patterns = StringUtil.parseListInQuotes(splits, ',', '[', ']', true);*/
         if (patterns.size() == 1) {
             return null; // let a 'single'-pattern parser handle it
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/SimplexPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/SimplexPatternParser.java
@@ -7,6 +7,8 @@ import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.function.pattern.RandomPattern;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.stream.Stream;
 
@@ -18,43 +20,43 @@ public class SimplexPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argument, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index) {
         if (index == 0) {
-            if (argument.isEmpty()) {
+            if (argumentInput.isEmpty()) {
                 return Stream.of("1", "2", "3", "4", "5", "6", "7", "8", "9");
             }
             // if already a valid number, suggest more digits
-            if (isDouble(argument)) {
+            if (isDouble(argumentInput)) {
                 Stream<String> numbers = Stream.of("", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
-                if (argument.indexOf('.') == -1) {
+                if (argumentInput.indexOf('.') == -1) {
                     numbers = Stream.concat(numbers, Stream.of("."));
                 }
-                return numbers.map(s -> argument + s);
+                return numbers.map(s -> argumentInput + s);
             }
             // no valid input anymore
             return Stream.empty();
         }
         if (index == 1) {
-            return worldEdit.getPatternFactory().getSuggestions(argument).stream();
+            return worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
         }
         return Stream.empty();
     }
 
     @Override
-    protected Pattern parseFromInput(String[] arguments, ParserContext context) {
+    protected Pattern parseFromInput(@NotNull String[] arguments, ParserContext context) {
         if (arguments.length != 2) {
-            // TODO
-            throw new InputParseException("Invalid amount of arguments. Syntax: #simplex[scale][pattern]");
+            throw new InputParseException("Simplex requires a scale and a pattern, e.g. #simplex[5][dirt,stone]");
         }
         double scale = Double.parseDouble(arguments[0]);
         scale = 1d / Math.max(1, scale);
         Pattern inner = worldEdit.getPatternFactory().parseFromInput(arguments[1], context);
         if (inner instanceof RandomPattern) {
             return new RandomPattern(new SimplexRandom(scale), (RandomPattern) inner);
+        } else if (inner instanceof BlockStateHolder) {
+            return inner; // single blocks won't have any impact on how simplex behaves
+        } else {
+            throw new InputParseException("Pattern " + inner.getClass().getSimpleName() + " cannot be used with #simplex");
         }
-        // TODO handle RandomStatePattern?
-        // TODO for other patterns, either warn actor (inner pattern will be returned) or throw exception
-        return inner;
     }
 
     private static boolean isDouble(String input) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/SimplexPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/SimplexPatternParser.java
@@ -29,7 +29,7 @@ public class SimplexPatternParser extends RichParser<Pattern> {
                 if (argument.indexOf('.') == -1) {
                     numbers = Stream.concat(numbers, Stream.of("."));
                 }
-                return numbers;
+                return numbers.map(s -> argument + s);
             }
             // no valid input anymore
             return Stream.empty();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/SimplexPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/SimplexPatternParser.java
@@ -1,0 +1,73 @@
+package com.sk89q.worldedit.extension.factory.parser.pattern;
+
+import com.boydti.fawe.object.random.SimplexRandom;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.factory.parser.RichParser;
+import com.sk89q.worldedit.extension.input.InputParseException;
+import com.sk89q.worldedit.extension.input.ParserContext;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.function.pattern.RandomPattern;
+
+import java.util.stream.Stream;
+
+public class SimplexPatternParser extends RichParser<Pattern> {
+    private static final String SIMPLEX_PREFIX = "#simplex";
+
+    public SimplexPatternParser(WorldEdit worldEdit) {
+        super(worldEdit, SIMPLEX_PREFIX);
+    }
+
+    @Override
+    protected Stream<String> getSuggestions(String argument, int index) {
+        if (index == 0) {
+            if (argument.isEmpty()) {
+                return Stream.of("1", "2", "3", "4", "5", "6", "7", "8", "9");
+            }
+            // if already a valid number, suggest more digits
+            if (isDouble(argument)) {
+                Stream<String> numbers = Stream.of("", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+                if (argument.indexOf('.') == -1) {
+                    numbers = Stream.concat(numbers, Stream.of("."));
+                }
+                return numbers;
+            }
+            // no valid input anymore
+            return Stream.empty();
+        }
+        if (index == 1) {
+            return worldEdit.getPatternFactory().getSuggestions(argument).stream();
+        }
+        return Stream.empty();
+    }
+
+    @Override
+    protected Pattern parseFromInput(String[] arguments, ParserContext context) {
+        if (arguments.length != 2) {
+            // TODO
+            throw new InputParseException("Invalid amount of arguments. Syntax: #simplex[scale][pattern]");
+        }
+        double scale = Double.parseDouble(arguments[0]);
+        scale = 1d / Math.max(1, scale);
+        Pattern inner = worldEdit.getPatternFactory().parseFromInput(arguments[1], context);
+        if (inner instanceof RandomPattern) {
+            return new RandomPattern(new SimplexRandom(scale), (RandomPattern) inner);
+        }
+        // TODO handle RandomStatePattern?
+        // TODO for other patterns, either warn actor (inner pattern will be returned) or throw exception
+        return inner;
+    }
+
+    private static boolean isDouble(String input) {
+        boolean point = false;
+        for (char c : input.toCharArray()) {
+            if (!Character.isDigit(c)) {
+                if (c == '.' && !point) {
+                    point = true;
+                } else {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RandomPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RandomPattern.java
@@ -53,6 +53,19 @@ public class RandomPattern extends AbstractPattern {
     }
 
     /**
+     * Create a random pattern from an existing one but with a different random.
+     *
+     * @param random the new random to use.
+     * @param parent the existing random pattern.
+     */
+    public RandomPattern(SimpleRandom random, RandomPattern parent) {
+        this.random = random;
+        this.weights = parent.weights;
+        this.collection = RandomCollection.of(weights, random);
+        this.patterns = parent.patterns;
+    }
+
+    /**
      * Add a pattern to the weight list of patterns.
      *
      * <p>The probability for the pattern added is chance / max where max is


### PR DESCRIPTION
## Overview
Would partly cover #437 (the simplex mask isn't included)

## Description
### Short version: 
I've added a SimplexPatternParser which parses `#simplex[scale][pattern]`.
### Long version: 
As FAWE has multiple patterns/masks that require additional arguments (provided in [] normally), I've added the class `RichParser` which allows to easily parse those arguments.  Other parsers can extend it, they only need to provide the name of the pattern or mask. They then need to implement the following methods:
##### - `protected Stream<String> getSuggestions(String argument, int index)` 
(maybe that should be optional) For suggestions of the argument at the given index (e.g. for the simplex pattern, it will suggest numbers as first (index 0) argument and patterns as second (index 1) argument.

##### - `protected Pattern parseFromInput(String[] arguments, ParserContext context)`
Parses the actual pattern or mask with the given arguments. The arguments can be validated there.

That way, the parsers don't need to handle the extraction of arguments as this is done by the RichParser (If you have a better name for it, please let me know).

~This is a draft as it's not ready to merge. While the simplex pattern already works, there are still code parts that need to be discussed. I'll comment those issues.~

## Checklist
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [ ] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.15/CONTRIBUTING.md)
