### PR TITLE
Don't error when loading a schematic fails

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -87,6 +87,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
@@ -399,7 +400,7 @@ public class SchematicCommands {
         } catch (IllegalArgumentException e) {
             actor.print(Caption.of("worldedit.schematic.unknown-filename", TextComponent.of(filename)));
         } catch (URISyntaxException | IOException e) {
-            actor.print(Caption.of("worldedit.schematic.file-not-exist", TextComponent.of(e.getMessage())));
+            actor.print(Caption.of("worldedit.schematic.file-not-exist", TextComponent.of(Objects.toString(e.getMessage()))));
             LOGGER.warn("Failed to load a saved clipboard", e);
         } finally {
             if (in != null) {


### PR DESCRIPTION
## Description
Based on the Javadocs of Throwable#getMessage:
> /**
     * Returns the detail message string of this throwable.
     *
     * @\return  the detail message string of this {@\code Throwable} instance
     *          (which may be {@\code null}).
     */

the return value of getMessage may be null.
Calling TextComponent.of with a null object throws an error. Rather embed "null"

For further reference: https://discord.com/channels/268444645527126017/344128526435221505/975119810172174336

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
