### PR TITLE
Schem file limits

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -396,16 +396,16 @@ public class Settings extends Config {
         public boolean SEND_BEFORE_HISTORY = false;
 
         @Comment({
-                "Sets a maximum limit (in Mb) for the size of a player's schematics directory (per-player mode only)",
+                "Sets a maximum limit (in kb) for the size of a player's schematics directory (per-player mode only)",
                 "set to -1 to have no limit"
         })
-        public long PERPLAYER_FILESIZELIMIT = -1;
+        public double PERPLAYER_FILESIZELIMIT = -1;
 
         @Comment({
                 "Sets a maximum limit for the amount of schematics in a player's schematics directory (per-player mode only)",
                 "set to -1 to have no limit"
         })
-        public long PERPLAYER_FILENUMLIMIT = -1;
+        public int PERPLAYER_FILENUMLIMIT = -1;
     }
 
     public static class PLOTSQUARED_INTEGRATION {

--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -397,7 +397,7 @@ public class Settings extends Config {
 
         @Comment({
                 "Sets a maximum limit (in kb) for the size of a player's schematics directory (per-player mode only)",
-                "set to -1 to have no limit"
+                "Set to -1 to disable"
         })
         public int PERPLAYER_FILESIZELIMIT = -1;
 

--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -394,6 +394,18 @@ public class Settings extends Config {
             " - Requires combine_stages = true"
         })
         public boolean SEND_BEFORE_HISTORY = false;
+
+        @Comment({
+                "Sets a maximum limit (in Mb) for the size of a player's schematics directory (per-player mode only)",
+                "set to -1 to have no limit"
+        })
+        public long PERPLAYER_FILESIZELIMIT = -1;
+
+        @Comment({
+                "Sets a maximum limit for the amount of schematics in a player's schematics directory (per-player mode only)",
+                "set to -1 to have no limit"
+        })
+        public long PERPLAYER_FILENUMLIMIT = -1;
     }
 
     public static class PLOTSQUARED_INTEGRATION {

--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -405,7 +405,7 @@ public class Settings extends Config {
                 "Sets a maximum limit for the amount of schematics in a player's schematics directory (per-player mode only)",
                 "set to -1 to have no limit"
         })
-        public int PERPLAYER_FILENUMLIMIT = -1;
+        public int PER_PLAYER_FILE_NUM_LIMIT = -1;
     }
 
     public static class PLOTSQUARED_INTEGRATION {

--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -403,7 +403,7 @@ public class Settings extends Config {
 
         @Comment({
                 "Sets a maximum limit for the amount of schematics in a player's schematics directory (per-player mode only)",
-                "set to -1 to have no limit"
+                "Set to -1 to disable"
         })
         public int PER_PLAYER_FILE_NUM_LIMIT = -1;
     }

--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -399,7 +399,7 @@ public class Settings extends Config {
                 "Sets a maximum limit (in kb) for the size of a player's schematics directory (per-player mode only)",
                 "set to -1 to have no limit"
         })
-        public double PERPLAYER_FILESIZELIMIT = -1;
+        public int PERPLAYER_FILESIZELIMIT = -1;
 
         @Comment({
                 "Sets a maximum limit for the amount of schematics in a player's schematics directory (per-player mode only)",

--- a/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -399,7 +399,7 @@ public class Settings extends Config {
                 "Sets a maximum limit (in kb) for the size of a player's schematics directory (per-player mode only)",
                 "Set to -1 to disable"
         })
-        public int PERPLAYER_FILESIZELIMIT = -1;
+        public int PER_PLAYER_FILE_SIZE_LIMIT = -1;
 
         @Comment({
                 "Sets a maximum limit for the amount of schematics in a player's schematics directory (per-player mode only)",

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -815,7 +815,6 @@ public class SchematicCommands {
                             cur_kb -= overwrite_old_kb;
                         }
 
-
                         if ((cur_kb) > allocated_kb) {
 
                             file.delete();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -761,7 +761,7 @@ public class SchematicCommands {
 
                 if (curFilesAmount >= limit) {
                     TextComponent noSlotsErr = TextComponent.of( //TODO - to be moved into captions/translatablecomponents
-                        "You have " + String.format("You have " + curFilesAmount + "/" + limit + " saved schematics. Delete some to save this one!",
+                        String.format("You have " + curFilesAmount + "/" + limit + " saved schematics. Delete some to save this one!",
                             TextColor.RED));
                     log.info(actor.getName() + " failed to save " + file.getCanonicalPath() + " - too many schematics!");
                     throw new WorldEditException(noSlotsErr) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -836,7 +836,7 @@ public class SchematicCommands {
                         actor.print(kb_left_notif);
                     }
 
-                    if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS && Settings.IMP.EXPERIMENTAL.PERPLAYER_FILENUMLIMIT > -1) {
+                    if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS && Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_NUM_LIMIT > -1) {
                         int cur_files = new File(file.getParent()).listFiles().length;
 
                         TextComponent slots_left_notif = TextComponent.of( //TODO - to be moved into captions/translatablecomponents

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -616,7 +616,7 @@ public class SchematicCommands {
 
         String header_bytes_elem = String.format("%.1fkb", total_bytes / 1000.0);
 
-        if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS && Settings.IMP.EXPERIMENTAL.PERPLAYER_FILESIZELIMIT > -1) {
+        if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS && Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_SIZE_LIMIT > -1) {
             header_bytes_elem += String.format(" / %dkb",
                 Settings.IMP.EXPERIMENTAL.PERPLAYER_FILESIZELIMIT);
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -840,7 +840,7 @@ public class SchematicCommands {
                         int cur_files = new File(file.getParent()).listFiles().length;
 
                         TextComponent slots_left_notif = TextComponent.of( //TODO - to be moved into captions/translatablecomponents
-                            "You have " + (Settings.IMP.EXPERIMENTAL.PERPLAYER_FILENUMLIMIT - cur_files)
+                            "You have " + (Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_NUM_LIMIT - cur_files)
                                 + " schematic file slots left.", TextColor.GRAY);
                         actor.print(slots_left_notif);
                     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -621,7 +621,7 @@ public class SchematicCommands {
                 Settings.IMP.EXPERIMENTAL.PERPLAYER_FILESIZELIMIT);
         }
 
-        String full_header = " Schematics | " + header_bytes_elem + " |";
+        String full_header = "| Schematics: " + header_bytes_elem + " |";
         PaginationBox paginationBox = PaginationBox.fromComponents(full_header, pageCommand, components);
         actor.print(paginationBox.create(page));
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -759,7 +759,7 @@ public class SchematicCommands {
             if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS && Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_NUM_LIMIT > -1) {
 
                 int cur_files = new File(file.getParent()).listFiles().length;
-                int limit = Settings.IMP.EXPERIMENTAL.PERPLAYER_FILENUMLIMIT;
+                int limit = Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_NUM_LIMIT ;
 
                 if (cur_files >= limit) {
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -604,7 +604,6 @@ public class SchematicCommands {
         File parent_dir = new File(dir.getAbsolutePath() + (playerFolder ? File.separator + uuid.toString() : ""));
         try {
             for (File schem : parent_dir.listFiles()) {
-
                 if (schem.getName().endsWith(".schem") || schem.getName().endsWith(".schematic")) {
                     total_bytes += Files.size(Paths.get(schem.getAbsolutePath()));
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -618,7 +618,7 @@ public class SchematicCommands {
 
         if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS && Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_SIZE_LIMIT > -1) {
             header_bytes_elem += String.format(" / %dkb",
-                Settings.IMP.EXPERIMENTAL.PERPLAYER_FILESIZELIMIT);
+                Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_SIZE_LIMIT );
         }
 
         String full_header = "| Schematics: " + header_bytes_elem + " |";

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.command;
 
+import javax.annotation.Nullable;
 import com.boydti.fawe.config.Caption;
 import com.boydti.fawe.config.Settings;
 import com.boydti.fawe.object.clipboard.MultiClipboardHolder;
@@ -48,6 +49,7 @@ import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.util.formatting.component.ErrorFormat;
+import com.sk89q.worldedit.util.formatting.component.MessageBox;
 import com.sk89q.worldedit.util.formatting.component.PaginationBox;
 import com.sk89q.worldedit.util.formatting.component.TextComponentProducer;
 import com.sk89q.worldedit.util.formatting.text.Component;
@@ -615,11 +617,11 @@ public class SchematicCommands {
         String header_bytes_elem = String.format("%.1fkb", total_bytes / 1000.0);
 
         if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS && Settings.IMP.EXPERIMENTAL.PERPLAYER_FILESIZELIMIT > -1) {
-            header_bytes_elem += String.format("/%dkb",
+            header_bytes_elem += String.format(" / %dkb",
                 Settings.IMP.EXPERIMENTAL.PERPLAYER_FILESIZELIMIT);
         }
 
-        String full_header = "Schematics [" + header_bytes_elem + "]";
+        String full_header = " Schematics | " + header_bytes_elem + " |";
         PaginationBox paginationBox = PaginationBox.fromComponents(full_header, pageCommand, components);
         actor.print(paginationBox.create(page));
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -756,7 +756,7 @@ public class SchematicCommands {
             }
 
 
-            if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS && Settings.IMP.EXPERIMENTAL.PERPLAYER_FILENUMLIMIT > -1) {
+            if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS && Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_NUM_LIMIT > -1) {
 
                 int cur_files = new File(file.getParent()).listFiles().length;
                 int limit = Settings.IMP.EXPERIMENTAL.PERPLAYER_FILENUMLIMIT;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -762,7 +762,6 @@ public class SchematicCommands {
                 int limit = Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_NUM_LIMIT ;
 
                 if (cur_files >= limit) {
-
                     TextComponent no_slots_err = TextComponent.of( //TODO - to be moved into captions/translatablecomponents
                         "You have " + String.format("You have " + cur_files + "/" + limit + " saved schematics. Delete some to save this one!",
                             TextColor.RED));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -823,7 +823,6 @@ public class SchematicCommands {
                                     + String.format("%dkb", allocated_kb) + " available) Delete some first to save this one!",
                                 TextColor.RED);
                             actor.printError(no_kb_err);
-
                             log.info(actor.getName() + " failed to save " + SCHEMATIC_NAME + " - not enough space!");
                             return null;
                         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -816,7 +816,6 @@ public class SchematicCommands {
                         }
 
                         if ((cur_kb) > allocated_kb) {
-
                             file.delete();
                             TextComponent no_kb_err = TextComponent.of( //TODO - to be moved into captions/translatablecomponents
                                 "You're about to be at " + String.format("%.1f", cur_kb) + "kb of schematics. ("

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -816,7 +816,6 @@ public class SchematicCommands {
                                 "You're about to be at " + String.format("%.1f", curKb) + "kb of schematics. ("
                                     + String.format("%dkb", allocatedKb) + " available) Delete some first to save this one!",
                                 TextColor.RED);
-                            //actor.printError(notEnoughKbErr);
                             log.info(actor.getName() + " failed to save " + SCHEMATIC_NAME + " - not enough space!");
                             throw new WorldEditException(notEnoughKbErr) {
                             };

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -724,7 +724,7 @@ public class SchematicCommands {
             boolean check_filesize = false;
 
             if (Settings.IMP.PATHS.PER_PLAYER_SCHEMATICS
-                && Settings.IMP.EXPERIMENTAL.PERPLAYER_FILESIZELIMIT > -1) {
+                && Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_SIZE_LIMIT > -1) {
                 check_filesize = true;
             }
 
@@ -807,7 +807,7 @@ public class SchematicCommands {
                     if (check_filesize) {
 
                         double cur_kb = filesize_kb + directorysize_kb;
-                        int allocated_kb = Settings.IMP.EXPERIMENTAL.PERPLAYER_FILESIZELIMIT;
+                        int allocated_kb = Settings.IMP.EXPERIMENTAL.PER_PLAYER_FILE_SIZE_LIMIT;
 
                         if (overwrite) {
                             cur_kb -= overwrite_old_kb;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/MessageBox.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/MessageBox.java
@@ -33,7 +33,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class MessageBox extends TextComponentProducer {
 
-    private static final int GUARANTEED_NO_WRAP_CHAT_PAGE_WIDTH = 47;
+    //decremented by one (from 47) to account for minecraft font characters having varying widths
+
+    // method for applying border needs to be replaced in the future  - need to
+    // be able to measure length of title (and prefix) by pixel width, not by character width
+    // (to avoid wrapping in case of thick chars, or not enough spacers in case of thin chars)
+    private static final int GUARANTEED_NO_WRAP_CHAT_PAGE_WIDTH = 46;
 
     private TextComponentProducer contents;
     private TextColor borderColor;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/MessageBox.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/component/MessageBox.java
@@ -33,12 +33,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class MessageBox extends TextComponentProducer {
 
-    //decremented by one (from 47) to account for minecraft font characters having varying widths
-
-    // method for applying border needs to be replaced in the future  - need to
-    // be able to measure length of title (and prefix) by pixel width, not by character width
-    // (to avoid wrapping in case of thick chars, or not enough spacers in case of thin chars)
-    private static final int GUARANTEED_NO_WRAP_CHAT_PAGE_WIDTH = 46;
+    private static final int GUARANTEED_NO_WRAP_CHAT_PAGE_WIDTH = 47;
 
     private TextComponentProducer contents;
     private TextColor borderColor;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets -->
This pull request adds a way to set limits on per-player schematics - adding config options which define the maximum space a player's schematics folder can take up (in kb) as well as the maximum number of schematics a player can have.

If there were to continue to be no limit on schematic size, players could conceivably run a script to save a large clipboard under multiple schematic names and in fill up the server's disk space.

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes https://github.com/IntellectualSites/FastAsyncWorldEdit/issues/742**

## Description
<!-- Please describe what you have changed -->

I have added some rough but functional logic which ensures that while the config options are set, players must have the required room (filesize & slots) in order to save their schematics.

I have also made some adjustments to what `/schematic list` displays, now also showing the size of each schematic on the disk, as well as the total size of all combined schematics (as well as the size quota, if that permission is set)


## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
