### PR TITLE
Fix Invalid pattern replacement / block category mask

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/RichMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/RichMaskParser.java
@@ -85,7 +85,7 @@ public class RichMaskParser extends FaweParser<Mask> {
                     if (charMask && input.charAt(0) == '=') {
                         mask = parseFromInput(char0 + "[" + input.substring(1) + "]", context);
                     }
-                    if (char0 == '#') {
+                    if (char0 == '#' && command.length() > 1 && command.charAt(1) != '#') {
                         throw new SuggestInputParseException(
                                 new NoMatchException(Caption.of("fawe.error.parse.unknown-mask", full,
                                         TextComponent
@@ -127,6 +127,12 @@ public class RichMaskParser extends FaweParser<Mask> {
                             case '%', '$', '<', '>', '!' -> {
                                 input = input.substring(input.indexOf(char0) + 1);
                                 mask = parseFromInput(char0 + "[" + input + "]", context);
+                            }
+                            case '#' -> {
+                                if (!(input.charAt(1) == '#')) {
+                                    break;
+                                }
+                                mask = worldEdit.getMaskFactory().parseWithoutRich(full, context);
                             }
                         }
                     }


### PR DESCRIPTION
## Overview
Fixes #1532

## Description
Applies the logic from the RichPatternParser to the RichMaskParser for block tags / categories as well.
The BlockCategoryMask now works again (e.g. `//replace #wool air`)

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
