### PR TITLE
fix: use servers removeGameEventListener instead of reimpl

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_19/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R1/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_19/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R1/PaperweightPlatformAdapter.java
@@ -101,7 +101,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final Field fieldLock;
     private static final long fieldLockOffset;
 
-    private static MethodHandle methodRemoveGameEventListener;
+    private static final MethodHandle methodRemoveGameEventListener;
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

there is an issue on servers that might have a different type for game event listeners (https://github.com/Bloom-host/Petal/issues/6)
this fix is also good for fawe because its less maintenance of internal code that can change. the generic stuff doesnt matter for reflection

## Description
replaces the copy of removeGameEventListener with calling it directly

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
