### PR TITLE
Add block break effect to area pickaxe

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -72,13 +72,13 @@ public class AreaPickaxe implements BlockTool {
                 for (int x = ox - range; x <= ox + range; ++x) {
                     for (int y = oy - range; y <= oy + range && y <= maxY; ++y) {
                         for (int z = oz - range; z <= oz + range; ++z) {
-                            BlockVector3 pos = BlockVector3.at(x, y, z);
                             if (!initialType.equals(editSession.getBlock(x, y, z).getBlockType())) {
                                 continue;
                             }
 
                             editSession.setBlock(x, y, z, BlockTypes.AIR.getDefaultState());
 
+                            BlockVector3 pos = BlockVector3.at(x, y, z);
                             ((World) clicked.getExtent()).queueBlockBreakEffect(server, pos, initialType,
                                     clicked.toVector().toBlockPoint().distanceSq(pos));
                         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -75,12 +75,14 @@ public class AreaPickaxe implements BlockTool {
                             if (!initialType.equals(editSession.getBlock(x, y, z).getBlockType())) {
                                 continue;
                             }
+                            // FAWE start
+                            if (editSession.setBlock(x, y, z, BlockTypes.AIR.getDefaultState())) {
 
-                            editSession.setBlock(x, y, z, BlockTypes.AIR.getDefaultState());
-
-                            BlockVector3 pos = BlockVector3.at(x, y, z);
-                            ((World) clicked.getExtent()).queueBlockBreakEffect(server, pos, initialType,
-                                    clicked.toVector().toBlockPoint().distanceSq(pos));
+                                BlockVector3 pos = BlockVector3.at(x, y, z);
+                                ((World) clicked.getExtent()).queueBlockBreakEffect(server, pos, initialType,
+                                        clicked.toVector().toBlockPoint().distanceSq(pos));
+                            }
+                            // FAWE end
                         }
                     }
                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -75,7 +75,7 @@ public class AreaPickaxe implements BlockTool {
                             if (!initialType.equals(editSession.getBlock(x, y, z).getBlockType())) {
                                 continue;
                             }
-                            // FAWE start
+                            // FAWE start - Only queue the block break effect if setting the block is successful
                             if (editSession.setBlock(x, y, z, BlockTypes.AIR.getDefaultState())) {
 
                                 BlockVector3 pos = BlockVector3.at(x, y, z);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/AreaPickaxe.java
@@ -27,7 +27,9 @@ import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extension.platform.Platform;
+import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 
@@ -70,12 +72,15 @@ public class AreaPickaxe implements BlockTool {
                 for (int x = ox - range; x <= ox + range; ++x) {
                     for (int y = oy - range; y <= oy + range && y <= maxY; ++y) {
                         for (int z = oz - range; z <= oz + range; ++z) {
+                            BlockVector3 pos = BlockVector3.at(x, y, z);
                             if (!initialType.equals(editSession.getBlock(x, y, z).getBlockType())) {
                                 continue;
                             }
 
                             editSession.setBlock(x, y, z, BlockTypes.AIR.getDefaultState());
 
+                            ((World) clicked.getExtent()).queueBlockBreakEffect(server, pos, initialType,
+                                    clicked.toVector().toBlockPoint().distanceSq(pos));
                         }
                     }
                 }


### PR DESCRIPTION
## Overview
Adds block break effect to area pickaxe.

## Description
Adds block break effect to area superpickaxe to match upstream/recursive pickaxe behavior.

I'm not sure what to do here as the commits that were responsible for adding this were reverted on a merge a _while_ back.
Added in: https://github.com/IntellectualSites/FastAsyncWorldEdit/commit/96e56bdd0cbf5d7640fa30984f78c27a084b6d05
Reverted in: https://github.com/IntellectualSites/FastAsyncWorldEdit/commit/66744bfaa4154569176e677ebb71a36470147d8b


## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X ] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
