### PR TITLE
Fix `//regen -b` on 1.18.2

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks.java
@@ -197,7 +197,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     public BiomeType getBiomeType(int x, int y, int z) {
         LevelChunkSection section = getSections(false)[(y >> 4) - getMinSectionPosition()];
         Holder<Biome> biomes = section.getNoiseBiome(x >> 2, (y & 15) >> 2, z >> 2);
-        return (BiomeType) PaperweightPlatformAdapter.adapt(biomes, serverLevel);
+        return BiomeTypes.get(PaperweightPlatformAdapter.adapt(biomes, serverLevel).unwrapKey().get().location().toString());
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks.java
@@ -197,7 +197,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     public BiomeType getBiomeType(int x, int y, int z) {
         LevelChunkSection section = getSections(false)[(y >> 4) - getMinSectionPosition()];
         Holder<Biome> biomes = section.getNoiseBiome(x >> 2, (y & 15) >> 2, z >> 2);
-        return BiomeTypes.get(PaperweightPlatformAdapter.adapt(biomes, serverLevel).unwrapKey().get().location().toString());
+        return PaperweightPlatformAdapter.adapt(biomes, serverLevel);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks_Copy.java
@@ -11,6 +11,7 @@ import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_18_R2.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
@@ -145,7 +146,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BiomeType getBiomeType(int x, int y, int z) {
         Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()].get(x >> 2, (y & 15) >> 2, z >> 2);
-        return biome != null ? (BiomeType) PaperweightPlatformAdapter.adapt(biome, serverLevel) : null;
+        return biome != null ?
+                BiomeTypes.get(PaperweightPlatformAdapter.adapt(biome, serverLevel).unwrapKey().get().location().toString()) : null;
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks_Copy.java
@@ -146,8 +146,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BiomeType getBiomeType(int x, int y, int z) {
         Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()].get(x >> 2, (y & 15) >> 2, z >> 2);
-        return biome != null ?
-                BiomeTypes.get(PaperweightPlatformAdapter.adapt(biome, serverLevel).unwrapKey().get().location().toString()) : null;
+        return PaperweightPlatformAdapter.adapt(biome, serverLevel);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightPlatformAdapter.java
@@ -26,8 +26,6 @@ import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
@@ -39,7 +37,6 @@ import net.minecraft.util.ZeroBitStorage;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
@@ -566,15 +563,13 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         fieldNonEmptyBlockCount.setShort(section, (short) nonEmptyBlockCount);
     }
 
-    public static Holder<Biome> adapt(Holder<Biome> biome, LevelAccessor levelAccessor) {
+    public static BiomeType adapt(Holder<Biome> biome, LevelAccessor levelAccessor) {
         final Registry<Biome> biomeRegistry = levelAccessor.registryAccess().ownedRegistryOrThrow(Registry.BIOME_REGISTRY);
-        final IdMap<Holder<Biome>> holders = biomeRegistry.asHolderIdMap();
-        ResourceLocation resourceLocation = biomeRegistry.getKey(biome.value());
-        if (resourceLocation == null) {
-            return holders.getId(biome) == -1 ? Holder.Reference.createStandAlone(biomeRegistry, Biomes.OCEAN)
+        if (biomeRegistry.getKey(biome.value()) == null) {
+            return biomeRegistry.asHolderIdMap().getId(biome) == -1 ? BiomeTypes.OCEAN
                     : null;
         }
-        return Holder.Reference.createStandAlone(biomeRegistry, ResourceKey.create(biomeRegistry.key(), resourceLocation));
+        return BiomeTypes.get(biome.unwrapKey().orElseThrow().location().toString());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Description
Fixes https://discord.com/channels/268444645527126017/344128526435221505/950410113687105606
`//regen -b` now works again, as the data type for the biome was casted wrong.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
