### PR TITLE
Fix convert function in AbstractDirectionConverter

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/AbstractDirectionConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/AbstractDirectionConverter.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import com.sk89q.worldedit.UnknownDirectionException;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.annotation.MultiDirection;
 import com.sk89q.worldedit.internal.annotation.OptionalArg;
@@ -93,8 +94,7 @@ public abstract class AbstractDirectionConverter<D> implements ArgumentConverter
 
     @Override
     public ConversionResult<D> convert(String argument, InjectedValueAccess context) {
-        Player player = context.injectedValue(Key.of(Player.class, OptionalArg.class))
-            .orElse(null);
+        Player player = context.injectedValue(Key.of(Actor.class)).filter(Player.class::isInstance).map(Player.class::cast).orElse(null);
         try {
             return SuccessfulConversion.fromSingle(convertDirection(argument, player, includeDiagonals));
         } catch (Exception e) {


### PR DESCRIPTION
Fixes issues with expand etc. not working when not specifying a direction. 
Now you are able to look at the direction you want to use again.
Issue was introduced in 28767d6e0fe8779b2f95f3580e5a8388b465d18d
