### PR TITLE
Fix reading of tile entities with "id" instead of "Id" tag

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SpongeSchematicReader.java
@@ -253,7 +253,13 @@ public class SpongeSchematicReader extends NBTSchematicReader {
                 values.put("x", new IntTag(pt.getBlockX()));
                 values.put("y", new IntTag(pt.getBlockY()));
                 values.put("z", new IntTag(pt.getBlockZ()));
-                values.put("id", values.get("Id"));
+                //FAWE start
+                if (!values.containsKey("id")) {
+                    values.put("id", requireTag(values, "Id", StringTag.class));
+                } else {
+                    requireTag(values, "id", StringTag.class);
+                }
+                //FAWE end
                 values.remove("Id");
                 values.remove("Pos");
                 if (fixer != null) {


### PR DESCRIPTION
## Overview
If a schematic contains a tile entity with an "id" instead of an "Id" the previous code would delete the id. The changed code checks which one of the tags is set.

This schematic for example caused this exception:
https://i.imgur.com/qjrT6ut.png
http://paste.cytooxien.de/jowobiyile.bash

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/main/CONTRIBUTING.md)
