### PR TITLE
fix #749 stackoverflow when player leave server when task is not finish

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
@@ -502,7 +502,6 @@ public interface Extent extends InputExtent, OutputExtent {
             traverser.setNext(nullExtent);
             child.cancel();
         }
-        addProcessor(nullExtent);
         return true;
     }
 


### PR DESCRIPTION
Hi,

**Fixes #{749}**
Related issue : https://github.com/IntellectualSites/FastAsyncWorldEdit/issues/749

## How to reproduce this ?

- You need to login non-op account with basic permission to //set in big region !
- Do a selection with about ~30.000.000 blocs
- Type //set stone, wait 1s and disconnect fast your account and a stackoverflow is produced

## How i fix this ?

I have analyze this bug with debug option and when i have enabled "other" option in experimental bloc, i see stackoverflow was produced with this :

Stackoverflow debug stracktrace : https://pastebin.com/JC9d9WMB

I have removed addProcessor in cancel method from Extend interface, but i don't think this is perfect solution, this is first time i edit code from FAWE and honestly i don't understand some parts of your code, i do this to fix this quickly because in my creatif server FAWE crash everyday.

Of course, I did another test and the stackoverflow is never produced.

Sincerely,
Fabien

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
