### PR TITLE
NullPointer fix for /schematic list

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -601,11 +601,13 @@ public class SchematicCommands {
         long totalBytes = 0;
         File parentDir = new File(dir.getAbsolutePath() + (playerFolder ? File.separator + uuid.toString() : ""));
         try {
-            for (File schem : getFiles(parentDir, null, null)) {
-                if (schem.getName().endsWith(".schem") || schem.getName().endsWith(".schematic")) {
-                    totalBytes += Files.size(Paths.get(schem.getAbsolutePath()));
+            List<File> toAddUp = getFiles(parentDir, null, null);
+            if(toAddUp != null &&  toAddUp.size() != 0)
+                for (File schem : toAddUp) {
+                    if (schem.getName().endsWith(".schem") || schem.getName().endsWith(".schematic")) {
+                        totalBytes += Files.size(Paths.get(schem.getAbsolutePath()));
+                    }
                 }
-            }
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -738,15 +738,15 @@ public class SchematicCommands {
 
             int numFiles = -1;
             if (checkFilesize) {
-                File parentDir = new File(file.getParent());
-
-                for (File child : getFiles(rootDir, null, null)) {
-                    if (child.getName().endsWith(".schem") || child.getName().endsWith(".schematic")) {
-                        directorysizeKb += Files.size(Paths.get(child.getAbsolutePath())) / 1000.0;
-                        numFiles++;
+                List<File> toAddUp = getFiles(rootDir, null, null);
+                if(toAddUp != null &&  toAddUp.size() != 0) {
+                    for (File child : toAddUp) {
+                        if (child.getName().endsWith(".schem") || child.getName().endsWith(".schematic")) {
+                            directorysizeKb += Files.size(Paths.get(child.getAbsolutePath())) / 1000.0;
+                            numFiles++;
+                        }
                     }
                 }
-
                 if (overwrite) {
                     oldKbOverwritten = Files.size(Paths.get(file.getAbsolutePath())) / 1000.0;
                     int iter = 1;
@@ -762,9 +762,12 @@ public class SchematicCommands {
 
                 if (numFiles == -1) {
                     numFiles = 0;
-                    for (File child : getFiles(rootDir, null, null)) {
-                        if (child.getName().endsWith(".schem") || child.getName().endsWith(".schematic")) {
-                            numFiles++;
+                    List<File> toAddUp = getFiles(rootDir, null, null);
+                    if(toAddUp != null &&  toAddUp.size() != 0) {
+                        for (File child : toAddUp) {
+                            if (child.getName().endsWith(".schem") || child.getName().endsWith(".schematic")) {
+                                numFiles++;
+                            }
                         }
                     }
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -602,12 +602,13 @@ public class SchematicCommands {
         File parentDir = new File(dir.getAbsolutePath() + (playerFolder ? File.separator + uuid.toString() : ""));
         try {
             List<File> toAddUp = getFiles(parentDir, null, null);
-            if(toAddUp != null &&  toAddUp.size() != 0)
+            if (toAddUp != null &&  toAddUp.size() != 0) {
                 for (File schem : toAddUp) {
                     if (schem.getName().endsWith(".schem") || schem.getName().endsWith(".schematic")) {
                         totalBytes += Files.size(Paths.get(schem.getAbsolutePath()));
                     }
                 }
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -739,7 +740,7 @@ public class SchematicCommands {
             int numFiles = -1;
             if (checkFilesize) {
                 List<File> toAddUp = getFiles(rootDir, null, null);
-                if(toAddUp != null &&  toAddUp.size() != 0) {
+                if (toAddUp != null &&  toAddUp.size() != 0) {
                     for (File child : toAddUp) {
                         if (child.getName().endsWith(".schem") || child.getName().endsWith(".schematic")) {
                             directorysizeKb += Files.size(Paths.get(child.getAbsolutePath())) / 1000.0;
@@ -763,7 +764,7 @@ public class SchematicCommands {
                 if (numFiles == -1) {
                     numFiles = 0;
                     List<File> toAddUp = getFiles(rootDir, null, null);
-                    if(toAddUp != null &&  toAddUp.size() != 0) {
+                    if (toAddUp != null &&  toAddUp.size() != 0) {
                         for (File child : toAddUp) {
                             if (child.getName().endsWith(".schem") || child.getName().endsWith(".schematic")) {
                                 numFiles++;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets
If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/FastAsyncWorldEdit/issues
-->

This solves the nullpointer exception players get when listing schematics where the parent directory was not made yet

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes #{issue number}**
fixes #780 
## Description
<!-- Please describe what you have changed -->

added checks to make sure if array returned by getFiles() is null it is not used

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
