### PR TITLE
Only implement cache to MaskingExtent when off main thread

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/FaweCache.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/FaweCache.java
@@ -143,11 +143,11 @@ public enum FaweCache implements Trimable {
      * from the main thread, it will return a {@link Function} referencing the {@link LoadingCache} returned by
      * {@link FaweCache#createCache(Supplier)}. If it is called from the main thread, it will return a {@link Function} that
      * will always return the result of the given {@link Supplier}. It is designed to prevent issues caused by
-     * interally-mutable and resettable classes such as {@link com.fastasyncworldedit.core.extent.filter.block.CharFilterBlock}
+     * internally-mutable and resettable classes such as {@link com.fastasyncworldedit.core.extent.filter.block.CharFilterBlock}
      * from causing issues when used in edits on the main thread.
      *
-     * @param withInitial The supplier used to determine the initial value if a thread cache is created, else to provide the
-     *                    a new instance of the class being cached if on the main thread.
+     * @param withInitial The supplier used to determine the initial value if a thread cache is created, else to provide a new
+     *                    instance of the class being cached if on the main thread.
      * @return a {@link Function} referencing a cache, or the given {@link Supplier}
      * @since TODO
      */

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/FaweCache.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/FaweCache.java
@@ -55,6 +55,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.function.LongFunction;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -152,13 +153,13 @@ public enum FaweCache implements Trimable {
      * @since TODO
      */
     @AnnotationHelper.ApiDescription(info = "Designed for specific internal use.")
-    public <V> Function<Long, V> createMainThreadSafeCache(Supplier<V> withInitial) {
-        return new com.google.common.base.Function<>() {
+    public <V> LongFunction<V> createMainThreadSafeCache(Supplier<V> withInitial) {
+        return new LongFunction<>() {
             private final LoadingCache<Long, V> loadingCache = Fawe.isMainThread() ? null : FaweCache.INSTANCE.createCache(
                     withInitial);
 
             @Override
-            public V apply(final Long input) {
+            public V apply(final long input) {
                 return loadingCache != null ? loadingCache.getUnchecked(input) : withInitial.get();
             }
         };

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
@@ -35,7 +35,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
-import java.util.function.Function;
+import java.util.function.LongFunction;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -45,7 +45,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class MaskingExtent extends AbstractDelegateExtent implements IBatchProcessor, Filter {
 
     //FAWE start
-    private final Function<Long, ChunkFilterBlock> getOrCreateFilterBlock;
+    private final LongFunction<ChunkFilterBlock> getOrCreateFilterBlock;
     private Mask mask;
     //FAWE end
 
@@ -65,7 +65,7 @@ public class MaskingExtent extends AbstractDelegateExtent implements IBatchProce
     }
 
     //FAWE start
-    private MaskingExtent(Extent extent, Mask mask, Function<Long, ChunkFilterBlock> getOrCreateFilterBlock) {
+    private MaskingExtent(Extent extent, Mask mask, LongFunction<ChunkFilterBlock> getOrCreateFilterBlock) {
         super(extent);
         checkNotNull(mask);
         this.mask = mask;


### PR DESCRIPTION
 - It's possible for a [Chunk/Char]FilterBlock to be used multiple times in the same "tree" of method calls meaning the mutable paramets (particularly index) get increased within a loop, causing AIOOBs and other issues
 - This is only possible on the main thread due to the handling of submissions in SingleThreadQueueExtent, as it ensures all operation remains on the main thread to prevent deadlocks
 - Therefore safe usage of FilterBlocks requires that main-threaded operation create a new [Chunk/Char]FilterBlock instance each time
 - Further fixes #1681