### PR TITLE
Set the correct delegate to the ChunkHolder when using get or set in NULL delegate

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -744,14 +744,14 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
         @Override
         public IChunkGet get(ChunkHolder chunk) {
             chunk.getOrCreateGet();
-            chunk.delegate = BOTH;
+            chunk.delegate = GET;
             return chunk.chunkExisting;
         }
 
         @Override
         public IChunkSet set(ChunkHolder chunk) {
             chunk.getOrCreateSet();
-            chunk.delegate = BOTH;
+            chunk.delegate = SET;
             return chunk.chunkSet;
         }
 


### PR DESCRIPTION
 - I can see no reason for it having been set to BOTH for either set or get?