### PR TITLE
Don't initialise a DiskOptimisedClipboard before checking for an existing one in the LocalSession when using loadClipboardFromDisk

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -463,7 +463,6 @@ public interface Player extends Entity, Actor {
         );
         try {
             if (file.exists() && file.length() > 5) {
-                DiskOptimizedClipboard doc = new DiskOptimizedClipboard(file);
                 LocalSession session = getSession();
                 try {
                     if (session.getClipboard() != null) {
@@ -471,9 +470,10 @@ public interface Player extends Entity, Actor {
                     }
                 } catch (EmptyClipboardException ignored) {
                 }
+                DiskOptimizedClipboard doc = new DiskOptimizedClipboard(file);
                 Clipboard clip = doc.toClipboard();
                 ClipboardHolder holder = new ClipboardHolder(clip);
-                getSession().setClipboard(holder);
+                session.setClipboard(holder);
             }
         } catch (FaweClipboardVersionMismatchException e) {
             print(Caption.of("fawe.error.clipboard.on.disk.version.mismatch"));


### PR DESCRIPTION
Fixes #1726
