### PR TITLE
fix: delay closing of clipboards on quit

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -437,12 +437,14 @@ public interface Player extends Entity, Actor {
                     } else {
                         continue;
                     }
-                    doc.close(); // Ensure closed before deletion
-                    doc.getFile().delete();
+                    WorldEdit.getInstance().getExecutorService().submit(() -> {
+                        doc.close(); // Ensure closed before deletion
+                        doc.getFile().delete();
+                    });
                 }
             }
         } else if (Settings.IMP.CLIPBOARD.DELETE_ON_LOGOUT || Settings.IMP.CLIPBOARD.USE_DISK) {
-            session.setClipboard(null);
+            WorldEdit.getInstance().getExecutorService().submit(() -> session.setClipboard(null));
         }
         if (Settings.IMP.HISTORY.DELETE_ON_LOGOUT) {
             session.clearHistory();


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, please create one so we can look into it before approving your PR.
-->

Fixes #1492 

## Description
<!-- Please describe what this pull request does. -->
Clipboard saving is done via the executor provided by WorldEdit. By using this executor to close clipboards, we avoid running into the situation where the thread saving the schematic reads from the clipboard after it was closed by the thread firing the PlayerQuitEvent.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
