### PR TITLE
accessing clipboards should not be synchronized to LocalSession

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -769,20 +769,20 @@ public class LocalSession implements TextureHolder {
      * @throws EmptyClipboardException thrown if no clipboard is set
      */
     public ClipboardHolder getClipboard() throws EmptyClipboardException {
-        if (clipboard == null) {
-            throw new EmptyClipboardException();
-        }
         synchronized (clipboardLock) {
+            if (clipboard == null) {
+                throw new EmptyClipboardException();
+            }
             return clipboard;
         }
     }
 
     @Nullable
     public ClipboardHolder getExistingClipboard() {
-        if (clipboard == null) {
-            return null;
-        }
         synchronized (clipboardLock) {
+            if (clipboard == null) {
+                return null;
+            }
             return clipboard;
         }
     }


### PR DESCRIPTION
I believe this may be the issue causing thread locks when wrapping new players. If we're attempting to run a synchronised method within the LocalSesison when initialising it, it may go wrong..?

Opinions?

Relevant parts of stacktrace:

```
[18:59:48] [Paper Watchdog Thread/ERROR]: Current Thread: Server thread
[18:59:48] [Paper Watchdog Thread/ERROR]: 	PID: 23 | Suspended: false | Native: false | State: BLOCKED
[18:59:48] [Paper Watchdog Thread/ERROR]: 	Stack:
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.bukkit.WorldEditPlugin.wrapPlayer(WorldEditPlugin.java:493)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.bukkit.BukkitAdapter.adapt(BukkitAdapter.java:136)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.boydti.fawe.bukkit.listener.BrushListener.onPlayerItemHoldEvent(BrushListener.java:33)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor20.execute(Unknown Source)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.bukkit.plugin.EventExecutor$$Lambda$4054/468495223.execute(Unknown Source)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:607)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.PlayerConnection.a(PlayerConnection.java:1648)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.PacketPlayInHeldItemSlot.a(SourceFile:30)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.PacketPlayInHeldItemSlot.a(SourceFile:8)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.PlayerConnectionUtils.lambda$ensureMainThread$1(PlayerConnectionUtils.java:23)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.PlayerConnectionUtils$$Lambda$5386/1812601841.run(Unknown Source)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.TickTask.run(SourceFile:18)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:136)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:109)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.MinecraftServer.ba(MinecraftServer.java:1135)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.MinecraftServer.executeNext(MinecraftServer.java:1128)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.IAsyncTaskHandler.awaitTasks(IAsyncTaskHandler.java:119)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.MinecraftServer.sleepForTick(MinecraftServer.java:1089)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.MinecraftServer.w(MinecraftServer.java:1003)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.MinecraftServer.lambda$a$0(MinecraftServer.java:177)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.Minecra
```

and

```
[18:59:48] [Paper Watchdog Thread/ERROR]: Current Thread: ForkJoinPool.commonPool-worker-0
[18:59:48] [Paper Watchdog Thread/ERROR]: 	PID: 533 | Suspended: false | Native: false | State: BLOCKED
[18:59:48] [Paper Watchdog Thread/ERROR]: 	Thread is waiting on monitor(s):
[18:59:48] [Paper Watchdog Thread/ERROR]: 		Locked on:com.sk89q.worldedit.bukkit.WorldEditPlugin.wrapPlayer(WorldEditPlugin.java:496)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		Locked on:com.mojang.brigadier.tree.CommandNode.canUse(CommandNode.java:79)
[18:59:48] [Paper Watchdog Thread/ERROR]: 	Stack:
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.LocalSession.getClipboard(LocalSession.java:771)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.entity.Player.loadClipboardFromDisk(Player.java:424)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.bukkit.BukkitPlayer.<init>(BukkitPlayer.java:87)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.bukkit.WorldEditPlugin.wrapPlayer(WorldEditPlugin.java:496)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.bukkit.WorldEditPlugin.wrapCommandSender(WorldEditPlugin.java:515)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.bukkit.BukkitCommandInspector.lambda$testPermission$0(BukkitCommandInspector.java:81)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.bukkit.BukkitCommandInspector$$Lambda$5383/245081268.value(Unknown Source)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.enginehub.piston.inject.MapBackedValueStore.lambda$injectedValue$0(MapBackedValueStore.java:56)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.enginehub.piston.inject.MapBackedValueStore$$Lambda$5384/325829960.apply(Unknown Source)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		java.util.Optional.flatMap(Optional.java:241)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.enginehub.piston.inject.MapBackedValueStore.injectedValue(MapBackedValueStore.java:56)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.enginehub.piston.inject.InjectedValueAccess.injectedValue(InjectedValueAccess.java:44)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.command.util.PermissionCondition.satisfied(PermissionCondition.java:52)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.worldedit.bukkit.BukkitCommandInspector.testPermission(BukkitCommandInspector.java:82)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.sk89q.bukkit.util.DynamicPluginCommand.testPermissionSilent(DynamicPluginCommand.java:100)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.bukkit.craftbukkit.v1_16_R2.command.BukkitCommandWrapper.test(BukkitCommandWrapper.java:48)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		org.bukkit.craftbukkit.v1_16_R2.command.BukkitCommandWrapper.test(BukkitCommandWrapper.java:20)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		com.mojang.brigadier.tree.CommandNode.canUse(CommandNode.java:79)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.CommandDispatcher.a(CommandDispatcher.java:302)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.CommandDispatcher.sendAsync(CommandDispatcher.java:266)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.CommandDispatcher.lambda$a$4(CommandDispatcher.java:249)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_16_R2.CommandDispatcher$$Lambda$5359/245879066.run(Unknown Source)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
[18:59:48] [Paper Watchdog Thread/ERROR]: 		java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:163)
```
