### PR TITLE
Update to Gradle 7.0.2

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 
 repositories {
     gradlePluginPortal()
-//    jcenter()
     maven {
         name = "EngineHub"
         url = uri("https://maven.enginehub.org/repo/")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 }
 
 repositories {
-    jcenter()
     gradlePluginPortal()
+//    jcenter()
     maven {
         name = "EngineHub"
         url = uri("https://maven.enginehub.org/repo/")
@@ -23,5 +23,5 @@ val properties = Properties().also { props ->
 dependencies {
     implementation(gradleApi())
     implementation("org.ajoberstar.grgit:grgit-gradle:4.1.0")
-    implementation("com.github.jengelman.gradle.plugins:shadow:6.1.0")
+    implementation("gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0")
 }

--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -53,7 +53,6 @@ fun Project.applyCommonConfiguration() {
         the<JavaPluginExtension>().toolchain {
             languageVersion.set(JavaLanguageVersion.of(11))
             vendor.set(JvmVendorSpec.ADOPTOPENJDK)
-
         }
     }
 

--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -50,7 +50,7 @@ fun Project.applyCommonConfiguration() {
 
     plugins.withId("java") {
         the<JavaPluginExtension>().toolchain {
-            languageVersion.set(JavaLanguageVersion.of(8))
+            languageVersion.set(JavaLanguageVersion.of(11))
         }
     }
 

--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -1,6 +1,7 @@
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.repositories
@@ -51,6 +52,8 @@ fun Project.applyCommonConfiguration() {
     plugins.withId("java") {
         the<JavaPluginExtension>().toolchain {
             languageVersion.set(JavaLanguageVersion.of(11))
+            vendor.set(JvmVendorSpec.ADOPTOPENJDK)
+
         }
     }
 

--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -38,7 +38,6 @@ fun Project.applyLibrariesConfiguration() {
     val relocations = mapOf(
         "net.kyori.text" to "com.sk89q.worldedit.util.formatting.text",
         "net.kyori.minecraft" to "com.sk89q.worldedit.util.kyori",
-        "net.kyori.adventure.nbt" to "com.sk89q.worldedit.util.nbt"
     )
 
     tasks.register<ShadowJar>("jar") {
@@ -110,7 +109,7 @@ fun Project.applyLibrariesConfiguration() {
             attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
             attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11)
         }
         outgoing.artifact(tasks.named("jar"))
     }
@@ -125,7 +124,7 @@ fun Project.applyLibrariesConfiguration() {
             attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
             attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11)
         }
         outgoing.artifact(tasks.named("jar"))
     }

--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -1,16 +1,27 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
-import org.gradle.api.internal.HasConvention
-import org.gradle.api.plugins.MavenRepositoryHandlerConvention
-import org.gradle.api.tasks.Upload
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.DocsType
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.java.TargetJvmVersion
+import org.gradle.api.component.AdhocComponentWithVariants
+import org.gradle.api.component.SoftwareComponentFactory
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getPlugin
 import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
+import javax.inject.Inject
 
 fun Project.applyLibrariesConfiguration() {
     applyCommonConfiguration()
@@ -20,14 +31,14 @@ fun Project.applyLibrariesConfiguration() {
 
     configurations {
         create("shade")
-        getByName("archives").extendsFrom(getByName("default"))
     }
 
     group = "${rootProject.group}.worldedit-libs"
 
     val relocations = mapOf(
-            "net.kyori.text" to "com.sk89q.worldedit.util.formatting.text",
-            "net.kyori.minecraft" to "com.sk89q.worldedit.util.kyori"
+        "net.kyori.text" to "com.sk89q.worldedit.util.formatting.text",
+        "net.kyori.minecraft" to "com.sk89q.worldedit.util.kyori",
+        "net.kyori.adventure.nbt" to "com.sk89q.worldedit.util.nbt"
     )
 
     tasks.register<ShadowJar>("jar") {
@@ -47,22 +58,22 @@ fun Project.applyLibrariesConfiguration() {
     }
     val altConfigFiles = { artifactType: String ->
         val deps = configurations["shade"].incoming.dependencies
-                .filterIsInstance<ModuleDependency>()
-                .map { it.copy() }
-                .map { dependency ->
-                    dependency.artifact {
-                        name = dependency.name
-                        type = artifactType
-                        extension = "jar"
-                        classifier = artifactType
-                    }
-                    dependency
+            .filterIsInstance<ModuleDependency>()
+            .map { it.copy() }
+            .map { dependency ->
+                dependency.artifact {
+                    name = dependency.name
+                    type = artifactType
+                    extension = "jar"
+                    classifier = artifactType
                 }
+                dependency
+            }
 
         files(configurations.detachedConfiguration(*deps.toTypedArray())
-                .resolvedConfiguration.lenientConfiguration.artifacts
-                .filter { it.classifier == artifactType }
-                .map { zipTree(it.file) })
+            .resolvedConfiguration.lenientConfiguration.artifacts
+            .filter { it.classifier == artifactType }
+            .map { zipTree(it.file) })
     }
     tasks.register<Jar>("sourcesJar") {
         from({
@@ -85,25 +96,85 @@ fun Project.applyLibrariesConfiguration() {
         dependsOn("jar", "sourcesJar")
     }
 
-    artifacts {
-        val jar = tasks.named("jar")
-        add("default", jar) {
-            builtBy(jar)
+    project.apply<LibsConfigPluginHack>()
+
+    val libsComponent = project.components["libs"] as AdhocComponentWithVariants
+
+    val apiElements = project.configurations.register("apiElements") {
+        isVisible = false
+        description = "API elements for libs"
+        isCanBeResolved = false
+        isCanBeConsumed = true
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_API))
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
         }
-        val sourcesJar = tasks.named("sourcesJar")
-        add("archives", sourcesJar) {
-            builtBy(sourcesJar)
+        outgoing.artifact(tasks.named("jar"))
+    }
+
+    val runtimeElements = project.configurations.register("runtimeElements") {
+        isVisible = false
+        description = "Runtime elements for libs"
+        isCanBeResolved = false
+        isCanBeConsumed = true
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+        }
+        outgoing.artifact(tasks.named("jar"))
+    }
+
+    val sourcesElements = project.configurations.register("sourcesElements") {
+        isVisible = false
+        description = "Source elements for libs"
+        isCanBeResolved = false
+        isCanBeConsumed = true
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.DOCUMENTATION))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
+            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, project.objects.named(DocsType.SOURCES))
+        }
+        outgoing.artifact(tasks.named("sourcesJar"))
+    }
+
+    libsComponent.addVariantsFromConfiguration(apiElements.get()) {
+        mapToMavenScope("compile")
+    }
+
+    libsComponent.addVariantsFromConfiguration(runtimeElements.get()) {
+        mapToMavenScope("runtime")
+    }
+
+    libsComponent.addVariantsFromConfiguration(sourcesElements.get()) {
+        mapToMavenScope("runtime")
+    }
+
+    configure<PublishingExtension> {
+        publications {
+            register<MavenPublication>("maven") {
+                from(libsComponent)
+            }
         }
     }
 
-    tasks.register<Upload>("install") {
-        configuration = configurations["archives"]
-        (repositories as HasConvention).convention.getPlugin<MavenRepositoryHandlerConvention>().mavenInstaller {
-            pom.version = project.version.toString()
-            pom.artifactId = project.name
-        }
-    }
+}
 
+// A horrible hack because `softwareComponentFactory` has to be gotten via plugin
+// gradle why
+internal open class LibsConfigPluginHack @Inject constructor(
+    private val softwareComponentFactory: SoftwareComponentFactory
+) : Plugin<Project> {
+    override fun apply(project: Project) {
+        val libsComponents = softwareComponentFactory.adhoc("libs")
+        project.components.add(libsComponents)
+    }
 }
 
 fun Project.constrainDependenciesToLibsCore() {

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -30,7 +30,7 @@ fun Project.applyPlatformAndCoreConfiguration() {
     } else {
         ext["internalVersion"] = "$version"
     }
-    
+
     tasks
         .withType<JavaCompile>()
         .matching { it.name == "compileJava" || it.name == "compileTestJava" }
@@ -60,7 +60,7 @@ fun Project.applyPlatformAndCoreConfiguration() {
         "testImplementation"("org.mockito:mockito-core:${Versions.MOCKITO}")
         "testImplementation"("org.mockito:mockito-junit-jupiter:${Versions.MOCKITO}")
         "testImplementation"("net.bytebuddy:byte-buddy:1.11.0")
-        "testRuntime"("org.junit.jupiter:junit-jupiter-engine:${Versions.JUNIT}")
+        "testRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:${Versions.JUNIT}")
     }
 
     // Java 8 turns on doclint which we fail

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
     compileOnly("com.github.MilkBowl:VaultAPI:1.7") { isTransitive = false }
     api(project(":worldedit-core"))
     api(project(":worldedit-libs:bukkit"))
-    compile(":worldedit-adapters:")
+    implementation(":worldedit-adapters:")
     // Paper-patched NMS jars
     compileOnly("com.destroystokyo.paperv1_15_r1:paperv1_15_r1:1_15_r1")
     compileOnly("com.destroystokyo.paperv1_16_r1:paperv1_16_r1:1_16_r1")

--- a/worldedit-core/doctools/build.gradle.kts
+++ b/worldedit-core/doctools/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 applyCommonConfiguration()
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.11"
+    kotlinOptions.jvmTarget = "11"
 }
 
 application.mainClass.set("com.sk89q.worldedit.internal.util.DocumentationPrinter")

--- a/worldedit-core/doctools/build.gradle.kts
+++ b/worldedit-core/doctools/build.gradle.kts
@@ -1,14 +1,14 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.4.21"
+    kotlin("jvm") version "1.5.0-RC"
     application
 }
 
 applyCommonConfiguration()
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "1.11"
 }
 
 application.mainClass.set("com.sk89q.worldedit.internal.util.DocumentationPrinter")


### PR DESCRIPTION
## Overview
Upgrade Gradle from 6.9 to 7.0.2

## Description
Updated the plugins and scripts we use to be compatible with Gradle 7.0.x. I only checked to make sure the plugin would compile I did not check if it loads properly. This should also bump the Java requirement to Java 11. 

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
