### PR TITLE
Add worldedit.schematic.list.other permission and functionality

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/StringMan.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/StringMan.java
@@ -9,10 +9,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class StringMan {
+
+    private static final Pattern UUID_PATTERN = Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
 
     public static boolean containsAny(CharSequence sequence, String any) {
         return IntStream.range(0, sequence.length())
@@ -540,6 +543,10 @@ public class StringMan {
 
     public static String repeat(String s, int n) {
         return IntStream.range(0, n).mapToObj(i -> s).collect(Collectors.joining());
+    }
+
+    public static boolean containsUuid(String str) {
+        return UUID_PATTERN.matcher(str).find();
     }
 
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/StringMan.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/StringMan.java
@@ -550,7 +550,8 @@ public class StringMan {
      * provided String.
      *
      * @param str provided string
-     * @return true if a uuid was found, false if not
+     * @return true if an uuid was found, false if not
+     * @since 2.0.0
      */
     public static boolean containsUuid(String str) {
         return UUID_PATTERN.matcher(str).find();

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/StringMan.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/StringMan.java
@@ -545,6 +545,13 @@ public class StringMan {
         return IntStream.range(0, n).mapToObj(i -> s).collect(Collectors.joining());
     }
 
+    /**
+     * Returns if there is a valid uuid contained inside the
+     * provided String.
+     *
+     * @param str provided string
+     * @return true if a uuid was found, false if not
+     */
     public static boolean containsUuid(String str) {
         return UUID_PATTERN.matcher(str).find();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -1033,7 +1033,30 @@ public class UtilityCommands {
         if (playerFolder) {
             if (listMine) {
                 File playerDir = MainUtil.resolveRelative(new File(dir, actor.getUniqueId() + dirFilter));
+                //FAWE start - Schematic list other permission
+                if (!actor.hasPermission("worldedit.schematic.list.other") && java.util.regex.Pattern
+                        .compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}") // See SchematicCommands: 361
+                        .matcher(dirFilter)
+                        .find()) {
+                    return;
+                }
                 if (playerDir.exists()) {
+                    if (!actor.hasPermission("worldedit.schematic.list.other")) {
+                        forEachFile = new DelegateConsumer<File>(forEachFile) {
+                            @Override
+                            public void accept(File f) {
+                                try {
+                                    if (f.isDirectory() && !UUID.fromString(f.getName()).equals(actor.getUniqueId())) { // Ignore
+                                        // directories of other players
+                                        return;
+                                    }
+                                } catch (IllegalArgumentException ignored) {
+                                }
+                                super.accept(f);
+                            }
+                        };
+                    }
+                    //FAWE end
                     allFiles(playerDir.listFiles(), false, forEachFile);
                 }
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -25,6 +25,7 @@ import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.function.QuadFunction;
 import com.fastasyncworldedit.core.util.MainUtil;
 import com.fastasyncworldedit.core.util.MaskTraverser;
+import com.fastasyncworldedit.core.util.StringMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.image.ImageUtil;
 import com.fastasyncworldedit.core.util.task.DelegateConsumer;
@@ -1034,15 +1035,12 @@ public class UtilityCommands {
             if (listMine) {
                 File playerDir = MainUtil.resolveRelative(new File(dir, actor.getUniqueId() + dirFilter));
                 //FAWE start - Schematic list other permission
-                if (!actor.hasPermission("worldedit.schematic.list.other") && java.util.regex.Pattern
-                        .compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}") // See SchematicCommands: 361
-                        .matcher(dirFilter)
-                        .find()) {
+                if (!actor.hasPermission("worldedit.schematic.list.other") && StringMan.containsUuid(dirFilter)) {
                     return;
                 }
                 if (playerDir.exists()) {
                     if (!actor.hasPermission("worldedit.schematic.list.other")) {
-                        forEachFile = new DelegateConsumer<File>(forEachFile) {
+                        forEachFile = new DelegateConsumer<>(forEachFile) {
                             @Override
                             public void accept(File f) {
                                 try {


### PR DESCRIPTION
## Overview
This adds a new permission which prevents other player's schematics from being displayed in the /schematic list command by using similar logic to /schematic load.

Resolves #1457 

## Description
This first will cause it so players that do not have the ``worldedit.schematic.list.other`` permission will not be able to see any directories that are just UUIDs. These are usually the top-level directory outside of the player's own schematic, so if you typed ``schem list ../`` you could see all of the other player's uuids. This filters them from the list.

Then, I check if there are UUIDs in the filter provided by the player, see SchematicCommands 361 for the logic that I implemented in this case (a regex check). 

Now, I wasn't sure whether to display an error message or to simply "not show them". So, feedback appreciated.

Video Demonstration:

https://user-images.githubusercontent.com/23108066/147713405-4a7b40f9-1711-4c63-9110-ab070abe1633.mp4




## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
