### PR TITLE
fix(regen): Use WE PaperweightAdapter for seed replacement

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ redprotect = "1.9.6"
 
 # Third party
 flow-math = "1.0.3"
-paperlib = "1.0.6"
+paperlib = "1.0.7"
 bstats = "2.2.1"
 serverlib = "2.3.1"
 paster = "1.1.1"

--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/PaperweightAdapter.java
@@ -658,8 +658,9 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
         }
     }
 
-    // FAWE private -> public static
+    // FAWE start - private -> public static
     public static WorldGenSettings replaceSeed(ServerLevel originalWorld, long seed, WorldGenSettings originalOpts) {
+    // FAWE end
         RegistryWriteOps<net.minecraft.nbt.Tag> nbtReadRegOps = RegistryWriteOps.create(
                 NbtOps.INSTANCE,
                 originalWorld.getServer().registryAccess()
@@ -686,9 +687,10 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
                 );
     }
 
-    // FAWE private -> private static
+    // FAWE start - private -> private static
     @SuppressWarnings("unchecked")
     private static Dynamic<net.minecraft.nbt.Tag> recursivelySetSeed(
+    // FAWE end
             Dynamic<net.minecraft.nbt.Tag> dynamic,
             long seed,
             Set<Dynamic<net.minecraft.nbt.Tag>> seen

--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/PaperweightAdapter.java
@@ -658,7 +658,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
         }
     }
 
-    private WorldGenSettings replaceSeed(ServerLevel originalWorld, long seed, WorldGenSettings originalOpts) {
+    // FAWE private -> public static
+    public static WorldGenSettings replaceSeed(ServerLevel originalWorld, long seed, WorldGenSettings originalOpts) {
         RegistryWriteOps<net.minecraft.nbt.Tag> nbtReadRegOps = RegistryWriteOps.create(
                 NbtOps.INSTANCE,
                 originalWorld.getServer().registryAccess()
@@ -685,8 +686,9 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
                 );
     }
 
+    // FAWE private -> private static
     @SuppressWarnings("unchecked")
-    private Dynamic<net.minecraft.nbt.Tag> recursivelySetSeed(
+    private static Dynamic<net.minecraft.nbt.Tag> recursivelySetSeed(
             Dynamic<net.minecraft.nbt.Tag> dynamic,
             long seed,
             Set<Dynamic<net.minecraft.nbt.Tag>> seen


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->
This uses exactly the same code as WE for seed replacement.

Fixes #1410 

## Description
<!-- Please describe what this pull request does. -->

Previously, FAWE always encoded and decoded the full WorldGenSettings. This is only necessary if a custom seed is given as command argument. And even then, it does not fail on invalid structure feature salts injected by bad server software as the RegistryWriteOps don't encode the structure features this way.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)