### PR TITLE
Properly delete ChangeSets on history clear

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -398,9 +398,20 @@ public class LocalSession implements TextureHolder {
      * Clear history.
      */
     public void clearHistory() {
-        history.clear();
         //FAWE start
+        historyWriteLock.lock();
+        try {
+            // Ensure that changesets are properly removed
+            for (Object item : history) {
+                getChangeSet(item).delete();
+            }
+            history.clear();
+        } finally {
+            historyWriteLock.unlock();
+        }
+
         historyNegativeIndex = 0;
+        save();
         historySize = 0;
         currentWorld = null;
         //FAWE end


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->

Fixes #1347

## Description
<!-- Please describe what this pull request does. -->

The issue was that changesets can contain extra data, for example, files.
Before the history was simply cleared so these objects may not have been properly deleted.
When the player then tried to run /undo or /redo it would run the ``loadSessionHistoryFromDisk`` method, which would cause the files to be read and their history to be repopulated. 

What I do now is ensure that each changeset is properly deleted when clearing history. I also make sure to run the save method which saves the history negative index, so that it should be reset. (I am not sure if this is 100% necessary) 

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)