### PR TITLE
Added support for GriefDefender

### DIFF
--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -107,6 +107,8 @@ dependencies {
     implementation("org.bstats:bstats-base:2.2.1")
     compileOnlyApi("org.inventivetalent:mapmanager:1.7.10-SNAPSHOT") { isTransitive = false }
     implementation("com.github.TechFortress:GriefPrevention:16.17.1") { isTransitive = false }
+    implementation("com.github.bloodmc:GriefDefenderApi:920a610") { isTransitive = false }
+    implementation("com.flowpowered:flow-math:1.0.3") { isTransitive = false }
     implementation("com.massivecraft:mcore:7.0.1") { isTransitive = false }
     implementation("com.bekvon.bukkit.residence:Residence:4.5._13.1") { isTransitive = false }
     implementation("com.palmergames.bukkit:towny:0.84.0.9") { isTransitive = false }

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
@@ -214,7 +214,7 @@ public class FaweBukkit implements IFawe, Listener {
         if (griefpreventionPlugin != null && griefpreventionPlugin.isEnabled()) {
             try {
                 managers.add(new GriefPreventionFeature(griefpreventionPlugin));
-                LOGGER.debug("Attempting to use plugin 'GriefPrevention'");
+                LOGGER.info("Attempting to use plugin 'GriefPrevention'");
             } catch (Throwable ignored) {
             }
         }
@@ -223,7 +223,7 @@ public class FaweBukkit implements IFawe, Listener {
         if (griefdefenderPlugin != null && griefdefenderPlugin.isEnabled()) {
             try {
                 managers.add(new GriefDefenderFeature(griefdefenderPlugin));
-                LOGGER.debug("Attempting to use plugin 'GriefDefender'");
+                LOGGER.info("Attempting to use plugin 'GriefDefender'");
             } catch (Throwable ignored) {
             }
         }

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
@@ -12,6 +12,7 @@ import com.boydti.fawe.bukkit.listener.BrushListener;
 import com.boydti.fawe.bukkit.listener.ChunkListener9;
 import com.boydti.fawe.bukkit.listener.RenderListener;
 import com.boydti.fawe.bukkit.regions.GriefPreventionFeature;
+import com.boydti.fawe.bukkit.regions.GriefDefenderFeature;
 import com.boydti.fawe.bukkit.regions.ResidenceFeature;
 import com.boydti.fawe.bukkit.regions.TownyFeature;
 import com.boydti.fawe.bukkit.regions.Worldguard;
@@ -214,6 +215,15 @@ public class FaweBukkit implements IFawe, Listener {
             try {
                 managers.add(new GriefPreventionFeature(griefpreventionPlugin));
                 LOGGER.debug("Attempting to use plugin 'GriefPrevention'");
+            } catch (Throwable ignored) {
+            }
+        }
+        final Plugin griefdefenderPlugin =
+                Bukkit.getServer().getPluginManager().getPlugin("GriefDefender");
+        if (griefdefenderPlugin != null && griefdefenderPlugin.isEnabled()) {
+            try {
+                managers.add(new GriefDefenderFeature(griefdefenderPlugin));
+                LOGGER.debug("Attempting to use plugin 'GriefDefender'");
             } catch (Throwable ignored) {
             }
         }

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/filter/GriefDefenderFilter.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/filter/GriefDefenderFilter.java
@@ -1,0 +1,40 @@
+package com.boydti.fawe.bukkit.filter;
+
+import com.boydti.fawe.regions.general.CuboidRegionFilter;
+import com.boydti.fawe.util.TaskManager;
+import com.sk89q.worldedit.math.BlockVector2;
+import com.griefdefender.api.claim.Claim;
+import com.griefdefender.api.GriefDefender;
+import com.flowpowered.math.vector.Vector3i;
+import org.bukkit.World;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class GriefDefenderFilter extends CuboidRegionFilter {
+    private final Collection<Claim> claims;
+    private final World world;
+
+    public GriefDefenderFilter(World world) {
+        checkNotNull(world);
+        this.claims = TaskManager.IMP.sync(
+                (Supplier<Collection<Claim>>) () -> new ArrayDeque<>(GriefDefender.getCore().getAllClaims()));
+        this.world = world;
+    }
+
+    @Override
+    public void calculateRegions() {
+        for (Claim claim : claims) {
+            Vector3i bot = claim.getGreaterBoundaryCorner();
+            if (world.getUID().equals(claim.getWorldUniqueId())) {
+                Vector3i top = claim.getGreaterBoundaryCorner();
+                BlockVector2 pos1 = BlockVector2.at(bot.getX(), bot.getZ());
+                BlockVector2 pos2 = BlockVector2.at(top.getX(), top.getZ());
+                add(pos1, pos2);
+            }
+        }
+    }
+}

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/regions/GriefDefenderFeature.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/regions/GriefDefenderFeature.java
@@ -24,7 +24,7 @@ public class GriefDefenderFeature extends BukkitMaskManager implements Listener 
 
     public GriefDefenderFeature(final Plugin GriefDefenderPlugin) {
         super(GriefDefenderPlugin.getName());
-        LOGGER.debug("Plugin 'GriefDefender' found. Using it now.");
+        LOGGER.info("Plugin 'GriefDefender' found. Using it now.");
     }
 
     public boolean isAllowed(Player player, Claim claim, MaskType type) {

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/regions/GriefDefenderFeature.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/regions/GriefDefenderFeature.java
@@ -1,0 +1,62 @@
+package com.boydti.fawe.bukkit.regions;
+
+import com.boydti.fawe.bukkit.filter.GriefDefenderFilter;
+import com.boydti.fawe.regions.FaweMask;
+import com.boydti.fawe.regions.general.RegionFilter;
+import com.flowpowered.math.vector.Vector3i;
+import com.griefdefender.api.GriefDefender;
+import com.griefdefender.api.claim.Claim;
+import com.griefdefender.api.claim.TrustTypes;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+
+public class GriefDefenderFeature extends BukkitMaskManager implements Listener {
+
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
+
+    public GriefDefenderFeature(final Plugin GriefDefenderPlugin) {
+        super(GriefDefenderPlugin.getName());
+        LOGGER.debug("Plugin 'GriefDefender' found. Using it now.");
+    }
+
+    public boolean isAllowed(Player player, Claim claim, MaskType type) {
+        return GriefDefender.getCore().isEnabled(player.getWorld().getUID()) && !claim.isWilderness() && (claim.getOwnerName().equalsIgnoreCase(player.getName()) || claim.getOwnerName().equals(player.getUniqueId()) ||
+                type == MaskType.MEMBER && claim.getUserTrusts(TrustTypes.BUILDER).contains(player.getUniqueId()));
+    }
+
+    @Override
+    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, MaskType type) {
+        final Player player = BukkitAdapter.adapt(wePlayer);
+        final Location loc = player.getLocation();
+        final Vector3i vector = Vector3i.from(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+        final Claim claim = GriefDefender.getCore().getClaimManager(loc.getWorld().getUID()).getClaimAt(vector);
+        if (!claim.isWilderness()) {
+            if (isAllowed(player, claim, type)) {
+                claim.getGreaterBoundaryCorner().getX();
+                final BlockVector3 pos1 = BlockVector3.at(claim.getLesserBoundaryCorner().getX(), 0, claim.getLesserBoundaryCorner().getZ());
+                final BlockVector3 pos2 = BlockVector3.at(claim.getGreaterBoundaryCorner().getX(), 256, claim.getGreaterBoundaryCorner().getZ());
+                return new FaweMask(new CuboidRegion(pos1, pos2)) {
+
+                    @Override
+                    public boolean isValid(com.sk89q.worldedit.entity.Player wePlayer, MaskType type) {
+                        return isAllowed(player, claim, type);
+                    }
+                };
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public RegionFilter getFilter(String world) {
+        return new GriefDefenderFilter(Bukkit.getWorld(world));
+    }
+}

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/regions/GriefDefenderFeature.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/regions/GriefDefenderFeature.java
@@ -28,7 +28,7 @@ public class GriefDefenderFeature extends BukkitMaskManager implements Listener 
     }
 
     public boolean isAllowed(Player player, Claim claim, MaskType type) {
-        return GriefDefender.getCore().isEnabled(player.getWorld().getUID()) && !claim.isWilderness() && (claim.getOwnerName().equalsIgnoreCase(player.getName()) || claim.getOwnerName().equals(player.getUniqueId()) ||
+        return GriefDefender.getCore().isEnabled(player.getWorld().getUID()) && !claim.isWilderness() && (claim.getOwnerName().equalsIgnoreCase(player.getName()) || claim.getOwnerUniqueId().equals(player.getUniqueId()) ||
                 type == MaskType.MEMBER && claim.getUserTrusts(TrustTypes.BUILDER).contains(player.getUniqueId()));
     }
 
@@ -41,8 +41,8 @@ public class GriefDefenderFeature extends BukkitMaskManager implements Listener 
         if (!claim.isWilderness()) {
             if (isAllowed(player, claim, type)) {
                 claim.getGreaterBoundaryCorner().getX();
-                final BlockVector3 pos1 = BlockVector3.at(claim.getLesserBoundaryCorner().getX(), 0, claim.getLesserBoundaryCorner().getZ());
-                final BlockVector3 pos2 = BlockVector3.at(claim.getGreaterBoundaryCorner().getX(), 256, claim.getGreaterBoundaryCorner().getZ());
+                final BlockVector3 pos1 = BlockVector3.at(claim.getLesserBoundaryCorner().getX(), claim.getLesserBoundaryCorner().getY(), claim.getLesserBoundaryCorner().getZ());
+                final BlockVector3 pos2 = BlockVector3.at(claim.getGreaterBoundaryCorner().getX(), claim.getGreaterBoundaryCorner().getY(), claim.getGreaterBoundaryCorner().getZ());
                 return new FaweMask(new CuboidRegion(pos1, pos2)) {
 
                     @Override


### PR DESCRIPTION
## Overview

**Fixed #1064**

## Description
<!-- Please describe what you have changed -->
Added support for [GriefDefender](https://github.com/bloodmc/GriefDefender) using [GriefDefenderAPI](https://github.com/bloodmc/GriefDefenderAPI)
~~In order to untie the bell, the person who tied it is required. XD~~
Permission Node: fawe.griefdefender

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/1.16/CONTRIBUTING.md)
