### PR TITLE
Fix incompatibility between WorldEdit and FAWE for LocalSession#getTool

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -1120,6 +1120,24 @@ public class LocalSession implements TextureHolder {
         //FAWE end
     }
 
+    /**
+     * Get the tool assigned to the item.
+     *
+     * @param item the item type
+     * @return the tool, which may be {@code null}
+     */
+    @Nullable
+    @Deprecated
+    //FAWE start
+    //This method is here for byte code compatibility with WorldEdit.
+    //WorldEdit does not have any other getTool method with matching overloads.
+    public Tool getTool(ItemType item) {
+        synchronized (this.tools) {
+            return tools.get(item.getInternalId());
+        }
+        //FAWE end
+    }
+
     //FAWE start
     @Nullable
     public Tool getTool(Player player) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -1125,13 +1125,13 @@ public class LocalSession implements TextureHolder {
      *
      * @param item the item type
      * @return the tool, which may be {@code null}
+     * @deprecated This method is deprecated and only for compatibility with WorldEdit. Use {@link #getTool(BaseItem, Player)}
+     * instead.
      */
     @Nullable
     @Deprecated
-    //FAWE start
-    //This method is here for byte code compatibility with WorldEdit.
-    //WorldEdit does not have any other getTool method with matching overloads.
     public Tool getTool(ItemType item) {
+        //FAWE start
         synchronized (this.tools) {
             return tools.get(item.getInternalId());
         }


### PR DESCRIPTION

## Overview
WorldEdit has only LocalSession#getTool(ItemType) and does not have any overload which matches any of the FAWE method signatures.
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->

Fixes #1398

## Description
The original WorldEdit method signature is readded again to avoid hacky workarounds when supporting FAWE and WorldEdit
<!-- Please describe what this pull request does. -->

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)