### PR TITLE
fix: Update StubServer.java to the latest spigot changes

### DIFF
--- a/worldedit-bukkit/src/test/java/com/fastasyncworldedit/util/StubServer.java
+++ b/worldedit-bukkit/src/test/java/com/fastasyncworldedit/util/StubServer.java
@@ -50,6 +50,7 @@ import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scoreboard.ScoreboardManager;
+import org.bukkit.structure.StructureManager;
 import org.bukkit.util.CachedServerIcon;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -223,6 +224,11 @@ public class StubServer implements Server {
 
     @Override
     public int getTicksPerWaterAmbientSpawns() {
+        return 0;
+    }
+
+    @Override
+    public int getTicksPerWaterUndergroundCreatureSpawns() {
         return 0;
     }
 
@@ -694,6 +700,11 @@ public class StubServer implements Server {
     }
 
     @Override
+    public int getWaterUndergroundCreatureSpawnLimit() {
+        return 0;
+    }
+
+    @Override
     public int getAmbientSpawnLimit() {
         return 0;
     }
@@ -915,6 +926,11 @@ public class StubServer implements Server {
     public @NotNull
     List<Entity> selectEntities(@NotNull CommandSender commandSender, @NotNull String s) throws
             IllegalArgumentException {
+        return null;
+    }
+
+    @Override
+    public @NotNull StructureManager getStructureManager() {
         return null;
     }
 


### PR DESCRIPTION
## Overview

- / -
## Description
Updated StubServer.java to the latest (Craft-)Bukkit changes, so the tests run again. Cause is missing overriden methods from Bukkits Server.java

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/main/CONTRIBUTING.md)
