### PR TITLE
Check cached bukkit player is the same as the current player online

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
@@ -87,6 +87,11 @@ public class WorldEditListener implements Listener {
         }
 
         BukkitPlayer player = plugin.wrapPlayer(event.getPlayer());
+        //If plugins do silly things like teleport, deop (anything that requires a perm-recheck) (anything that ultimately
+        // requires a BukkitPlayer at some point) then the retention of metadata by the server (as it's stored based on a
+        // string value indescriminate of player a player relogging) means that a BukkitPlayer caching an old player object
+        // will be kept, cached and retrieved by FAWE. Adding a simple memory-based equality check when the player rejoins,
+        // and then "invaliding" (redoing) the cache if the players are not equal, fixes this.
         if (player.getPlayer() != event.getPlayer()) {
             player = plugin.reCachePlayer(event.getPlayer());
         }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditListener.java
@@ -86,7 +86,10 @@ public class WorldEditListener implements Listener {
             return;
         }
 
-        Player player = plugin.wrapPlayer(event.getPlayer());
+        BukkitPlayer player = plugin.wrapPlayer(event.getPlayer());
+        if (player.getPlayer() != event.getPlayer()) {
+            player = plugin.reCachePlayer(event.getPlayer());
+        }
         LocalSession session;
         if ((session = WorldEdit.getInstance().getSessionManager().getIfPresent(player)) != null) {
             session.loadDefaults(player, true);

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -573,15 +573,15 @@ public class WorldEditPlugin extends JavaPlugin {
         }
         return (BukkitPlayer) meta.get(0).value();
     }
-    //FAWE end
 
-    public BukkitPlayer reCachePlayer(Player player) {
+    BukkitPlayer reCachePlayer(Player player) {
         synchronized (player) {
             BukkitPlayer wePlayer = new BukkitPlayer(this, player);
             player.setMetadata("WE", new FixedMetadataValue(this, wePlayer));
             return wePlayer;
         }
     }
+    //FAWE end
 
     public Actor wrapCommandSender(CommandSender sender) {
         if (sender instanceof Player) {

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -575,6 +575,14 @@ public class WorldEditPlugin extends JavaPlugin {
     }
     //FAWE end
 
+    public BukkitPlayer reCachePlayer(Player player) {
+        synchronized (player) {
+            BukkitPlayer wePlayer = new BukkitPlayer(this, player);
+            player.setMetadata("WE", new FixedMetadataValue(this, wePlayer));
+            return wePlayer;
+        }
+    }
+
     public Actor wrapCommandSender(CommandSender sender) {
         if (sender instanceof Player) {
             return wrapPlayer((Player) sender);


### PR DESCRIPTION
 - If plugins do silly things like teleport, deop (anything that requires a perm-recheck) (anything that ultimately requires a BukkitPlayer at some point) then the retention of metadata by the server (as it's stored based on a string value indescriminate of player a player relogging) means that a BukkitPlayer caching an old player object will be kept, cached and retrieved by FAWE. Adding a simple memory-based equality check when the player rejoins, and then "invaliding" (redoing) the cache if the players are not equal, fixes this.
 - Fixes #1730

- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
