### PR TITLE
Some fixes and improvements to internal queuing

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSAdapter.java
@@ -88,7 +88,7 @@ public class NMSAdapter implements FAWEPlatformAdapterImpl {
                     set[i] = switch (ordinal = getArr[i]) {
                         case BlockTypesCache.ReservedIDs.__RESERVED__ -> {
                             nonAir--;
-                            yield BlockTypesCache.ReservedIDs.AIR;
+                            yield (ordinal = BlockTypesCache.ReservedIDs.AIR);
                         }
                         case BlockTypesCache.ReservedIDs.AIR, BlockTypesCache.ReservedIDs.CAVE_AIR,
                                 BlockTypesCache.ReservedIDs.VOID_AIR -> {

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSAdapter.java
@@ -4,10 +4,14 @@ import com.fastasyncworldedit.core.FAWEPlatformAdapterImpl;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.function.Function;
 
 public class NMSAdapter implements FAWEPlatformAdapterImpl {
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     public static int createPalette(
             int[] blockToPalette,
@@ -79,14 +83,20 @@ public class NMSAdapter implements FAWEPlatformAdapterImpl {
                     if (getArr == null) {
                         getArr = get.apply(layer);
                     }
-                    ordinal = getArr[i];
-                    switch (ordinal) {
+                    // write to set array as this should be a copied array, and will be important when the changes are written
+                    // to the GET chunk cached by FAWE
+                    set[i] = switch (ordinal = getArr[i]) {
                         case BlockTypesCache.ReservedIDs.__RESERVED__ -> {
-                            ordinal = BlockTypesCache.ReservedIDs.AIR;
                             nonAir--;
+                            yield BlockTypesCache.ReservedIDs.AIR;
                         }
-                        case BlockTypesCache.ReservedIDs.AIR, BlockTypesCache.ReservedIDs.CAVE_AIR, BlockTypesCache.ReservedIDs.VOID_AIR -> nonAir--;
-                    }
+                        case BlockTypesCache.ReservedIDs.AIR, BlockTypesCache.ReservedIDs.CAVE_AIR,
+                                BlockTypesCache.ReservedIDs.VOID_AIR -> {
+                            nonAir--;
+                            yield ordinal;
+                        }
+                        default -> ordinal;
+                    };
                 }
                 case BlockTypesCache.ReservedIDs.AIR, BlockTypesCache.ReservedIDs.CAVE_AIR, BlockTypesCache.ReservedIDs.VOID_AIR -> nonAir--;
             }
@@ -109,12 +119,8 @@ public class NMSAdapter implements FAWEPlatformAdapterImpl {
         for (int i = 0; i < 4096; i++) {
             char ordinal = set[i];
             if (ordinal == BlockTypesCache.ReservedIDs.__RESERVED__) {
-                if (getArr == null) {
-                    getArr = get.apply(layer);
-                }
-                if ((ordinal = getArr[i]) == BlockTypesCache.ReservedIDs.__RESERVED__) {
-                    ordinal = BlockTypesCache.ReservedIDs.AIR;
-                }
+                LOGGER.error("Empty (__RESERVED__) ordinal given where not expected, default to air.");
+                ordinal = BlockTypesCache.ReservedIDs.AIR;
             }
             int palette = blockToPalette[ordinal];
             blocksCopy[i] = palette;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/Fawe.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/Fawe.java
@@ -335,7 +335,17 @@ public class Fawe {
         } catch (Throwable e) {
             LOGGER.error("Failed to load config.", e);
         }
-        Settings.settings().QUEUE.TARGET_SIZE = Math.max(Settings.settings().QUEUE.TARGET_SIZE, Settings.settings().QUEUE.PARALLEL_THREADS);
+        Settings.settings().QUEUE.TARGET_SIZE = Math.max(
+                Settings.settings().QUEUE.TARGET_SIZE,
+                Settings.settings().QUEUE.PARALLEL_THREADS
+        );
+        if (Settings.settings().QUEUE.TARGET_SIZE < 2 * Settings.settings().QUEUE.PARALLEL_THREADS) {
+            LOGGER.error(
+                    "queue.target_size is {}, and queue.parallel_threads is {}. It is HIGHLY recommended that queue" + ".target_size be at least twice queue.parallel_threads or higher.",
+                    Settings.settings().QUEUE.TARGET_SIZE,
+                    Settings.settings().QUEUE.PARALLEL_THREADS
+            );
+        }
         try {
             byte[] in = new byte[0];
             byte[] compressed = LZ4Factory.fastestJavaInstance().fastCompressor().compress(in);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/concurrent/ReentrantWrappedStampedLock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/concurrent/ReentrantWrappedStampedLock.java
@@ -9,6 +9,8 @@ import java.util.concurrent.locks.StampedLock;
 
 /**
  * Allows for reentrant behaviour of a wrapped {@link StampedLock}. Will not count the number of times it is re-entered.
+ *
+ * @since TODO
  */
 public class ReentrantWrappedStampedLock implements Lock {
 
@@ -82,6 +84,7 @@ public class ReentrantWrappedStampedLock implements Lock {
      *
      * @return lock stam[ or 0 if not locked.
      * @throws IllegalCallerException if the {@link StampedLock} is write-locked and the calling thread is not the lock owner
+     * @since TODO
      */
     public long getStampChecked() {
         if (stamp != 0 && owner != Thread.currentThread()) {
@@ -95,6 +98,7 @@ public class ReentrantWrappedStampedLock implements Lock {
      *
      * @param stamp Stamp to unlock with
      * @throws IllegalMonitorStateException if the given stamp does not match the lock's stamp
+     * @since TODO
      */
     public void unlock(final long stamp) {
         parent.unlockWrite(stamp);
@@ -106,6 +110,7 @@ public class ReentrantWrappedStampedLock implements Lock {
      * Returns true if the lock is currently held.
      *
      * @return true if the lock is currently held.
+     * @since TODO
      */
     public boolean isLocked() {
         return owner == null && this.stamp == 0 && parent.isWriteLocked(); // Be verbose

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/concurrent/ReentrantWrappedStampedLock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/concurrent/ReentrantWrappedStampedLock.java
@@ -1,0 +1,114 @@
+package com.fastasyncworldedit.core.concurrent;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.StampedLock;
+
+/**
+ * Allows for reentrant behaviour of a wrapped {@link StampedLock}. Will not count the number of times it is re-entered.
+ */
+public class ReentrantWrappedStampedLock implements Lock {
+
+    private final StampedLock parent = new StampedLock();
+    private volatile Thread owner;
+    private volatile long stamp = 0;
+
+    @Override
+    public void lock() {
+        if (Thread.currentThread() == owner) {
+            return;
+        }
+        stamp = parent.writeLock();
+        owner = Thread.currentThread();
+    }
+
+    @Override
+    public void lockInterruptibly() throws InterruptedException {
+        if (Thread.currentThread() == owner) {
+            return;
+        }
+        stamp = parent.writeLockInterruptibly();
+        owner = Thread.currentThread();
+    }
+
+    @Override
+    public boolean tryLock() {
+        if (Thread.currentThread() == owner) {
+            return true;
+        }
+        if (parent.isWriteLocked()) {
+            return false;
+        }
+        stamp = parent.writeLock();
+        owner = Thread.currentThread();
+        return true;
+    }
+
+    @Override
+    public boolean tryLock(final long time, @NotNull final TimeUnit unit) throws InterruptedException {
+        if (Thread.currentThread() == owner) {
+            return true;
+        }
+        if (!parent.isWriteLocked()) {
+            stamp = parent.writeLock();
+            owner = Thread.currentThread();
+            return true;
+        }
+        stamp = parent.tryWriteLock(time, unit);
+        owner = Thread.currentThread();
+        return false;
+    }
+
+    @Override
+    public void unlock() {
+        if (owner != Thread.currentThread()) {
+            throw new IllegalCallerException("The lock should only be unlocked by the owning thread when a stamp is not supplied");
+        }
+        unlock(stamp);
+    }
+
+    @NotNull
+    @Override
+    public Condition newCondition() {
+        throw new UnsupportedOperationException("Conditions are not supported by StampedLock");
+    }
+
+    /**
+     * Retrieves the stamp associated with the current lock. 0 if the wrapped {@link StampedLock} is not write-locked. This method is
+     * thread-checking.
+     *
+     * @return lock stam[ or 0 if not locked.
+     * @throws IllegalCallerException if the {@link StampedLock} is write-locked and the calling thread is not the lock owner
+     */
+    public long getStampChecked() {
+        if (stamp != 0 && owner != Thread.currentThread()) {
+            throw new IllegalCallerException("The stamp should be be acquired by a thread that does not own the lock");
+        }
+        return stamp;
+    }
+
+    /**
+     * Unlock the wrapped {@link StampedLock} using the given stamp. This can be called by any thread.
+     *
+     * @param stamp Stamp to unlock with
+     * @throws IllegalMonitorStateException if the given stamp does not match the lock's stamp
+     */
+    public void unlock(final long stamp) {
+        parent.unlockWrite(stamp);
+        this.stamp = 0;
+        owner = null;
+    }
+
+    /**
+     * Returns true if the lock is currently held.
+     *
+     * @return true if the lock is currently held.
+     */
+    public boolean isLocked() {
+        return owner == null && this.stamp == 0 && parent.isWriteLocked(); // Be verbose
+    }
+
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -519,7 +519,8 @@ public class Settings extends Config {
                 " - A larger value will use slightly less CPU time",
                 " - A smaller value will reduce memory usage",
                 " - A value too small may break some operations (deform?)",
-                " - Values smaller than the configurated parallel threads are not accepted"
+                " - Values smaller than the configurated parallel-threads are not accepted",
+                " - It is recommended this option be at least 2x greater than parallel-threads"
 
         })
         public int TARGET_SIZE = 64;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharGetBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharGetBlocks.java
@@ -26,7 +26,7 @@ public abstract class CharGetBlocks extends CharBlocks implements IChunkGet {
     @Override
     public synchronized boolean trim(boolean aggressive) {
         for (int i = 0; i < sectionCount; i++) {
-            sections[i] = empty;
+            sections[i] = EMPTY;
             blocks[i] = null;
         }
         return true;
@@ -49,7 +49,7 @@ public abstract class CharGetBlocks extends CharBlocks implements IChunkGet {
     @Override
     public synchronized boolean trim(boolean aggressive, int layer) {
         layer -= minSectionPosition;
-        sections[layer] = empty;
+        sections[layer] = EMPTY;
         blocks[layer] = null;
         return true;
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
@@ -299,7 +299,8 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
         if (biomes != null || light != null || skyLight != null) {
             return false;
         }
-        return IntStream.range(minSectionPosition, maxSectionPosition + 1).noneMatch(this::hasSection);
+        //noinspection SimplifyStreamApiCallChains - this is faster than using #noneMatch
+        return !IntStream.range(minSectionPosition, maxSectionPosition + 1).anyMatch(this::hasSection);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
@@ -121,8 +121,8 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     public void setBlocks(int layer, char[] data) {
         updateSectionIndexRange(layer);
         layer -= minSectionPosition;
+        this.sections[layer] = data == null ? EMPTY : FULL;
         this.blocks[layer] = data;
-        this.sections[layer] = data == null ? empty : FULL;
     }
 
     @Override
@@ -347,7 +347,7 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
             System.arraycopy(sections, 0, tmpSections, diff, sections.length);
             System.arraycopy(sectionLocks, 0, tmpSectionLocks, diff, sections.length);
             for (int i = 0; i < diff; i++) {
-                tmpSections[i] = empty;
+                tmpSections[i] = EMPTY;
                 tmpSectionLocks[i] = new Object();
             }
             blocks = tmpBlocks;
@@ -379,7 +379,7 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
             System.arraycopy(sections, 0, tmpSections, 0, sections.length);
             System.arraycopy(sectionLocks, 0, tmpSectionLocks, 0, sections.length);
             for (int i = sectionCount - diff; i < sectionCount; i++) {
-                tmpSections[i] = empty;
+                tmpSections[i] = EMPTY;
                 tmpSectionLocks[i] = new Object();
             }
             blocks = tmpBlocks;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -145,15 +145,16 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public char[] load(int layer) {
-        checkAndWaitOnCalledLock();
         return getOrCreateGet().load(layer);
     }
 
     @Nullable
     @Override
     public char[] loadIfPresent(final int layer) {
-        checkAndWaitOnCalledLock();
-        return getOrCreateGet().loadIfPresent(layer);
+        if (chunkExisting == null) {
+            return null;
+        }
+        return chunkExisting.loadIfPresent(layer);
     }
 
     @Override
@@ -224,25 +225,21 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public int getMaxY() {
-        checkAndWaitOnCalledLock();
         return getOrCreateGet().getMaxY();
     }
 
     @Override
     public int getMinY() {
-        checkAndWaitOnCalledLock();
         return getOrCreateGet().getMinY();
     }
 
     @Override
     public int getMaxSectionPosition() {
-        checkAndWaitOnCalledLock();
         return getOrCreateGet().getMaxSectionPosition();
     }
 
     @Override
     public int getMinSectionPosition() {
-        checkAndWaitOnCalledLock();
         return getOrCreateGet().getMinSectionPosition();
     }
 
@@ -973,7 +970,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public int getSectionCount() {
-        checkAndWaitOnCalledLock();
         return getOrCreateGet().getSectionCount();
     }
 
@@ -1012,7 +1008,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
      * - e.g., caching, optimizations, filtering
      */
     private IChunkSet newWrappedSet() {
-        checkAndWaitOnCalledLock();
         return extent.getCachedSet(chunkX, chunkZ);
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -79,12 +79,8 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
      */
     private void checkAndWaitOnCalledLock() {
         if (calledLock.isLocked()) {
-            synchronized (this) {
-                if (calledLock.isLocked()) {
-                    calledLock.lock();
-                    calledLock.unlock();
-                }
-            }
+            calledLock.lock();
+            calledLock.unlock();
         }
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -65,12 +65,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
         this.delegate = delegate;
     }
 
-    private void checkAndWaitOnCalledLock() {
-        if (calledLock.tryLock()) {
-            calledLock.unlock();
-        }
-    }
-
     @Override
     public synchronized void recycle() {
         delegate = NULL;
@@ -79,6 +73,15 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     public synchronized IBlockDelegate getDelegate() {
         return delegate;
+    }
+
+    /**
+     * If the chunk is currently being "called", this method will block until completed.
+     */
+    private void checkAndWaitOnCalledLock() {
+        if (calledLock.tryLock()) {
+            calledLock.unlock();
+        }
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -1048,7 +1048,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
                 });
             } catch (Throwable t) {
                 calledLock.unlock();
-                t.printStackTrace();
                 throw t;
             }
         }


### PR DESCRIPTION
 - The set array given in NMSAdapter should have get data written to it
 - Having target size >= 2* parallel threads allows for adjacent chunks to be loaded with issues
 - "empty" chunk section doesn't need to be localised to the chunk and may be static
 - Switch to slightly more performant stream method for testing for non-empty sections
 - Implement lock into ChunkHolder preventing any modification to occur whilst the edit is being applied to the world (when ChunkHolder is called)

 - Fixes #1664
 - May fix #1700