### PR TITLE
Run GitHub Actions build on Java 1.8 and 1.11

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [1.8, 1.11]
 
     steps:
     - name: Checkout
@@ -18,23 +21,23 @@ jobs:
     - name: Setup Java JDK
       uses: actions/setup-java@v1.4.2
       with:
-        java-version: 1.8
+        java-version: ${{ matrix.java }}
     - name: Cache Gradle
       uses: actions/cache@v2
       with:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        key: ${{ runner.os }}-${{ matrix.java }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
-          ${{ runner.os }}-gradle-
+          ${{ runner.os }}-${{ matrix.java }}-gradle-
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-${{ matrix.java }}-maven-
     - name: Cache BuildTools decompiled code
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
## Overview
Fixes #678

## Description
Updated the job to be a matrix build, running on 1.8 and 1.11. The cache keys now reflect these changes, so this build may take a bit longer than others.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality (this PR is the test!) :)
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
