### PR TITLE
Reimplement biome pattern

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/object/pattern/BiomeApplyingPattern.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/pattern/BiomeApplyingPattern.java
@@ -1,0 +1,28 @@
+package com.boydti.fawe.object.pattern;
+
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.block.BaseBlock;
+
+public class BiomeApplyingPattern extends AbstractExtentPattern {
+    private final BiomeType biomeType;
+
+    public BiomeApplyingPattern(Extent extent, BiomeType biomeType) {
+        super(extent);
+        this.biomeType = biomeType;
+    }
+
+    @Override
+    public BaseBlock apply(BlockVector3 position) {
+        getExtent().setBiome(position, this.biomeType);
+        // don't change the block, everything should remain the same
+        return getExtent().getFullBlock(position);
+    }
+
+    @Override
+    public boolean apply(Extent extent, BlockVector3 get, BlockVector3 set) throws WorldEditException {
+        return extent.setBiome(set, this.biomeType);
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/PatternFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/PatternFactory.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.extension.factory;
 
 import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.factory.parser.pattern.BiomePatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.BlockCategoryPatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.ClipboardPatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.PerlinPatternParser;
@@ -64,6 +65,7 @@ public final class PatternFactory extends AbstractFactory<Pattern> {
         register(new VoronoiPatternParser(worldEdit));
         register(new PerlinPatternParser(worldEdit));
         register(new RidgedMultiFractalPatternParser(worldEdit));
+        register(new BiomePatternParser(worldEdit));
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/BiomePatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/BiomePatternParser.java
@@ -1,0 +1,71 @@
+package com.sk89q.worldedit.extension.factory.parser.pattern;
+
+import com.boydti.fawe.object.pattern.BiomeApplyingPattern;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.extension.factory.parser.RichParser;
+import com.sk89q.worldedit.extension.input.InputParseException;
+import com.sk89q.worldedit.extension.input.ParserContext;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.biome.BiomeTypes;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.stream.Stream;
+
+public class BiomePatternParser extends RichParser<Pattern> {
+    private final static String BIOME_PREFIX = "$";
+
+    /**
+     * Create a new biome pattern parser.
+     *
+     * @param worldEdit the worldedit instance.
+     */
+    public BiomePatternParser(WorldEdit worldEdit) {
+        super(worldEdit, "#biome");
+    }
+
+    // overridden to provide $<biome> too
+    @Override
+    public Pattern parseFromInput(String input, ParserContext context) throws InputParseException {
+        if (input.startsWith(BIOME_PREFIX)) {
+            String biomeId = input.substring(1);
+            BiomeType biomeType = BiomeTypes.get(biomeId);
+            if (biomeType == null) {
+                throw new InputParseException("Not a valid biome: " + biomeId);
+            }
+            return new BiomeApplyingPattern(context.requireExtent(), biomeType);
+        } else {
+            return super.parseFromInput(input, context);
+        }
+    }
+
+    // overridden to provide $<biome> too
+    @Override
+    public Stream<String> getSuggestions(String input) {
+        if (input.startsWith(BIOME_PREFIX)) {
+            return BiomeType.REGISTRY.getSuggestions(input.substring(1)).map(biome -> BIOME_PREFIX + biome);
+        } else {
+            return super.getSuggestions(input);
+        }
+    }
+
+    @Override
+    protected Stream<String> getSuggestions(String argumentInput, int index) {
+        if (index == 0) {
+            return BiomeType.REGISTRY.getSuggestions(argumentInput);
+        }
+        return Stream.empty();
+    }
+
+    @Override
+    protected Pattern parseFromInput(@NotNull String[] arguments, ParserContext context) throws InputParseException {
+        if (arguments.length != 1) {
+            throw new InputParseException("Invalid amount of arguments. Expected: #biome[<biome>]");
+        }
+        BiomeType biomeType = BiomeTypes.get(arguments[0]);
+        if (biomeType == null) {
+            throw new InputParseException("Not a valid biome: " + arguments[0]);
+        }
+        return new BiomeApplyingPattern(context.requireExtent(), biomeType);
+    }
+}

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/BiomePatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/BiomePatternParser.java
@@ -4,8 +4,11 @@ import com.boydti.fawe.object.pattern.BiomeApplyingPattern;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.factory.parser.RichParser;
 import com.sk89q.worldedit.extension.input.InputParseException;
+import com.sk89q.worldedit.extension.input.NoMatchException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.biome.BiomeTypes;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +34,7 @@ public class BiomePatternParser extends RichParser<Pattern> {
             String biomeId = input.substring(1);
             BiomeType biomeType = BiomeTypes.get(biomeId);
             if (biomeType == null) {
-                throw new InputParseException("Not a valid biome: " + biomeId);
+                throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-biome", TextComponent.of(biomeId)));
             }
             return new BiomeApplyingPattern(context.requireExtent(), biomeType);
         } else {
@@ -64,7 +67,7 @@ public class BiomePatternParser extends RichParser<Pattern> {
         }
         BiomeType biomeType = BiomeTypes.get(arguments[0]);
         if (biomeType == null) {
-            throw new InputParseException("Not a valid biome: " + arguments[0]);
+            throw new NoMatchException(TranslatableComponent.of("worldedit.error.unknown-biome", TextComponent.of(arguments[0])));
         }
         return new BiomeApplyingPattern(context.requireExtent(), biomeType);
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/registry/NamespacedRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/registry/NamespacedRegistry.java
@@ -19,19 +19,18 @@
 
 package com.sk89q.worldedit.registry;
 
+import com.sk89q.worldedit.command.util.SuggestionHelper;
+
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
-import static org.enginehub.piston.converter.SuggestionHelper.byPrefix;
 
 public final class NamespacedRegistry<V extends Keyed> extends Registry<V> {
     private static final String MINECRAFT_NAMESPACE = "minecraft";
@@ -107,29 +106,6 @@ public final class NamespacedRegistry<V extends Keyed> extends Registry<V> {
     }
 
     public <V1 extends Keyed> Stream<String> getSuggestions(String input) {
-        if (input.isEmpty() || input.equals(":")) {
-            final Set<String> namespaces = getKnownNamespaces();
-            if (namespaces.size() == 1) {
-                return keySet().stream();
-            } else {
-                return namespaces.stream().map(s -> s + ":");
-            }
-        }
-        if (input.startsWith(":")) { // special case - search across namespaces
-            final String term = input.substring(1).toLowerCase(Locale.ROOT);
-            Predicate<String> search = byPrefix(term);
-            return keySet().stream().filter(s -> search.test(s.substring(s.indexOf(':') + 1)));
-        }
-        // otherwise, we actually have some text to search
-        if (input.indexOf(':') < 0) {
-            // don't yet have namespace - search namespaces + default
-            final String lowerSearch = input.toLowerCase(Locale.ROOT);
-            String defKey = getDefaultNamespace() + ":" + lowerSearch;
-            return Stream.concat(keySet().stream().filter(s -> s.startsWith(defKey)),
-                    getKnownNamespaces().stream().filter(n -> n.startsWith(lowerSearch)).map(n -> n + ":"));
-        }
-        // have a namespace - search that
-        Predicate<String> search = byPrefix(input.toLowerCase(Locale.ROOT));
-        return keySet().stream().filter(search);
+        return SuggestionHelper.getNamespacedRegistrySuggestions(this, input);
     }
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/FastAsyncWorldEdit/issues
-->

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes #635**

## Description
<!-- Please describe what you have changed -->
This reimplements the biome pattern, means `$<biome>` and `#biome[<biome>]` can be used again like a regular pattern (and therefore in combination with noise patterns like `#simplex`, or even better, `#voronoi`)

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
