### PR TITLE
Use Material rather than legacy int/data when specifying block break effect type

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -50,6 +50,7 @@ import com.sk89q.worldedit.world.RegenOptions;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.weather.WeatherType;
 import com.sk89q.worldedit.world.weather.WeatherTypes;
 import io.papermc.lib.PaperLib;
@@ -414,6 +415,15 @@ public class BukkitWorld extends AbstractWorld {
 
         return true;
     }
+
+    //FAWE start - allow block break effect of non-legacy blocks
+    @Override
+    public boolean playBlockBreakEffect(Vector3 position, BlockType type) {
+        World world = getWorld();
+        world.playEffect(BukkitAdapter.adapt(world, position), Effect.STEP_SOUND, BukkitAdapter.adapt(type));
+        return true;
+    }
+    //FAWE end
 
     @Override
     public WeatherType getWeather() {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/wrappers/WorldWrapper.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/wrappers/WorldWrapper.java
@@ -131,6 +131,13 @@ public class WorldWrapper extends AbstractWorld {
         return parent.playEffect(position, type, data);
     }
 
+    //FAWE start - allow block break effect of non-legacy blocks
+    @Override
+    public boolean playBlockBreakEffect(Vector3 position, BlockType type) {
+        return parent.playBlockBreakEffect(position, type);
+    }
+    //FAWE end
+
     @Override
     public boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockType blockType, double priority) {
         return parent.queueBlockBreakEffect(server, position, blockType, priority);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/AbstractWorld.java
@@ -107,6 +107,13 @@ public abstract class AbstractWorld implements World {
         return false;
     }
 
+    //FAWE start - allow block break effect of non-legacy blocks
+    @Override
+    public boolean playBlockBreakEffect(Vector3 position, BlockType type) {
+        return false;
+    }
+    //FAWE end
+
     @Override
     public boolean queueBlockBreakEffect(Platform server, BlockVector3 position, BlockType blockType, double priority) {
         if (taskId == -1) {
@@ -185,10 +192,11 @@ public abstract class AbstractWorld implements World {
             this.priority = priority;
         }
 
-        @SuppressWarnings("deprecation")
+        //FAWE start - allow block break effect of non-legacy blocks
         public void play() {
-            playEffect(position, 2001, blockType.getLegacyId());
+            playBlockBreakEffect(position, blockType);
         }
+        //FAWE end
 
         @Override
         public int compareTo(@Nullable QueuedEffect other) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/World.java
@@ -348,6 +348,17 @@ public interface World extends Extent, Keyed, IChunkCache<IChunkGet> {
      */
     boolean playEffect(Vector3 position, int type, int data);
 
+    //FAWE start - allow block break effect of non-legacy blocks
+    /**
+     * Play a block break effect.
+     *
+     * @param position the position
+     * @param type     the effect block type
+     * @return true if the effect was played
+     */
+    boolean playBlockBreakEffect(Vector3 position, BlockType type);
+    //FAWE end
+
     /**
      * Queue a block break effect.
      *


### PR DESCRIPTION
 - Fixes #1828