### PR TITLE
refactor: removed unused variable

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/FaweBukkit.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/FaweBukkit.java
@@ -61,7 +61,6 @@ public class FaweBukkit implements IFawe, Listener {
     private final boolean chunksStretched;
     private final FAWEPlatformAdapterImpl platformAdapter;
     private ItemUtil itemUtil;
-    private boolean listeningImages;
     private Preloader preloader;
     private volatile boolean keepUnloaded;
 
@@ -119,7 +118,6 @@ public class FaweBukkit implements IFawe, Listener {
     @Override
     public synchronized ImageViewer getImageViewer(com.sk89q.worldedit.entity.Player player) {
         try {
-            listeningImages = true;
             PluginManager manager = Bukkit.getPluginManager();
 
             if (manager.getPlugin("PacketListenerApi") == null) {


### PR DESCRIPTION
## Overview
- Removed the variable 'listeningImages' from 'FaweBukkit.java' due to it not being used anywhere.

## Description
The variable 'listeningImages' is never used anywhere in the code and should therefore be removed.

## Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
