### PR TITLE
Implement biome-specific regen

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/Regenerator.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/Regenerator.java
@@ -11,6 +11,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.RegenOptions;
+import com.sk89q.worldedit.world.biome.BiomeType;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
@@ -266,9 +267,13 @@ public abstract class Regenerator<IChunkAccess, ProtoChunk extends IChunkAccess,
         //Setting Blocks
         long start = System.currentTimeMillis();
         boolean genbiomes = options.shouldRegenBiomes();
+        boolean hasBiome = options.hasBiomeType();
+        BiomeType biome = options.getBiomeType();
         for (BlockVector3 vec : region) {
             target.setBlock(vec, source.getBlock(vec));
-            if (genbiomes) {
+            if (hasBiome) {
+                target.setBiome(vec, biome);
+            } else if (genbiomes) {
                 target.setBiome(vec, source.getBiome(vec));
             }
 //                    realExtent.setSkyLight(vec, extent.getSkyLight(vec));

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_15_R2.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_15_R2.java
@@ -185,10 +185,12 @@ public class Regen_v1_15_R2 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
             public void doTick(BooleanSupplier booleansupplier) { //no ticking
             }
 
+            private final BiomeBase singleBiome = options.hasBiomeType() ? IRegistry.BIOME.get(MinecraftKey.a(options.getBiomeType().getId())) : null;
+
             @Override
             public BiomeBase a(int i, int k, int j) {
                 if (options.hasBiomeType()) {
-                    return IRegistry.BIOME.get(MinecraftKey.a(options.getBiomeType().getId()));
+                    return singleBiome;
                 }
                 return this.getChunkProvider().getChunkGenerator().getWorldChunkManager().getBiome(i, j, k);
             }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_16_R1.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_16_R1.java
@@ -203,10 +203,12 @@ public class Regen_v1_16_R1 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
             public void doTick(BooleanSupplier booleansupplier) { //no ticking
             }
 
+            private final BiomeBase singleBiome = options.hasBiomeType() ? IRegistry.BIOME.get(MinecraftKey.a(options.getBiomeType().getId())) : null;
+
             @Override
             public BiomeBase a(int i, int j, int k) {
                 if (options.hasBiomeType()) {
-                    return IRegistry.BIOME.get(MinecraftKey.a(options.getBiomeType().getId()));
+                    return singleBiome;
                 }
                 return this.getChunkProvider().getChunkGenerator().getWorldChunkManager().getBiome(i, j, k);
             }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_16_R2.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_16_R2.java
@@ -208,10 +208,12 @@ public class Regen_v1_16_R2 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
             public void doTick(BooleanSupplier booleansupplier) { //no ticking
             }
 
+            private final BiomeBase singleBiome = options.hasBiomeType() ? RegistryGeneration.WORLDGEN_BIOME.get(MinecraftKey.a(options.getBiomeType().getId())) : null;
+
             @Override
             public BiomeBase a(int i, int j, int k) {
                 if (options.hasBiomeType()) {
-                    return RegistryGeneration.WORLDGEN_BIOME.get(MinecraftKey.a(options.getBiomeType().getId()));
+                    return singleBiome;
                 }
                 return this.getChunkProvider().getChunkGenerator().getWorldChunkManager().getBiome(i, j, k);
             }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_16_R2.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_16_R2.java
@@ -6,6 +6,7 @@ import com.boydti.fawe.beta.IChunkGet;
 import com.boydti.fawe.bukkit.adapter.mc1_16_2.BukkitGetBlocks_1_16_2;
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.Codec;
 import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.Lifecycle;
 import com.sk89q.worldedit.bukkit.adapter.Regenerator;
@@ -28,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongFunction;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import net.minecraft.server.v1_16_R2.Area;
 import net.minecraft.server.v1_16_R2.AreaContextTransformed;
@@ -56,11 +58,14 @@ import net.minecraft.server.v1_16_R2.IRegistry;
 import net.minecraft.server.v1_16_R2.IRegistryCustom;
 import net.minecraft.server.v1_16_R2.LightEngineThreaded;
 import net.minecraft.server.v1_16_R2.LinearCongruentialGenerator;
+import net.minecraft.server.v1_16_R2.MinecraftKey;
 import net.minecraft.server.v1_16_R2.MinecraftServer;
 import net.minecraft.server.v1_16_R2.NBTBase;
 import net.minecraft.server.v1_16_R2.NBTTagCompound;
 import net.minecraft.server.v1_16_R2.NoiseGeneratorPerlin;
 import net.minecraft.server.v1_16_R2.ProtoChunk;
+import net.minecraft.server.v1_16_R2.RegistryGeneration;
+import net.minecraft.server.v1_16_R2.RegistryMaterials;
 import net.minecraft.server.v1_16_R2.RegistryReadOps;
 import net.minecraft.server.v1_16_R2.ResourceKey;
 import net.minecraft.server.v1_16_R2.World;
@@ -201,6 +206,14 @@ public class Regen_v1_16_R2 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
         freshNMSWorld = Fawe.get().getQueueHandler().sync((Supplier<WorldServer>) () -> new WorldServer(server, server.executorService, session, newWorldData, originalNMSWorld.getDimensionKey(), originalNMSWorld.getDimensionManager(), new RegenNoOpWorldLoadListener(), ((WorldDimension) newOpts.d().a(worldDimKey)).c(), originalNMSWorld.isDebugWorld(), seed, ImmutableList.of(), false, env, gen) {
             @Override
             public void doTick(BooleanSupplier booleansupplier) { //no ticking
+            }
+
+            @Override
+            public BiomeBase a(int i, int j, int k) {
+                if (options.hasBiomeType()) {
+                    return RegistryGeneration.WORLDGEN_BIOME.get(MinecraftKey.a(options.getBiomeType().getId()));
+                }
+                return this.getChunkProvider().getChunkGenerator().getWorldChunkManager().getBiome(i, j, k);
             }
         }).get();
         freshNMSWorld.savingDisabled = true;
@@ -395,8 +408,6 @@ public class Regen_v1_16_R2 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
         largeBiomesField.setAccessible(true);
         Field biomeRegistryField = WorldChunkManagerOverworld.class.getDeclaredField("k");
         biomeRegistryField.setAccessible(true);
-        Field genLayerField = WorldChunkManagerOverworld.class.getDeclaredField("f");
-        genLayerField.setAccessible(true);
         Field areaLazyField = GenLayer.class.getDeclaredField("b");
         areaLazyField.setAccessible(true);
         Method initAreaFactoryMethod = GenLayers.class.getDeclaredMethod("a", boolean.class, int.class, int.class, LongFunction.class);
@@ -405,15 +416,51 @@ public class Regen_v1_16_R2 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
         //init new WorldChunkManagerOverworld
         boolean legacyBiomeInitLayer = legacyBiomeInitLayerField.getBoolean(chunkManager);
         boolean largebiomes = largeBiomesField.getBoolean(chunkManager);
-        IRegistry<BiomeBase> biomeRegistry = (IRegistry<BiomeBase>) biomeRegistryField.get(chunkManager);
-        chunkManager = new WorldChunkManagerOverworld(seed, legacyBiomeInitLayer, largebiomes, biomeRegistry);
+        IRegistry<BiomeBase> biomeRegistrynms = (IRegistry<BiomeBase>) biomeRegistryField.get(chunkManager);
+        IRegistry<BiomeBase> biomeRegistry;
+        if (options.hasBiomeType()) {
+            BiomeBase biome = RegistryGeneration.WORLDGEN_BIOME.get(MinecraftKey.a(options.getBiomeType().getId()));
+            biomeRegistry = new RegistryMaterials<>(ResourceKey.a(new MinecraftKey("fawe_biomes")), Lifecycle.experimental());
+            ((RegistryMaterials) biomeRegistry).a(0, RegistryGeneration.WORLDGEN_BIOME.c(biome).get(), biome, Lifecycle.experimental());
+        } else {
+            biomeRegistry = biomeRegistrynms;
+        }
+        chunkManager = new FastWorldChunkManagerOverworld(seed, legacyBiomeInitLayer, largebiomes, biomeRegistry);
 
         //replace genLayer
         AreaFactory<FastAreaLazy> factory = (AreaFactory<FastAreaLazy>) initAreaFactoryMethod.invoke(null, legacyBiomeInitLayer, largebiomes ? 6 : 4, 4, (LongFunction) (l -> new FastWorldGenContextArea(seed, l)));
-        genLayerField.set(chunkManager, new FastGenLayer(factory));
+        ((FastWorldChunkManagerOverworld) chunkManager).genLayer = new FastGenLayer(factory);
 
         return chunkManager;
     }
+
+    private static class FastWorldChunkManagerOverworld extends WorldChunkManager {
+
+        private GenLayer genLayer;
+        private final IRegistry<BiomeBase> k;
+        private final boolean isSingleRegistry;
+
+        public FastWorldChunkManagerOverworld(long seed, boolean legacyBiomeInitLayer, boolean largeBiomes, IRegistry<BiomeBase> biomeRegistry) {
+            super(biomeRegistry.g().collect(Collectors.toList()));
+            this.k = biomeRegistry;
+            this.isSingleRegistry = biomeRegistry.d().size() == 1;
+            this.genLayer = GenLayers.a(seed, legacyBiomeInitLayer, largeBiomes ? 6 : 4, 4);
+        }
+
+        @Override
+        protected Codec<? extends WorldChunkManager> a() {
+            return WorldChunkManagerOverworld.e;
+        }
+
+        @Override
+        public BiomeBase getBiome(int i, int i1, int i2) {
+            if (this.isSingleRegistry) {
+                return this.k.fromId(0);
+            }
+            return this.genLayer.a(this.k, i, i2);
+        }
+    }
+
 
     private static class FastWorldGenContextArea implements AreaContextTransformed<FastAreaLazy> {
 

--- a/worldedit-core/src/main/java/com/boydti/fawe/wrappers/WorldWrapper.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/wrappers/WorldWrapper.java
@@ -29,6 +29,7 @@ import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.SideEffectSet;
 import com.sk89q.worldedit.util.TreeGenerator;
 import com.sk89q.worldedit.world.AbstractWorld;
+import com.sk89q.worldedit.world.RegenOptions;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
@@ -240,6 +241,11 @@ public class WorldWrapper extends AbstractWorld {
     @Override
     public boolean regenerate(Region region, EditSession session) {
         return parent.regenerate(region, session);
+    }
+
+    @Override
+    public boolean regenerate(Region region, Extent extent, RegenOptions options) {
+        return parent.regenerate(region, extent, options);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -63,7 +63,9 @@ import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.TreeGenerator.TreeType;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.util.formatting.text.TranslatableComponent;
+import com.sk89q.worldedit.world.RegenOptions;
 import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import org.enginehub.piston.annotation.Command;
@@ -609,15 +611,26 @@ public class RegionCommands {
     @CommandPermissions("worldedit.regen")
     @Logging(REGION)
     @Confirm(Confirm.Processor.REGION)
-    public void regenerateChunk(Actor actor, World world, LocalSession session, EditSession editSession,
-                                @Selection Region region) throws WorldEditException {
+    void regenerate(Actor actor, World world, LocalSession session, EditSession editSession,
+                    @Selection Region region,
+                    @Arg(desc = "The seed to regenerate with, otherwise uses world seed", def = "")
+                            Long seed,
+                    @Switch(name = 'b', desc = "Regenerate biomes as well")
+                            boolean regenBiomes,
+                    @Arg(desc = "Biome to apply for this regeneration (only works in overworld)", def = "")
+                            BiomeType biomeType) throws WorldEditException {
         Mask mask = session.getMask();
         boolean success;
         try {
-            session.setMask((Mask) null);
-            session.setSourceMask((Mask) null);
+            session.setMask(null);
+            session.setSourceMask(null);
             actor.printInfo(TranslatableComponent.of("fawe.regen.time"));
-            success = world.regenerate(region, editSession);
+            RegenOptions options = RegenOptions.builder()
+                    .seed(seed)
+                    .regenBiomes(regenBiomes)
+                    .biomeType(biomeType)
+                    .build();
+            success = world.regenerate(region, editSession, options);
         } finally {
             session.setMask(mask);
             session.setSourceMask(mask);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/RegenOptions.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/RegenOptions.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.world;
 import com.google.auto.value.AutoValue;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.world.biome.BiomeType;
 
 import java.util.OptionalLong;
 import javax.annotation.Nullable;
@@ -38,7 +39,7 @@ public abstract class RegenOptions {
      * @return the builder
      */
     public static Builder builder() {
-        return new AutoValue_RegenOptions.Builder().seed(OptionalLong.empty()).regenBiomes(false);
+        return new AutoValue_RegenOptions.Builder().seed(OptionalLong.empty()).regenBiomes(false).biomeType(null);
     }
 
     @AutoValue.Builder
@@ -70,6 +71,13 @@ public abstract class RegenOptions {
         public abstract Builder regenBiomes(boolean regenBiomes);
 
         /**
+         * Defines the {@code BiomeType} the regenerator should use for regeneration. Defaults to {@code null}.
+         * @param biomeType the {@code BiomeType} to be used for regeneration
+         * @return this builder
+         */
+        public abstract Builder biomeType(@Nullable BiomeType biomeType);
+
+        /**
          * Build the options object.
          *
          * @return the options object
@@ -97,6 +105,12 @@ public abstract class RegenOptions {
      */
     public final boolean shouldRegenBiomes() {
         return isRegenBiomes();
+    }
+
+    @Nullable public abstract BiomeType getBiomeType();
+
+    public boolean hasBiomeType() {
+        return getBiomeType() != null;
     }
 
 }


### PR DESCRIPTION
## Overview
This PR implements the ability to regenerate regions with biome specifications.

## Description
This allows the user to regenerate a region with whatever biome they specify. To use this, the user would execute "//regen BiomeType", where BiomeType is replaced with the name of the biome they want. For example, selecting a region of ocean and typing "//regen plains" will regenerate the region not with the original ocean biome, but with a seamless plains biome with accurate features (cave generation, tree and other populator placement, etc.).

One current downside of this implementation is that the biome-specific regeneration only works in overworld worlds, so using this in worlds like The End and Nether will simply regenerate the region with original, respective terrain instead of the target biome. This should not be used against the consideration of approving this PR.

BEFORE APPROVING:
I don't have anything locally that allows me to easily test on 1.16.1 and 1.15.x environments, thus this feature in those versions is implemented but UNTESTED! Please ensure someone has tested this in those versions prior to any approvals.

## Checklist
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality (Only tested 1.16.3 at the time of PR creation)
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
