### PR TITLE
fix: Don't synchronize DelegateSemaphore

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/DelegateSemaphore.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/DelegateSemaphore.java
@@ -13,7 +13,7 @@ public class DelegateSemaphore extends Semaphore {
 
     // this is bad
     @Override
-    public synchronized boolean tryAcquire() {
+    public boolean tryAcquire() {
         try {
             this.delegate.acquire();
             return true;
@@ -23,12 +23,12 @@ public class DelegateSemaphore extends Semaphore {
     }
 
     @Override
-    public synchronized void acquire() throws InterruptedException {
+    public void acquire() throws InterruptedException {
         this.delegate.acquire();
     }
 
     @Override
-    public synchronized void release() {
+    public void release() {
         this.delegate.release();
     }
 


### PR DESCRIPTION
## Overview

Fixes #1565

## Description
I could reproduce the issue using the following code snippet: https://h.pschwang.eu/iyeduwexin.cs
The semaphore couldn't be released as the synchronization blocks after the 2nd acquire from another thread.

The method doesn't need to be marked as synchronized itself - removing that seems to have fixed the issue - at least with my provided code snippet as test

Adapter stuff works fine nevertheless (e.g. regen)

## Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
