### PR TITLE
docs: Use rootProject.name over project.name for javadocs title

### DIFF
--- a/buildSrc/src/main/kotlin/CommonJavaConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonJavaConfig.kt
@@ -67,6 +67,7 @@ fun Project.applyCommonJavaConfiguration(sourcesJar: Boolean, banSlf4j: Boolean 
                     "https://jd.papermc.io/paper/1.18/",
                     "https://intellectualsites.github.io/fastasyncworldedit-javadocs/worldedit-core/"
             )
+            docTitle = "${rootProject.name}" + " " + "${rootProject.version}"
         }
     }
 


### PR DESCRIPTION
As the title says, our javadocs are now named "FastAsyncWorldEdit + version", as appropriate.