### PR TITLE
Reimplement #offset mask

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -38,6 +38,7 @@ import com.sk89q.worldedit.extension.factory.parser.mask.NoiseMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.OffsetMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.ROCAngleMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.RegionMaskParser;
+import com.sk89q.worldedit.extension.factory.parser.mask.RichOffsetMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.SimplexMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.SolidMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.SurfaceMaskParser;
@@ -97,6 +98,7 @@ public final class MaskFactory extends AbstractFactory<Mask> {
         register(new FalseMaskParser(worldEdit));
         register(new LiquidMaskParser(worldEdit));
         //register(new RadiusMaskParser(worldEdit)); TODO: Adapt to work with FAWE's Chunk I/O
+        register(new RichOffsetMaskParser(worldEdit));
         register(new ROCAngleMaskParser(worldEdit));
         register(new SimplexMaskParser(worldEdit));
         register(new SurfaceMaskParser(worldEdit));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/RichOffsetMaskParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/mask/RichOffsetMaskParser.java
@@ -1,0 +1,51 @@
+package com.sk89q.worldedit.extension.factory.parser.mask;
+
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.command.util.SuggestionHelper;
+import com.sk89q.worldedit.extension.factory.parser.RichParser;
+import com.sk89q.worldedit.extension.input.InputParseException;
+import com.sk89q.worldedit.extension.input.ParserContext;
+import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.function.mask.MaskIntersection;
+import com.sk89q.worldedit.function.mask.Masks;
+import com.sk89q.worldedit.function.mask.OffsetMask;
+import com.sk89q.worldedit.math.BlockVector3;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.stream.Stream;
+
+public class RichOffsetMaskParser extends RichParser<Mask> {
+
+    /**
+     * Create a new rich parser with a defined prefix for the result, e.g. {@code #simplex}.
+     *
+     * @param worldEdit the worldedit instance.
+     */
+    public RichOffsetMaskParser(WorldEdit worldEdit) {
+        super(worldEdit, "#offset");
+    }
+
+    @Override
+    protected Stream<String> getSuggestions(String argumentInput, int index) {
+        if (index < 3) {
+            return SuggestionHelper.suggestPositiveIntegers(argumentInput);
+        }
+        if (index == 3) {
+            return worldEdit.getMaskFactory().getSuggestions(argumentInput).stream();
+        }
+        return Stream.empty();
+    }
+
+    @Override
+    protected Mask parseFromInput(@NotNull String[] arguments, ParserContext context) throws InputParseException {
+        if (arguments.length != 4) {
+            return null;
+        }
+        int x = Integer.parseInt(arguments[0]);
+        int y = Integer.parseInt(arguments[1]);
+        int z = Integer.parseInt(arguments[2]);
+        Mask submask = worldEdit.getMaskFactory().parseFromInput(arguments[3], context);
+        OffsetMask offsetMask = new OffsetMask(submask, BlockVector3.at(x, y, z));
+        return new MaskIntersection(offsetMask, Masks.negate(submask));
+    }
+}


### PR DESCRIPTION
## Overview

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Partly fixes #637**

## Description
<!-- Please describe what you have changed -->
This reimplements the #offset mask that takes arbitrary integers as offset (compared to `>` and `<` which only allow masking blocks above and below). 
Syntax: `#offset[<x>][<y>][<z>][<mask>]`

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
