### PR TITLE
chore: Drop WEManager#cancelEditSafe() logger

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/WEManager.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/WEManager.java
@@ -66,7 +66,6 @@ public class WEManager {
     }
 
     public void cancelEditSafe(AbstractDelegateExtent parent, FaweException reason) throws FaweException {
-        LOGGER.warn("CancelEditSafe was hit. Please ignore this message.");
         Extent currentExtent = parent.getExtent();
         if (!(currentExtent instanceof NullExtent)) {
             parent.extent = new NullExtent(parent.extent, reason);


### PR DESCRIPTION
## Overview

## Description
I'm not sure why we introduced the logger interface here, it isn't used to diagnose a current open issue, nor does it provide useful information for the end user, therefore we should remove it.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
