### PR TITLE
Fix erosion and pull brushes

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/object/brush/ErodeBrush.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/brush/ErodeBrush.java
@@ -91,7 +91,7 @@ public class ErodeBrush implements Brush {
                 int x2y2 = x2 + z * z;
                 for (int y = -brushSize, rely = 0; y <= brushSize; y++, rely++) {
                     int cube = x2y2 + y * y;
-                    target.setBlock(x, y, z, current.getBlock(relx, rely, relz));
+                    target.setBlock(relx, rely, relz, current.getBlock(relx, rely, relz));
                     if (cube >= brushSizeSquared) {
                         continue;
                     }
@@ -136,7 +136,7 @@ public class ErodeBrush implements Brush {
                 int x2y2 = x2 + z * z;
                 for (int y = -brushSize, rely = 0; y <= brushSize; y++, rely++) {
                     int cube = x2y2 + y * y;
-                    target.setBlock(x, y, z, current.getBlock(relx, rely, relz));
+                    target.setBlock(relx, rely, relz, current.getBlock(relx, rely, relz));
                     if (cube >= brushSizeSquared) {
                         continue;
                     }

--- a/worldedit-core/src/main/java/com/boydti/fawe/object/brush/RaiseBrush.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/brush/RaiseBrush.java
@@ -5,6 +5,6 @@ public class RaiseBrush extends ErodeBrush {
         this(6, 0, 1, 1);
     }
     public RaiseBrush(int erodeFaces, int erodeRec, int fillFaces, int fillRec) {
-        super(2, 1, 5, 1);
+        super(erodeFaces, erodeRec, fillFaces, fillRec);
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -182,9 +182,9 @@ public class BrushCommands {
     public void erodeBrush(InjectedValueAccess context, @Arg(desc = "The radius for eroding",
                                                              def = "5") Expression radius,
         @Arg(desc = "erodeFaces",
-             def = "6") int erodefaces, @Arg(desc = "erodeRec",
-                                             def = "0") int erodeRec, @Arg(desc = "fillFaces",
-                                                                           def = "1") int fillFaces,
+             def = "2") int erodefaces, @Arg(desc = "erodeRec",
+                                             def = "1") int erodeRec, @Arg(desc = "fillFaces",
+                                                                           def = "5") int fillFaces,
         @Arg(desc = "fillRec",
              def = "1") int fillRec) throws WorldEditException {
         worldEdit.checkMaxBrushRadius(radius);
@@ -197,10 +197,10 @@ public class BrushCommands {
     public void pullBrush(InjectedValueAccess context,
         @Arg(desc = "The radius to sample for blending",
              def = "5") Expression radius, @Arg(desc = "erodeFaces",
-                                                def = "2") int erodefaces, @Arg(desc = "erodeRec",
-                                                                                def = "1")
+                                                def = "6") int erodefaces, @Arg(desc = "erodeRec",
+                                                                                def = "0")
         int erodeRec, @Arg(desc = "fillFaces",
-                           def = "5") int fillFaces, @Arg(desc = "fillRec",
+                           def = "1") int fillFaces, @Arg(desc = "fillRec",
                                                           def = "1") int fillRec)
         throws WorldEditException {
         worldEdit.checkMaxBrushRadius(radius);


### PR DESCRIPTION
**Fixes #559 **

## Description
Fixes the erosion and pull brushes ArrayIndexOutOfBoundsException, as well as revert their default values to their proper, respective values. Also, re-enabled the ability to edit the arguments ingame for the pull brush.

## Checklist
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
