### PR TITLE
Fix performance issues getting next file ids

### DIFF
--- a/worldedit-core/src/main/java/com/boydti/fawe/object/changeset/CFIChangeSet.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/changeset/CFIChangeSet.java
@@ -11,7 +11,11 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
 
 public class CFIChangeSet extends AbstractChangeSet {
 

--- a/worldedit-core/src/main/java/com/boydti/fawe/object/changeset/CFIChangeSet.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/changeset/CFIChangeSet.java
@@ -11,18 +11,27 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.UUID;
+import java.util.*;
 
 public class CFIChangeSet extends AbstractChangeSet {
+
+    private static final Map<UUID, Map<String, Integer>> NEXT_INDEX = new HashMap<>();
 
     private final File file;
 
     public CFIChangeSet(HeightMapMCAGenerator hmmg, UUID uuid) throws IOException {
         super(hmmg);
-        File folder = MainUtil.getFile(Fawe.imp().getDirectory(), Settings.IMP.PATHS.HISTORY + File.separator + uuid + File.separator + "CFI" + File.separator + hmmg.getId());
-        int max = MainUtil.getMaxFileId(folder);
+        final String hmmgId = hmmg.getId();
+        final File folder = MainUtil.getFile(Fawe.imp().getDirectory(), Settings.IMP.PATHS.HISTORY + File.separator + uuid + File.separator + "CFI" + File.separator + hmmgId);
+
+        final Map<String, Integer> hmmgMap = NEXT_INDEX.getOrDefault(uuid, new HashMap<>());
+        int max = hmmgMap.getOrDefault(hmmgId, -1);
+        if (max == -1) {
+            max = MainUtil.getMaxFileId(folder);
+        }
+        hmmgMap.put(hmmgId, max + 1);
+        NEXT_INDEX.putIfAbsent(uuid, hmmgMap);
+
         this.file = new File(folder, max + ".cfi");
         File parent = this.file.getParentFile();
         if (!parent.exists()) {

--- a/worldedit-core/src/main/java/com/boydti/fawe/object/changeset/DiskStorageHistory.java
+++ b/worldedit-core/src/main/java/com/boydti/fawe/object/changeset/DiskStorageHistory.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -29,6 +31,8 @@ import java.util.UUID;
  * - Slow
  */
 public class DiskStorageHistory extends FaweStreamChangeSet {
+
+    private static final Map<String, Map<UUID, Integer>> NEXT_INDEX = new HashMap<>();
 
     private UUID uuid;
     private File bdFile;
@@ -67,8 +71,16 @@ public class DiskStorageHistory extends FaweStreamChangeSet {
     }
 
     private void init(UUID uuid, String worldName) {
-        File folder = MainUtil.getFile(Fawe.imp().getDirectory(), Settings.IMP.PATHS.HISTORY + File.separator + worldName + File.separator + uuid);
-        int max = MainUtil.getMaxFileId(folder);
+        final File folder = MainUtil.getFile(Fawe.imp().getDirectory(), Settings.IMP.PATHS.HISTORY + File.separator + worldName + File.separator + uuid);
+
+        final Map<UUID, Integer> playerMap = NEXT_INDEX.getOrDefault(worldName, new HashMap<>());
+        int max = playerMap.getOrDefault(uuid, -1);
+        if (max == -1) {
+            max = MainUtil.getMaxFileId(folder);
+        }
+        playerMap.put(uuid, max + 1);
+        NEXT_INDEX.putIfAbsent(worldName, playerMap);
+
         init(uuid, max);
     }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/FastAsyncWorldEdit/issues
-->
This PR aims to fix a huge issue with thousands of history files saved on disk.
The same behavior has been copied out to CfiChangeSet, class that used the same behaviour to get the next file id.

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes #887**

## Description
<!-- Please describe what you have changed -->
Firstly, I tried the suggested fix using ``java.nio`` package, that wasn't successful at all.
Then, I decided to simply cache these heavy values in Maps, and load the first value thanks to the old method, still needed with this implementation.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
