### PR TITLE
Fix tabcomplete for random pattern / multiple pattern

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
@@ -30,6 +30,9 @@ public class RandomPatternParser extends InputParser<Pattern> {
     public Stream<String> getSuggestions(String input) {
         //FAWE start
         List<String> patterns = StringUtil.split(input, ',', '[', ']');
+        if (patterns.isEmpty()) {
+            return Stream.empty();
+        }
         //FAWE end
         // get suggestions for the last token only
         String percent = null;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomPatternParser.java
@@ -30,34 +30,20 @@ public class RandomPatternParser extends InputParser<Pattern> {
     public Stream<String> getSuggestions(String input) {
         //FAWE start
         List<String> patterns = StringUtil.split(input, ',', '[', ']');
-        if (patterns.size() == 0) {
-            return Stream.empty();
-        }
-        // get suggestions for the last token only
-        String token = patterns.get(patterns.size() - 1);
-        String percent;
-        String previous;
-        if (patterns.size() != 1) {
-            previous = String.join(",", patterns.subList(0, patterns.size() - 1));
-            percent = ",";
-        } else {
-            previous = "";
-            percent = "";
-        }
-        if (regex.matcher(token).matches()) {
-            String[] p = token.split("%");
-            if (p.length < 2) {
-                return Stream.empty();
-            } else {
-                percent += p[0] + "%";
-                token = p[1];
-            }
-        } else {
-            return Stream.empty();
-        }
-        final List<String> innerSuggestions = worldEdit.getPatternFactory().getSuggestions(token);
-        String prefix = previous + percent;
         //FAWE end
+        // get suggestions for the last token only
+        String percent = null;
+        String token = patterns.get(patterns.size() - 1);
+        if (regex.matcher(token).matches()) {
+            String[] p = token.split("%", 2);
+            percent = p[0];
+            token = p[1];
+        } else if (patterns.size() == 1) {
+            return Stream.empty(); // handled by DefaultBlockParser
+        }
+        String previous = patterns.size() == 1 ? "" : String.join(",", patterns.subList(0, patterns.size() - 1)) + ",";
+        String prefix = previous + (percent == null ? "" : percent + "%");
+        final List<String> innerSuggestions = worldEdit.getPatternFactory().getSuggestions(token);
         return innerSuggestions.stream().map(s -> prefix + s);
     }
 


### PR DESCRIPTION
## Overview
Merge RandomPatternParser#getSuggestions with upstream (https://github.com/EngineHub/WorldEdit/commit/da3fd6c9fa2a185f25312aeac29c48436cd20d14)

Fixes #1509

## Description
Removed implementation introduced in https://github.com/IntellectualSites/FastAsyncWorldEdit/commit/ef61ecccaab13481aaa9e6c305c200980d098387 and merged https://github.com/EngineHub/WorldEdit/commit/da3fd6c9fa2a185f25312aeac29c48436cd20d14 into the RandomPatternParser (except the split part) - Does the same thing but works with multiple pattern.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
