### PR TITLE
Fix copypaste brush

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/object/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/changeset/AbstractChangeSet.java
@@ -303,8 +303,8 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
                 MainUtil.setPosition(nbt, x, y, z);
                 addTileCreate(nbt);
             }
-            int combinedFrom = from.getInternalId();
-            int combinedTo = to.getInternalId();
+            int combinedFrom = from.getOrdinal();
+            int combinedTo = to.getOrdinal();
             add(x, y, z, combinedFrom, combinedTo);
 
         } catch (Exception e) {


### PR DESCRIPTION
## Overview

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes #562**

## Description
<!-- Please describe what you have changed -->
Previously, the internal id of the block state was used when copying instead of the ordinal id. As FAWE reads it as ordinal when pasting, this caused wrong blocks being placed.

I'm not sure if this caused other issues before or if it was required to use the internal id elsewhere, but from my testings other commands that might use the AbstractChangeSet still seem to work. I'd be happy if someone else could approve functionality too.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
