### PR TITLE
Use the correct CuboidRegion constructor to prevent clipboard height being limited when loading schematics

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardReader.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardReader.java
@@ -61,7 +61,12 @@ public interface ClipboardReader extends Closeable {
     default Clipboard read(UUID uuid) throws IOException {
         return read(
                 uuid,
-                (dimensions) -> Clipboard.create(new CuboidRegion(BlockVector3.ZERO, dimensions.subtract(BlockVector3.ONE)), uuid)
+                (dimensions) -> Clipboard.create(new CuboidRegion(
+                        null,
+                        BlockVector3.ZERO,
+                        dimensions.subtract(BlockVector3.ONE),
+                        false
+                ), uuid)
         );
     }
 


### PR DESCRIPTION
 - Fixes #1757