### PR TITLE
Fix memory leak by Citizen NPCs

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/BukkitPermissionAttachmentManager.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/BukkitPermissionAttachmentManager.java
@@ -2,6 +2,8 @@ package com.fastasyncworldedit.bukkit;
 
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import org.bukkit.entity.Player;
+import org.bukkit.permissions.Permissible;
+import org.bukkit.permissions.PermissibleBase;
 import org.bukkit.permissions.PermissionAttachment;
 
 import javax.annotation.Nullable;
@@ -12,20 +14,29 @@ public class BukkitPermissionAttachmentManager {
 
     private final WorldEditPlugin plugin;
     private final Map<Player, PermissionAttachment> attachments = new ConcurrentHashMap<>();
+    private final PermissionAttachment noopAttachment;
 
     public BukkitPermissionAttachmentManager(WorldEditPlugin plugin) {
         this.plugin = plugin;
+        this.noopAttachment = new PermissionAttachment(plugin, new PermissibleBase(null));
     }
 
     public PermissionAttachment getOrAddAttachment(@Nullable final Player p) {
         if (p == null) {
             return null;
         }
+        if (p.getUniqueId().version() == 2) {
+            return noopAttachment;
+        }
         return attachments.computeIfAbsent(p, k -> k.addAttachment(plugin));
     }
 
     public void removeAttachment(@Nullable final Player p) {
         if (p == null) {
+            return;
+        }
+        if (p.getUniqueId().version() == 2) {
+            p.removeAttachment(noopAttachment);
             return;
         }
         PermissionAttachment attach = attachments.remove(p);

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/BukkitPermissionAttachmentManager.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/BukkitPermissionAttachmentManager.java
@@ -23,7 +23,7 @@ public class BukkitPermissionAttachmentManager {
         if (p == null) {
             return null;
         }
-        if (p.getUniqueId().version() == 2) {
+        if (p.hasMetadata("NPC")) {
             if (this.noopAttachment == null) {
                 this.noopAttachment = new PermissionAttachment(plugin, new PermissibleBase(null));
             }
@@ -36,7 +36,7 @@ public class BukkitPermissionAttachmentManager {
         if (p == null) {
             return;
         }
-        if (p.getUniqueId().version() == 2 && noopAttachment != null) {
+        if (p.hasMetadata("NPC") && noopAttachment != null) {
             p.removeAttachment(noopAttachment);
             return;
         }

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/BukkitPermissionAttachmentManager.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/BukkitPermissionAttachmentManager.java
@@ -2,7 +2,6 @@ package com.fastasyncworldedit.bukkit;
 
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import org.bukkit.entity.Player;
-import org.bukkit.permissions.Permissible;
 import org.bukkit.permissions.PermissibleBase;
 import org.bukkit.permissions.PermissionAttachment;
 
@@ -14,11 +13,10 @@ public class BukkitPermissionAttachmentManager {
 
     private final WorldEditPlugin plugin;
     private final Map<Player, PermissionAttachment> attachments = new ConcurrentHashMap<>();
-    private final PermissionAttachment noopAttachment;
+    private PermissionAttachment noopAttachment;
 
     public BukkitPermissionAttachmentManager(WorldEditPlugin plugin) {
         this.plugin = plugin;
-        this.noopAttachment = new PermissionAttachment(plugin, new PermissibleBase(null));
     }
 
     public PermissionAttachment getOrAddAttachment(@Nullable final Player p) {
@@ -26,6 +24,9 @@ public class BukkitPermissionAttachmentManager {
             return null;
         }
         if (p.getUniqueId().version() == 2) {
+            if (this.noopAttachment == null) {
+                this.noopAttachment = new PermissionAttachment(plugin, new PermissibleBase(null));
+            }
             return noopAttachment;
         }
         return attachments.computeIfAbsent(p, k -> k.addAttachment(plugin));
@@ -35,7 +36,7 @@ public class BukkitPermissionAttachmentManager {
         if (p == null) {
             return;
         }
-        if (p.getUniqueId().version() == 2) {
+        if (p.getUniqueId().version() == 2 && noopAttachment != null) {
             p.removeAttachment(noopAttachment);
             return;
         }


### PR DESCRIPTION
## Description
Fixes a memory leak that attaches and caches PermissionAttachments to NPCs. Citizens uses version 2 UUIDs, which are not used for regular player uuids. Those v2 uuids are now excluded.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
