### PR TITLE
fix: Lazy fix macro stacktrace

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/UtilityCommands.java
@@ -115,13 +115,14 @@ public class UtilityCommands {
         this.we = we;
     }
 
+    // TODO: Reimplement
     @Command(
             name = "/macro",
             desc = "Generate or run a macro"
     )
     @CommandPermissions("worldedit.macro")
-    public void macro(Actor actor, LocalSession session, String name, String argument) throws IOException {
-
+    public void macro(Actor actor) {
+        actor.print(TextComponent.of("This command is currently not implemented."));
     }
 
     @Command(


### PR DESCRIPTION
The command is commented out since 2019, given there is no forseeable change anytime soon, we don't need to keep it up as-is.

Fixes https://github.com/IntellectualSites/FastAsyncWorldEdit/issues/1902