### PR TITLE
Deduplicate error messages

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ChunkCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ChunkCommands.java
@@ -114,8 +114,6 @@ public class ChunkCommands {
                         TextComponent.of(actor.getName())
                 )
         );
-        actor.print(new ChunkListPaginationBox(region).create(page));
-        actor.print(Caption.of("worldedit.listchunks.listfor", TextComponent.of(actor.getName())));
     }
 
     @Command(

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -769,13 +769,6 @@ public final class PlatformCommandManager {
         } catch (FaweException e) {
             actor.print(Caption.of("fawe.cancel.reason", e.getComponent()));
         } catch (UsageException e) {
-            ImmutableList<Command> cmd = e.getCommands();
-            if (!cmd.isEmpty()) {
-                actor.print(Caption.of(
-                        "fawe.error.command.syntax",
-                        HelpGenerator.create(e.getCommandParseResult()).getFullHelp()
-                ));
-            }
             actor.printError(e.getRichMessage());
         } catch (CommandExecutionException e) {
             handleUnknownException(actor, e.getCause());


### PR DESCRIPTION
## Overview

Fixes https://github.com/IntellectualSites/FastAsyncWorldEdit/issues/1535

## Description
At the moment we throw two exceptions for improper command handling, the first time the one in the WorldEdit-like format and right afterwards our red-like format. I removed the WorldEdit-like part to match with our other messages.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] I tested my changes and approved their functionality.
- [X] I ensured my changes do not break other parts of the code
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [X] Changelog entries in the PR title are correct
- [X] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.