### PR TITLE
Correct typo from max world height of 265 to 256

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -2559,7 +2559,7 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
                     int zv = (int) (z.getValue() * unit.getZ() + zero2.getZ());
 
                     BlockState get;
-                    if (yv >= 0 && yv < 265) {
+                    if (yv >= 0 && yv < 256) {
                         get = getBlock(xv, yv, zv);
                     } else {
                         get = BlockTypes.AIR.getDefaultState();


### PR DESCRIPTION
## Description
Corrected typo where max world height was defined as 265
