### PR TITLE
fix: Unify superpickaxe behavior

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
@@ -180,8 +180,8 @@ public class ToolUtilCommands {
     }
 
     @Command(
-            name = "/superpickaxe",
-            aliases = {",", "/sp", "/pickaxe", "/"},
+            name = "/",
+            aliases = {","},
             desc = "Toggle the super pickaxe function"
     )
     @CommandPermissions("worldedit.superpickaxe")

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -474,7 +474,9 @@ public final class PlatformCommandManager {
             );
             registerSubCommands(
                     "superpickaxe",
-                    ImmutableList.of("pickaxe", "sp"),
+                    //FAWE start - register /<command> commands
+                    ImmutableList.of("pickaxe", "/pickaxe", "sp", "/sp"),
+                    //FAWE end
                     "Super-pickaxe commands",
                     SuperPickaxeCommandsRegistration.builder(),
                     new SuperPickaxeCommands(worldEdit)


### PR DESCRIPTION
## Overview
Fixes https://github.com/IntellectualSites/FastAsyncWorldEdit/issues/1547

## Description
We're adapting the proper functionality here while outsourcing our custom aliases to the registration classes.
Looking over the documentation, `//` is the way to toggle the superpickaxe, not any other command or sub command, hence the change proposed aligns our handling with upstream again, while retaining our aliases.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [X] Changelog entries in the PR title are correct
- [X] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
