### PR TITLE
Fix confirm deadlock and confirm permissions/limits

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/annotation/Confirm.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/annotation/Confirm.java
@@ -52,7 +52,8 @@ public @interface Confirm {
                     * (long) value;
                 long max = 2 << 18;
                 if (max != -1 && area > max) {
-                    actor.print(Caption.of("fawe.cancel.worldedit.cancel.reason.confirm.region", pos1, pos2, getArgs(context)));
+                    actor.print(Caption.of("fawe.cancel.worldedit.cancel.reason.confirm.region",
+                            pos1, pos2, getArgs(context), region.getHeight() * area));
                     return confirm(actor, context);
                 }
                 return true;
@@ -63,8 +64,9 @@ public @interface Confirm {
             public boolean passes(Actor actor, InjectedValueAccess context, double value) {
                 int max = WorldEdit.getInstance().getConfiguration().maxRadius;
                 if (max != -1 && value > max) {
-                    actor.print(Caption.of("fawe.cancel.worldedit.cancel.reason.confirm.region", value, max, getArgs(context)));
-                    return Processor.confirm(actor, context);
+                    actor.print(Caption.of("fawe.cancel.worldedit.cancel.reason.confirm.radius",
+                            value, max, getArgs(context)));
+                    return confirm(actor, context);
                 }
                 return true;
             }
@@ -74,8 +76,9 @@ public @interface Confirm {
             public boolean passes(Actor actor, InjectedValueAccess context, double value) {
                 int max = 50; //TODO configurable, get Key.of(Method.class) @Limit
                 if (max != -1 && value > max) {
-                    actor.print(Caption.of("fawe.cancel.worldedit.cancel.reason.confirm.region", value, max, getArgs(context)));
-                    return Processor.confirm(actor, context);
+                    actor.print(Caption.of("fawe.cancel.worldedit.cancel.reason.confirm.limit",
+                            value, max, getArgs(context)));
+                    return confirm(actor, context);
                 }
                 return true;
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Actor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/Actor.java
@@ -192,7 +192,7 @@ public interface Actor extends Identifiable, SessionOwner, Subject, MapMetadatab
         if (confirm == null) {
             return false;
         }
-        queueAction(confirm::signal);
+        confirm.signal();
         return true;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/ConfirmHandler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/ConfirmHandler.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.internal.command;
 
+import com.boydti.fawe.config.Settings;
 import com.sk89q.worldedit.command.util.annotation.Confirm;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
@@ -46,6 +47,10 @@ public class ConfirmHandler implements CommandCallListener {
             return;
         }
         Actor actor = actorOpt.get();
+        // don't check confirmation if actor doesn't need to confirm
+        if (!Settings.IMP.getLimit(actor).CONFIRM_LARGE) {
+            return;
+        }
         if (!confirmAnnotation.value().passes(actor, parameters, 1)) {
             throw new StopExecutionException(TextComponent.empty());
         }

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -108,6 +108,8 @@
 	"fawe.cancel.worldedit.cancel.count": "Cancelled {0} edits.",
 	"fawe.cancel.worldedit.cancel.reason.confirm": "Use //confirm to execute {2}",
 	"fawe.cancel.worldedit.cancel.reason.confirm.region": "Your selection is large ({0} -> {1}, containing {3} blocks). Use //confirm to execute {2}",
+	"fawe.cancel.worldedit.cancel.reason.confirm.radius": "Your radius is large ({0} > {1}). Use //confirm to execute {2}",
+	"fawe.cancel.worldedit.cancel.reason.confirm.limit": "You're exceeding your limit for this action ({0} > {1}). Use //confirm to execute {2}",
 	"fawe.cancel.worldedit.cancel.reason": "Your WorldEdit action was cancelled: {0}.",
 	"fawe.cancel.worldedit.cancel.reason.manual": "Manual cancellation",
 	"fawe.cancel.worldedit.cancel.reason.low.memory": "Low memory",


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/FastAsyncWorldEdit/issues
-->

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
`//confirm` was enqueued, therefore it waited for the previous action (which is waiting for confirmation) to finish.

Also, the `confirm-large` option in config wasn't respected previously.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
