### PR TITLE
Don't add entities to chunk on regen

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_16_R3.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/regen/Regen_v1_16_R3.java
@@ -70,6 +70,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -302,6 +303,12 @@ public class Regen_v1_16_R3 extends Regenerator<IChunkAccess, ProtoChunk, Chunk,
         return new ProtoChunk(new ChunkCoordIntPair(x, z), ChunkConverter.a) {
             public boolean generateFlatBedrock() {
                 return generateFlatBedrock;
+            }
+
+            // no one will ever see the entities!
+            @Override
+            public List<NBTTagCompound> y() {
+                return Collections.emptyList();
             }
         };
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/FastAsyncWorldEdit/issues
-->

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes #896**

## Description
<!-- Please describe what you have changed -->
This prevents entities from being added to the chunk by returning an empty list instead. This way we can avoid triggering the async catcher. As this only applies for 1.16.5, I ignored older versions. I only tested with paper but it seems to work there. so I'm assuming it'll work on forks and spigot too.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [ ] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
