### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ worldedit-core/src/main/resources/lang/*
 **/*.eml
 /worldedit-core/FastAsyncWorldEdit.worldedit-core.eml
 /worldedit-core/.factorypath
+
+.DS_Store


### PR DESCRIPTION
Only relevant for mac os users not working with a global .gitignore file