### PR TITLE
Keep order of block properties

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypesCache.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypesCache.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -62,7 +63,8 @@ public class BlockTypesCache {
                 this.propertiesMapArr = new AbstractProperty[maxOrdinal + 1];
                 int prop_arr_i = 0;
                 this.propertiesArr = new AbstractProperty[properties.size()];
-                HashMap<String, AbstractProperty<?>> propMap = new HashMap<>();
+                // Preserve properties order with LinkedHashMap
+                HashMap<String, AbstractProperty<?>> propMap = new LinkedHashMap<>();
 
                 int bitOffset = 0;
                 for (Map.Entry<String, ? extends Property<?>> entry : properties.entrySet()) {


### PR DESCRIPTION
## Overview
Block properties are not in order like they are in Minecraft and WorldEdit
**Fixes #1052**

## Description
Modified the HashMap of BlockTypesCache.propertiesMap to be a LinkedHashMap in order to keep the keys in order

## Checklist
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
