### PR TITLE
Fix `//snowsmooth` not working below Y0

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/SnowHeightMap.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/convolution/SnowHeightMap.java
@@ -195,7 +195,7 @@ public class SnowHeightMap {
                     }
                 } else {
                     // Shrink -- start from bottom
-                    for (int y = 0; y < (int) Math.floor(newHeight - originY); ++y) {
+                    for (int y = session.getMinY(); y < (int) Math.floor(newHeight - originY); ++y) { // FAWE - Use world bottom
                         if (y >= (int) Math.floor(newHeight - originY - layerBlocks)) {
                             //FAWE start - avoid BlockVector3 creation for no reason
                             session.setBlock(xr, originY + y, zr, fillerSnow);


### PR DESCRIPTION
## Overview
Fixes https://github.com/IntellectualSites/FastAsyncWorldEdit/issues/1768

## Description
<!-- Please describe what this pull request does. -->
Uses the session min y instead of 0.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
