### PR TITLE
Fix: Set size of MappedByteBuffer accordingly if no file system entry is present

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java
@@ -172,7 +172,7 @@ public class DiskOptimizedClipboard extends LinearClipboard implements Closeable
         if (this.fileChannel == null) {
             this.fileChannel = braf.getChannel();
             this.fileChannel.lock();
-            this.byteBuffer = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, file.length());
+            this.byteBuffer = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, braf.length());
         }
     }
 


### PR DESCRIPTION
## Overview
## Description
The length and therefore limit of the MappedByteBuffer was set using the file size of the entry in the file system. That way, creating new clipboard fails as the file size is 0, and therefor the MappedByteBuffer can't be filled with data as the MappedByteBuffers' limit is 0 as well. 
To get the correct size for the MappedByteBuffer, now the RandomAccessFile#getLength() is used, as the value is set based on the dimensions of the clipboard / region:
https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/main/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java#L119
https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/main/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java#L137

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
