### PR TITLE
Fixed a NullPointerException

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPermissionAttachmentManager.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPermissionAttachmentManager.java
@@ -10,7 +10,7 @@ public class BukkitPermissionAttachmentManager {
 
     private final WorldEditPlugin plugin;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-    private final Map<Player, PermissionAttachment> attachments = new HashMap();
+    private final Map<Player, PermissionAttachment> attachments = new HashMap<>();
 
     public BukkitPermissionAttachmentManager(WorldEditPlugin plugin) {
         this.plugin = plugin;

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -82,7 +82,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
      * 
      * @param player The corresponding {@link Player} or null if they are offline
      */
-    public BukkitPlayer(Player player) {
+    public BukkitPlayer(@Nullable Player player) {
         super(getExistingMap(WorldEditPlugin.getInstance(), player));
         this.plugin = WorldEditPlugin.getInstance();
         this.player = player;
@@ -112,7 +112,7 @@ public class BukkitPlayer extends AbstractPlayerActor {
      * 
      * @return A data {@link Map} for that {@link Player}
      */
-    private static Map<String, Object> getExistingMap(WorldEditPlugin plugin, Player player) {
+    private static Map<String, Object> getExistingMap(WorldEditPlugin plugin, @Nullable Player player) {
         if (player == null) {
             // Null cannot have any data, so we just return an empty Map
             return new ConcurrentHashMap<>();

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -77,6 +77,11 @@ public class BukkitPlayer extends AbstractPlayerActor {
     private final WorldEditPlugin plugin;
     private final PermissionAttachment permAttachment;
 
+    /**
+     * This constructs a new {@link BukkitPlayer} for the given {@link Player}.
+     * 
+     * @param player The corresponding {@link Player} or null if they are offline
+     */
     public BukkitPlayer(Player player) {
         super(getExistingMap(WorldEditPlugin.getInstance(), player));
         this.plugin = WorldEditPlugin.getInstance();
@@ -84,6 +89,12 @@ public class BukkitPlayer extends AbstractPlayerActor {
         this.permAttachment = plugin.getPermissionAttachmentManager().addAttachment(player);
     }
 
+    /**
+     * This constructs a new {@link BukkitPlayer} for the given {@link Player}.
+     * 
+     * @param plugin The running instance of {@link WorldEditPlugin}
+     * @param player The corresponding {@link Player} or null if they are offline
+     */
     public BukkitPlayer(WorldEditPlugin plugin, Player player) {
         this.plugin = plugin;
         this.player = player;
@@ -93,7 +104,20 @@ public class BukkitPlayer extends AbstractPlayerActor {
         }
     }
 
+    /**
+     * This method gets the existing data {@link Map} for a {@link Player}.
+     * 
+     * @param plugin Our instance of {@link WorldEditPlugin}
+     * @param player The {@link Player} to get the data for, can be null
+     * 
+     * @return A data {@link Map} for that {@link Player}
+     */
     private static Map<String, Object> getExistingMap(WorldEditPlugin plugin, Player player) {
+        if (player == null) {
+            // Null cannot have any data, so we just return an empty Map
+            return new ConcurrentHashMap<>();
+        }
+
         BukkitPlayer cached = plugin.getCachedPlayer(player);
         if (cached != null) {
             return cached.getRawMeta();


### PR DESCRIPTION
## Overview
This Pull Requets adresses a `NullPointerException` in the `BukkitPlayer` class of `worldedit-bukkit`.
The exception can be seen here: https://pastebin.com/dq72vmsD

This exception is caused due to an unhandled Player variable which is set as nullable by WorldGuard.
The original WorldEdit handles this nullability correctly, however it seems that FAWE does not, so that's why I am proposing this change.

## Description
<!-- Please describe what you have changed -->
When you call `WorldGuardPlugin#wrapOfflinePlayer(OfflinePlayer)` in WorldGuard as seen here: [WorldGuardPlugin.java#L450](https://github.com/EngineHub/WorldGuard/blob/master/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java#L450)
it will create a new `BukkitOfflinePlayer` (an extension of `BukkitPlayer`).

This will pass a `Player` object to the super constructor, while there is no annotation or documentation about this actually being nullable. You can find a comment in the code of WorldGuard: [BukkitOfflinePlayer.java#L42](https://github.com/EngineHub/WorldGuard/blob/master/worldguard-bukkit/src/main/java/com/sk89q/worldguard/bukkit/BukkitOfflinePlayer.java#L42) explaining that it can in fact be null.

This leads us to FAWE's `BukkitPlayer` constructor:
https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/main/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java#L81
Here the method `getExistingMap()` is called for a nullable Player variable which is then passed on to other methods which expect it to be non-null.

This PR adds a simple null-check to the `getExistingMap()` method and a few javadocs comments that should raise awareness about this nullability for the future.
On that regard I have also added an `@Nullable` annotation to this parameter.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
