### PR TITLE
Properly repeat extents for negative coordinates

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RepeatingExtentPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RepeatingExtentPattern.java
@@ -21,7 +21,6 @@ package com.sk89q.worldedit.function.pattern;
 
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldedit.math.MutableBlockVector3;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -88,9 +87,9 @@ public class RepeatingExtentPattern extends AbstractExtentPattern {
 
     @Override
     public BaseBlock apply(BlockVector3 position) {
-        int x = Math.abs(position.getX() + offset.getX()) % size.getBlockX() + origin.getX();
-        int y = Math.abs(position.getY() + offset.getY()) % size.getBlockY() + origin.getY();
-        int z = Math.abs(position.getZ() + offset.getZ()) % size.getBlockZ() + origin.getZ();
+        int x = Math.floorMod(position.getBlockX() + offset.getBlockX(), size.getBlockX()) + origin.getBlockX();
+        int y = Math.floorMod(position.getBlockY() + offset.getBlockY(), size.getBlockY()) + origin.getBlockY();
+        int z = Math.floorMod(position.getBlockZ() + offset.getBlockZ(), size.getBlockZ()) + origin.getBlockZ();
         return getExtent().getFullBlock(x, y, z);
     }
 


### PR DESCRIPTION
An extent's content was returned flipped when applied for negative positions, as e.g. `Math.abs(-2) % 3` returns 2 instead of 1 (as 1 + -1 * 3 = -2)

(cherry picked from commit b0cf5dd2bf1b9bcbf1c7efff0fe25de7ee9a2090)
