### PR TITLE
feat: Improve wording of allowed-plugins message

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -461,9 +461,9 @@ public class Settings extends Config {
 
         @Comment({
                 "Don't bug console when these plugins slow down WorldEdit operations",
-                " - You'll see a message in console if you need to change this option"
+                " - You'll see a message in console or ingame if you need to change this option"
         })
-        public List<String> ALLOWED_PLUGINS = new ArrayList<>(Collections.singleton(("ExamplePlugin")));
+        public List<String> ALLOWED_PLUGINS = new ArrayList<>(Collections.singleton(("com.example.ExamplePlugin")));
         @Comment("Should debug messages be sent when third party extents are used?")
         public boolean DEBUG = true;
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/EditSessionBuilder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/EditSessionBuilder.java
@@ -256,23 +256,20 @@ public class EditSessionBuilder {
                     event.getActor().printDebug(TextComponent.of("Potentially unsafe extent blocked: " + toReturn
                             .getClass()
                             .getName()));
-                    event.getActor().printDebug(TextComponent.of(
-                            " - For area restrictions and block logging, it is recommended to use the FaweAPI"));
-                    event.getActor().printDebug(TextComponent.of(" - To allow " + toReturn
-                            .getClass()
-                            .getName() + ", add it to the FAWE `allowed-plugins` list in config.yml"));
-                    event.getActor().printDebug(TextComponent.of(
-                            " - If you are unsure which plugin tries to use the extent, you can find some additional information below:"));
-                    event.getActor().printDebug(TextComponent.of(" - " + toReturn.getClass().getClassLoader()));
+                    event.getActor().print(TextComponent.of(
+                            "- For area restrictions and block logging, it is recommended that third party plugins use the FAWE" +
+                                    " API"));
+                    event.getActor().print(TextComponent.of("- Add the following line to the `allowed-plugins` list in the " +
+                            "FAWE config.yml to let FAWE recognize the extent:"));
+                    event.getActor().print(toReturn.getClass().getName());
                 } else {
-                    LOGGER.debug("Potentially unsafe extent blocked: " + toReturn.getClass().getName());
-                    LOGGER.debug(" - For area restrictions and block logging, it is recommended to use the FaweAPI");
-                    LOGGER.debug(" - To allow " + toReturn
-                            .getClass()
-                            .getName() + ", add it to the FAWE `allowed-plugins` list in config.yml");
-                    LOGGER.debug(
-                            " - If you are unsure which plugin tries to use the extent, you can find some additional information below:");
-                    LOGGER.debug(" - " + toReturn.getClass().getClassLoader());
+                    LOGGER.warn("Potentially unsafe extent blocked: " + toReturn.getClass().getName());
+                    LOGGER.warn(
+                            " - For area restrictions and block logging, it is recommended that third party plugins use the FAWE API");
+                    LOGGER.warn(
+                            " - Add the following classpath to the `allowed-plugins` list in the FAWE config.yml to let FAWE " +
+                                    "recognize the extent:");
+                    LOGGER.warn(toReturn.getClass().getName());
                 }
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
@@ -167,7 +167,6 @@ public final class EditSessionBuilder {
     }
 
     /**
-     *
      * Get the {@link BlockBag} associated with the edit if present or null
      */
     @Nullable
@@ -664,23 +663,20 @@ public final class EditSessionBuilder {
                     event.getActor().printDebug(TextComponent.of("Potentially unsafe extent blocked: " + toReturn
                             .getClass()
                             .getName()));
-                    event.getActor().printDebug(TextComponent.of(
-                            " - For area restrictions and block logging, it is recommended to use the FaweAPI"));
-                    event.getActor().printDebug(TextComponent.of(" - To allow " + toReturn
-                            .getClass()
-                            .getName() + ", add it to the FAWE `allowed-plugins` list in config.yml"));
-                    event.getActor().printDebug(TextComponent.of(
-                            " - If you are unsure which plugin tries to use the extent, you can find some additional information below:"));
-                    event.getActor().printDebug(TextComponent.of(" - " + toReturn.getClass().getClassLoader()));
+                    event.getActor().print(TextComponent.of(
+                            "- For area restrictions and block logging, it is recommended that third party plugins use the FAWE" +
+                                    " API"));
+                    event.getActor().print(TextComponent.of("- Add the following line to the `allowed-plugins` list in the " +
+                            "FAWE config.yml to let FAWE recognize the extent:"));
+                    event.getActor().print(toReturn.getClass().getName());
                 } else {
-                    LOGGER.debug("Potentially unsafe extent blocked: " + toReturn.getClass().getName());
-                    LOGGER.debug(" - For area restrictions and block logging, it is recommended to use the FaweAPI");
-                    LOGGER.debug(" - To allow " + toReturn
-                            .getClass()
-                            .getName() + ", add it to the FAWE `allowed-plugins` list in config.yml");
-                    LOGGER.debug(
-                            " - If you are unsure which plugin tries to use the extent, you can find some additional information below:");
-                    LOGGER.debug(" - " + toReturn.getClass().getClassLoader());
+                    LOGGER.warn("Potentially unsafe extent blocked: " + toReturn.getClass().getName());
+                    LOGGER.warn(
+                            " - For area restrictions and block logging, it is recommended that third party plugins use the FAWE API");
+                    LOGGER.warn(
+                            " - Add the following classpath to the `allowed-plugins` list in the FAWE config.yml to let FAWE " +
+                                    "recognize the extent:");
+                    LOGGER.warn(toReturn.getClass().getName());
                 }
             }
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/IntellectualSites/FastAsyncWorldEdit/issues
-->

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
Fixes #1319 

## Description
Rewrite `allowed-plugins` message to be more descriptive about the way, how Fawe checks classpaths for the extent. Also switch log level to warn (could also be info), debug is not fired with the log4j configuration shipped.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/main/CONTRIBUTING.md)
