### PR TITLE
Fixed unit tests + Version Determination

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: "Run BuildTools"
       run: "java -jar BuildTools.jar --rev 1.16.5"
     - name: "Clean Build"
-      run: "./gradlew clean build -x test sourcesJar javadocJar"
+      run: "./gradlew clean build sourcesJar javadocJar"
     - name: Cleanup Gradle Cache
       # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
       # Restoring these files from a GitHub Actions cache might cause problems for future builds.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.ajoberstar.grgit.Grgit
 import java.time.format.DateTimeFormatter
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat.*
-import org.gradle.api.tasks.testing.logging.TestLogEvent.*
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 
 logger.lifecycle("""
 *******************************************

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.ajoberstar.grgit.Grgit
 import java.time.format.DateTimeFormatter
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat.*
+import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 logger.lifecycle("""
 *******************************************
@@ -50,6 +52,15 @@ allprojects {
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile::class) {
             options.compilerArgs.addAll(arrayOf("-Xmaxerrs", "1000"))
+        }
+        tasks.withType(Test::class) {
+            testLogging {
+                events(FAILED)
+                exceptionFormat = FULL
+                showExceptions = true
+                showCauses = true
+                showStackTraces = true
+            }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -59,6 +59,7 @@ fun Project.applyPlatformAndCoreConfiguration() {
         "testImplementation"("org.junit.jupiter:junit-jupiter-params:${Versions.JUNIT}")
         "testImplementation"("org.mockito:mockito-core:${Versions.MOCKITO}")
         "testImplementation"("org.mockito:mockito-junit-jupiter:${Versions.MOCKITO}")
+        "testImplementation"("net.bytebuddy:byte-buddy:1.11.0")
         "testRuntime"("org.junit.jupiter:junit-jupiter-engine:${Versions.JUNIT}")
     }
 

--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -98,9 +98,7 @@ dependencies {
     compileOnly("net.kyori:adventure-api:4.7.0")
     testImplementation("net.kyori:adventure-api:4.7.0")
     testImplementation("org.checkerframework:checker-qual:3.13.0")
-    testImplementation("org.spigotmc:spigot-api:1.16.2-R0.1-SNAPSHOT") {
-        isTransitive = true
-    }
+    testImplementation("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT") { isTransitive = true }
     api("com.intellectualsites.paster:Paster:1.0.1-SNAPSHOT")
     // Third party
     implementation("org.bstats:bstats-bukkit:2.2.1")

--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-api")
     compileOnly("org.spigotmc:spigot:1.16.5-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    testCompileOnly("org.jetbrains:annotations:20.1.0")
     implementation("io.papermc:paperlib:1.0.6")
     compileOnly("com.sk89q:dummypermscompat:1.10") {
         exclude("com.github.MilkBowl", "VaultAPI")
@@ -97,7 +96,11 @@ dependencies {
         exclude("com.sk89q.worldedit.worldedit-libs", "core")
     }
     compileOnly("net.kyori:adventure-api:4.7.0")
-    testCompileOnly("net.kyori:adventure-api:4.7.0")
+    testImplementation("net.kyori:adventure-api:4.7.0")
+    testImplementation("org.checkerframework:checker-qual:3.13.0")
+    testImplementation("org.spigotmc:spigot-api:1.16.2-R0.1-SNAPSHOT") {
+        isTransitive = true
+    }
     api("com.intellectualsites.paster:Paster:1.0.1-SNAPSHOT")
     // Third party
     implementation("org.bstats:bstats-bukkit:2.2.1")

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
@@ -19,6 +19,7 @@ import com.boydti.fawe.bukkit.regions.TownyFeature;
 import com.boydti.fawe.bukkit.regions.Worldguard;
 import com.boydti.fawe.bukkit.util.BukkitTaskManager;
 import com.boydti.fawe.bukkit.util.ItemUtil;
+import com.boydti.fawe.bukkit.util.MinecraftVersion;
 import com.boydti.fawe.bukkit.util.image.BukkitImageViewer;
 import com.boydti.fawe.config.Settings;
 import com.boydti.fawe.regions.FaweMaskManager;
@@ -80,8 +81,7 @@ public class FaweBukkit implements IFawe, Listener {
             Bukkit.getServer().shutdown();
         }
 
-        chunksStretched =
-            Integer.parseInt(Bukkit.getBukkitVersion().split("-")[0].split("\\.")[1]) >= 16;
+        chunksStretched = new MinecraftVersion().isEqualOrHigher(MinecraftVersion.NETHER);
 
         platformAdapter = new NMSAdapter();
 

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/util/MinecraftVersion.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/util/MinecraftVersion.java
@@ -130,8 +130,8 @@ public class MinecraftVersion implements Comparable<MinecraftVersion> {
     }
 
     /**
-     * Determines the server version based on the package path, e.g. {@code org.bukkit.craftbukkit.v1_8_R3},
-     * where v1_8_R3 is the resolved version.
+     * Determines the server version based on the package path, e.g. {@code org.bukkit.craftbukkit.v1_16_R3},
+     * where v1_16_R3 is the resolved version.
      *
      * @return The package version.
      */

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/util/MinecraftVersion.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/util/MinecraftVersion.java
@@ -1,0 +1,143 @@
+package com.boydti.fawe.bukkit.util;
+
+import com.google.common.collect.ComparisonChain;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Utility class for retrieving and comparing minecraft server versions.
+ */
+public class MinecraftVersion implements Comparable<MinecraftVersion> {
+
+    public static final MinecraftVersion NETHER = new MinecraftVersion(1, 16);
+
+    private final int major;
+    private final int minor;
+    private final int release;
+
+    /**
+     * Construct a new version with major, minor and release version.
+     *
+     * @param major   Major part of the version, only {@code 1} would make sense.
+     * @param minor   Minor part, full updates, e.g. Nether & Caves & Cliffs
+     * @param release Release, changes for the server software during a minor update.
+     */
+    public MinecraftVersion(int major, int minor, int release) {
+        this.major = major;
+        this.minor = minor;
+        this.release = release;
+    }
+
+    /**
+     * Construct a new version with major and minor version.
+     * The release version is set to 0, therefore ignored.
+     *
+     * @see MinecraftVersion#MinecraftVersion(int, int, int)
+     */
+    public MinecraftVersion(int major, int minor) {
+        this(major, minor, 0);
+    }
+
+    /**
+     * Construct a new version with major, minor and release based on the server version.
+     */
+    public MinecraftVersion() {
+        // Array consists of three version parts, eg. ['v1', '16', 'R3']
+        String[] versionParts = getPackageVersion().split("_");
+
+        if (versionParts.length != 3) {
+            throw new IllegalStateException("Failed to determine minecraft version!");
+        }
+
+        this.major = Integer.parseInt(versionParts[0].substring(1));
+        this.minor = Integer.parseInt(versionParts[1]);
+        this.release = Integer.parseInt(versionParts[2].substring(1));
+    }
+
+    /**
+     * @param other The other version to compare against.
+     * @return {@code true} if this version is equal to the other version.
+     */
+    public boolean isEqual(MinecraftVersion other) {
+        return compareTo(other) == 0;
+    }
+
+    /**
+     * @param other The other version to compare against.
+     * @return {@code true} if this version is higher or equal compared to the other version.
+     */
+    public boolean isEqualOrHigher(MinecraftVersion other) {
+        return compareTo(other) >= 0;
+    }
+
+    /**
+     * @param other The other version to compare against.
+     * @return {@code true} if this version is lower or equal compared to the other version.
+     */
+    public boolean isEqualOrLower(MinecraftVersion other) {
+        return compareTo(other) <= 0;
+    }
+
+    /**
+     * @param other The other version to compare against.
+     * @return {@code true} if this version is higher than the other version.
+     */
+    public boolean isHigher(MinecraftVersion other) {
+        return compareTo(other) > 0;
+    }
+
+    /**
+     * @param other The other version to compare against.
+     * @return {@code true} if this version is lower than to the other version.
+     */
+    public boolean isLower(MinecraftVersion other) {
+        return compareTo(other) < 0;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getRelease() {
+        return release;
+    }
+
+    @Override
+    public int compareTo(@NotNull MinecraftVersion other) {
+        if (other.equals(this)) {
+            return 0;
+        }
+        return ComparisonChain.start()
+                .compare(getMajor(), other.getMajor())
+                .compare(getMinor(), other.getMinor())
+                .compare(getRelease(), other.getRelease()).result();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MinecraftVersion that = (MinecraftVersion) o;
+
+        if (getMajor() != that.getMajor()) return false;
+        if (getMinor() != that.getMinor()) return false;
+        return getRelease() == that.getRelease();
+    }
+
+    /**
+     * Determines the server version based on the package path, e.g. {@code org.bukkit.craftbukkit.v1_8_R3},
+     * where v1_8_R3 is the resolved version.
+     *
+     * @return The package version.
+     */
+    private static String getPackageVersion() {
+        String fullPackagePath = Bukkit.getServer().getClass().getPackage().getName();
+        return fullPackagePath.substring(fullPackagePath.lastIndexOf('.') + 1);
+    }
+
+}

--- a/worldedit-bukkit/src/test/java/com/sk89q/util/MinecraftVersionTest.java
+++ b/worldedit-bukkit/src/test/java/com/sk89q/util/MinecraftVersionTest.java
@@ -1,0 +1,51 @@
+package com.sk89q.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.boydti.fawe.bukkit.util.MinecraftVersion;
+import org.junit.jupiter.api.Test;
+
+public class MinecraftVersionTest {
+
+    private final MinecraftVersion latestVersion = new MinecraftVersion(1, 16, 3);
+
+    @Test
+    public void testComparable() {
+        assertEquals(0, latestVersion.compareTo(new MinecraftVersion(1, 16, 3)));
+        assertEquals(1, latestVersion.compareTo(new MinecraftVersion(1, 15, 2)));
+        assertEquals(-1, latestVersion.compareTo(new MinecraftVersion(1, 17, 0)));
+    }
+
+    @Test
+    public void testEqualOrHigher() {
+        assertTrue(latestVersion.isEqualOrHigher(new MinecraftVersion(1, 16, 3)));
+        assertTrue(latestVersion.isEqualOrHigher(new MinecraftVersion(1, 16, 2)));
+        assertFalse(latestVersion.isEqualOrHigher(new MinecraftVersion(1, 16, 4)));
+    }
+
+    @Test
+    public void testEqualOrHigherWithoutRelease() {
+        assertTrue(latestVersion.isEqualOrHigher(new MinecraftVersion(1, 16)));
+    }
+
+    @Test
+    public void testEqual() {
+        assertTrue(latestVersion.isEqual(new MinecraftVersion(1, 16, 3)));
+        assertFalse(latestVersion.isEqual(new MinecraftVersion(1, 16, 2)));
+        assertFalse(latestVersion.isEqual(new MinecraftVersion(1, 16)));
+    }
+
+    @Test
+    public void testEqualOrLower() {
+        assertTrue(latestVersion.isEqualOrLower(new MinecraftVersion(1, 16, 3)));
+        assertTrue(latestVersion.isEqualOrLower(new MinecraftVersion(1, 16, 4)));
+        assertFalse(latestVersion.isEqualOrLower(new MinecraftVersion(1, 16, 2)));
+    }
+
+    @Test
+    public void testForChunkStretched() {
+        assertTrue(latestVersion.isEqualOrHigher(MinecraftVersion.NETHER));
+        assertFalse(latestVersion.isLower(new MinecraftVersion(1, 14, 2)));
+    }
+
+}

--- a/worldedit-bukkit/src/test/java/com/sk89q/util/MinecraftVersionTest.java
+++ b/worldedit-bukkit/src/test/java/com/sk89q/util/MinecraftVersionTest.java
@@ -1,9 +1,11 @@
 package com.sk89q.util;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import com.boydti.fawe.bukkit.util.MinecraftVersion;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class MinecraftVersionTest {
 


### PR DESCRIPTION
## Overview
Changes to chunksStretched + Unit-Tests now work again 🥳 

## Description
First of all, unit tests are now executing properly again. This was due to missing libraries, transient dependencies, whatsoever.

The chunksStretched-Property in FaweBukkit.java checked if the version returned by Bukkit.getVersion() + splitting stuff is 16 or higher. This may work, but breaks on Software where this version is overriden, e.g: https://github.com/gommehdnet/cheetah-1.16 - You will only get an ArrayIndexOutOfBounds and Fawe won't start.
Now the version information is retrieved from the package path (`org.bukkit.craftbukkit.v1_16_R3`) with the possibility to compare the object against other versions for future use.
The functionality is ensured by created unit tests.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
