### PR TITLE
There's no need to duplicate everything when copying the intersection masks, as the Set and array should be the same.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/MaskIntersection.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/MaskIntersection.java
@@ -61,12 +61,6 @@ public class MaskIntersection extends AbstractMask {
         formArray();
     }
 
-    protected MaskIntersection(Set<Mask> masks, Mask[] masksArray, boolean defaultReturn) {
-        this.masks = masks;
-        this.masksArray = masksArray;
-        this.defaultReturn = defaultReturn;
-    }
-
     public static Mask of(Mask... masks) {
         Set<Mask> set = new LinkedHashSet<>();
         for (Mask mask : masks) {
@@ -260,8 +254,7 @@ public class MaskIntersection extends AbstractMask {
     @Override
     public Mask copy(){
         Set<Mask> masks = this.masks.stream().map(Mask::copy).collect(Collectors.toSet());
-        Mask[] maskArray = (Mask[]) Arrays.stream(this.masksArray).map(Mask::copy).toArray();
-        return new MaskIntersection(masks, maskArray, this.defaultReturn);
+        return new MaskIntersection(masks);
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/MaskUnion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/MaskUnion.java
@@ -22,7 +22,6 @@ package com.sk89q.worldedit.function.mask;
 import com.sk89q.worldedit.math.BlockVector3;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -55,10 +54,6 @@ public class MaskUnion extends MaskIntersection {
      */
     public MaskUnion(Mask... mask) {
         super(mask);
-    }
-
-    private MaskUnion(Set<Mask> masks, Mask[] maskArray, boolean defaultReturn) {
-        super(masks, maskArray, defaultReturn);
     }
 
     public static Mask of(Mask... masks) {
@@ -121,7 +116,6 @@ public class MaskUnion extends MaskIntersection {
     @Override
     public Mask copy() {
         Set<Mask> masksCopy = masks.stream().map(Mask::copy).collect(Collectors.toSet());
-        Mask[] maskArray = (Mask[]) Arrays.stream(masksArray).map(Mask::copy).toArray();
-        return new MaskUnion(masksCopy, maskArray, defaultReturn);
+        return new MaskUnion(masksCopy);
     }
 }


### PR DESCRIPTION
There's no need to duplicate everything when copying the intersection masks, as the Set and array should be the same.