### PR TITLE
Implement SupplyingExtent

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/object/extent/SupplyingExtent.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/extent/SupplyingExtent.java
@@ -1,0 +1,24 @@
+package com.boydti.fawe.object.extent;
+
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.extent.PassthroughExtent;
+
+import java.util.function.Supplier;
+
+/**
+ * An extent that delegates actions to another extent that may change at any time.
+ */
+public class SupplyingExtent extends PassthroughExtent {
+
+    private final Supplier<Extent> extentSupplier;
+
+    public SupplyingExtent(Supplier<Extent> extentSupplier) {
+        super(extentSupplier.get());
+        this.extentSupplier = extentSupplier;
+    }
+
+    @Override
+    public Extent getExtent() {
+        return this.extentSupplier.get();
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.command.argument;
 
+import com.boydti.fawe.object.extent.SupplyingExtent;
 import com.sk89q.worldedit.EmptyClipboardException;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
@@ -109,10 +110,10 @@ public class FactoryConverter<T> implements ArgumentConverter<T> {
             if (extent instanceof World) {
                 parserContext.setWorld((World) extent);
             }
-            parserContext.setExtent(new RequestExtent());
+            parserContext.setExtent(new SupplyingExtent(((Locatable) actor)::getExtent));
         } else if (session.hasWorldOverride()) {
             parserContext.setWorld(session.getWorldOverride());
-            parserContext.setExtent(new RequestExtent());
+            parserContext.setExtent(new SupplyingExtent(session::getWorldOverride));
         }
         parserContext.setSession(session);
         parserContext.setRestricted(true);


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/FastAsyncWorldEdit/issues
-->

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes #612 #501**

## Description
Before, RequestExtent caused several problems as Requests are based on ThreadLocals. Those weren't accessible to FAWE after splitting up work into multiple threads. Removing/skipping the RequestExtent would cause issues with world changes for masks and patterns.

This change requests the player's world on each action so it actually uses the correct world when checking masks but also is visible to all threads.

I don't know if this is the proper approach to resolve the linked issues but it works fine from my testings. I didn't spend that much time on it, so feel free to add changes to this PR to improve it or propose a better solution (or a better name for the extent).

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
