### PR TITLE
Implement getNameUnsafe method to allow an unloaded world's name to be accessed

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/WorldUnloadedException.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/WorldUnloadedException.java
@@ -15,4 +15,11 @@ public class WorldUnloadedException extends WorldEditException {
         super(Caption.of("worldedit.error.world-unloaded"));
     }
 
+    /**
+     * Create a new instance.
+     */
+    public WorldUnloadedException(String name) {
+        super(Caption.of("worldedit.error.named-world-unloaded", name));
+    }
+
 }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -193,18 +193,33 @@ public class BukkitWorld extends AbstractWorld {
      * @return the world
      */
     protected World getWorldChecked() throws WorldEditException {
-        World world = worldRef.get();
-        if (world == null) {
-            throw new WorldUnloadedException();
+        World tmp = worldRef.get();
+        if (tmp == null) {
+            tmp = Bukkit.getWorld(worldNameRef);
+            if (tmp != null) {
+                worldRef = new WeakReference<>(tmp);
+            }
         }
-        return world;
+        if (tmp == null) {
+            throw new WorldUnloadedException(worldNameRef);
+        }
+        return tmp;
     }
     //FAWE end
 
     @Override
     public String getName() {
-        return getWorld().getName();
+        //FAWE start - Throw WorldUnloadedException rather than NPE when world unloaded and attempted to be accessed
+        return getWorldChecked().getName();
+        //FAWE end
     }
+
+    //FAWE start - allow history to read an unloaded world's name
+    @Override
+    public String getNameUnsafe() {
+        return worldNameRef;
+    }
+    //FAWE end
 
     @Override
     public String getId() {

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
@@ -76,6 +76,13 @@ public class ClipboardWorld extends AbstractWorld implements Clipboard, CLIWorld
         return this.name;
     }
 
+    //FAWE start - allow history to read an unloaded world's name
+    @Override
+    public String getNameUnsafe() {
+        return this.name;
+    }
+    //FAWE end
+
     @Override
     public String getId() {
         return getName().replace(" ", "_").toLowerCase(Locale.ROOT);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/wrappers/WorldWrapper.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/wrappers/WorldWrapper.java
@@ -198,6 +198,13 @@ public class WorldWrapper extends AbstractWorld {
         return parent.getName();
     }
 
+    //FAWE start - allow history to read an unloaded world's name
+    @Override
+    public String getNameUnsafe() {
+        return parent.getNameUnsafe();
+    }
+    //FAWE end
+
     @Override
     public <B extends BlockStateHolder<B>> boolean setBlock(BlockVector3 position, B block, boolean notifyAndLight) throws
             WorldEditException {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -306,7 +306,8 @@ public class LocalSession implements TextureHolder {
         }
         File file = MainUtil.getFile(
                 Fawe.platform().getDirectory(),
-                Settings.settings().PATHS.HISTORY + File.separator + world.getName() + File.separator + uuid + File.separator + "index"
+                // Use "unsafe" method here as world does not need to be loaded to save this information.
+                Settings.settings().PATHS.HISTORY + File.separator + world.getNameUnsafe() + File.separator + uuid + File.separator + "index"
         );
         if (getHistoryNegativeIndex() != 0) {
             try {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
@@ -69,6 +69,13 @@ public class NullWorld extends AbstractWorld {
         return "null";
     }
 
+    //FAWE start - allow history to read an unloaded world's name
+    @Override
+    public String getNameUnsafe() {
+        return "null";
+    }
+    //FAWE end
+
     @Override
     public String getId() {
         return "null";

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -63,11 +63,21 @@ public interface World extends Extent, Keyed, IChunkCache<IChunkGet> {
 //FAWE end
 
     /**
-     * Get the name of the world.
+     * Get the name of the world. This will error if world has been unloaded by the server.
      *
      * @return a name for the world
      */
     String getName();
+
+    //FAWE start - allow history to read an unloaded world's name
+    /**
+     * Get the name of the world. If the world referenced has been unloaded, this will still return the name.
+     *
+     * @return a name for the world
+     */
+    String getNameUnsafe();
+    //FAWE end
+
 
     /**
      * Get the folder in which this world is stored. May return null if unknown

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -74,6 +74,7 @@ public interface World extends Extent, Keyed, IChunkCache<IChunkGet> {
      * Get the name of the world. If the world referenced has been unloaded, this will still return the name.
      *
      * @return a name for the world
+     * @since TODO
      */
     String getNameUnsafe();
     //FAWE end

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -248,6 +248,7 @@
   "worldedit.tool.error.cannot-bind": "Can't bind tool to {0}: {1}",
   "worldedit.error.file-aborted": "File selection aborted.",
   "worldedit.error.world-unloaded": "The world was unloaded already.",
+  "worldedit.error.named-world-unloaded": "The world '{0}' was unloaded already.",
   "worldedit.error.blocks-cant-be-used": "Blocks can't be used",
   "worldedit.error.unknown-tag": "Tag name '{0}' was not recognized.",
   "worldedit.error.empty-tag": "Tag name '{0}' has no contents.",


### PR DESCRIPTION
 - Fixes #1671 and #504