### PR TITLE
setup vault after loading

### DIFF
--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
@@ -88,7 +88,7 @@ public class FaweBukkit implements IFawe, Listener {
             Integer.parseInt(Bukkit.getBukkitVersion().split("-")[0].split("\\.")[1]) >= 16;
 
         //Vault is Spigot/Paper only so this needs to be done in the Bukkit module
-        setupVault();
+        TaskManager.IMP.later(this::setupVault, 0);
 
         //PlotSquared support is limited to Spigot/Paper as of 02/20/2020
         TaskManager.IMP.later(this::setupPlotSquared, 0);


### PR DESCRIPTION
Currently FAWE implements Vault in a way, that even while having Vault as a Softdepent it gets loaded after FAWE, causing permission problems. I don't know why we do that, that's why I changed it to be loaded at the end. This is somewhat related to #529 in that right now Vault can't even work correctly with FAWE, but the issue in #529 is a bit more complex then that.