### PR TITLE
fix: upstream missing `Region#getBoundingBox()`

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Lists;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalConfiguration;
 import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.command.util.CommandPermissions;
@@ -104,6 +105,20 @@ import static com.sk89q.worldedit.command.util.Logging.LogMode.REGION;
  */
 @CommandContainer(superTypes = CommandPermissionsConditionGenerator.Registration.class)
 public class ClipboardCommands {
+
+    /**
+     * Throws if the region would allocate a clipboard larger than the block change limit.
+     *
+     * @param region The region to check
+     * @param session The session
+     * @throws MaxChangedBlocksException if the volume exceeds the limit
+     */
+    private void checkRegionBounds(Region region, LocalSession session) throws MaxChangedBlocksException {
+        int limit = session.getBlockChangeLimit();
+        if (region.getBoundingBox().getVolume() > limit) {
+            throw new MaxChangedBlocksException(limit);
+        }
+    }
 
     @Command(
             name = "/copy",

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
@@ -257,6 +257,11 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
     }
 
     @Override
+    public CuboidRegion getBoundingBox() {
+        return this;
+    }
+
+    @Override
     public int getMinimumY() {
         return minY;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -73,6 +73,15 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
     //FAWE end
 
     /**
+     * Get the bounding box of this region as a {@link CuboidRegion}.
+     *
+     * @return the bounding box
+     */
+    default CuboidRegion getBoundingBox() {
+        return new CuboidRegion(getMinimumPoint(), getMaximumPoint());
+    }
+
+    /**
      * Get the center point of a region.
      * Note: Coordinates will not be integers
      * if the corresponding lengths are even.


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #1907 

## Description
<!-- Please describe what this pull request does. -->

Upstreaming a missing commit from 2020 adding the missing methods. The change in ClipboardCommands isn't needed in FAWE but I kept the method for consistency.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
