### PR TITLE
fix: use proper level data for regen

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/regen/PaperweightRegen.java
@@ -79,6 +79,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -217,10 +218,10 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         BiomeProvider biomeProvider = getBiomeProvider();
 
         MinecraftServer server = originalServerWorld.getCraftServer().getServer();
-        PrimaryLevelData levelProperties = (PrimaryLevelData) server.getWorldData();
-
-        WorldGenSettings newOpts = levelProperties.worldGenSettings()
-                .withSeed(originalWorldData.settings.hardcore(), options.getSeed());
+        WorldGenSettings originalOpts = originalWorldData.worldGenSettings();
+        WorldGenSettings newOpts = options.getSeed().isPresent()
+                ? originalOpts.withSeed(originalWorldData.isHardcore(), OptionalLong.of(seed))
+                : originalOpts;
         LevelSettings newWorldSettings = new LevelSettings(
                 "faweregentempworld",
                 originalWorldData.settings.gameType(),

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/regen/PaperweightRegen.java
@@ -213,10 +213,9 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         BiomeProvider biomeProvider = getBiomeProvider();
 
         MinecraftServer server = originalServerWorld.getCraftServer().getServer();
-        PrimaryLevelData levelProperties = (PrimaryLevelData) server.getWorldData();
-        WorldGenSettings originalOpts = levelProperties.worldGenSettings();
+        WorldGenSettings originalOpts = originalWorldData.worldGenSettings();
         WorldGenSettings newOpts = options.getSeed().isPresent()
-                ? originalOpts.withSeed(levelProperties.isHardcore(), OptionalLong.of(seed))
+                ? originalOpts.withSeed(originalWorldData.isHardcore(), OptionalLong.of(seed))
                 : originalOpts;
         LevelSettings newWorldSettings = new LevelSettings(
                 "faweregentempworld",

--- a/worldedit-bukkit/adapters/adapter-1_19/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R1/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_19/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R1/regen/PaperweightRegen.java
@@ -214,10 +214,9 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         PrimaryLevelData originalWorldData = originalServerWorld.serverLevelData;
 
         MinecraftServer server = originalServerWorld.getCraftServer().getServer();
-        PrimaryLevelData levelProperties = (PrimaryLevelData) server.getWorldData();
-        WorldGenSettings originalOpts = levelProperties.worldGenSettings();
+        WorldGenSettings originalOpts = originalWorldData.worldGenSettings();
         WorldGenSettings newOpts = options.getSeed().isPresent()
-                ? originalOpts.withSeed(levelProperties.isHardcore(), OptionalLong.of(seed))
+                ? originalOpts.withSeed(originalWorldData.isHardcore(), OptionalLong.of(seed))
                 : originalOpts;
         LevelSettings newWorldSettings = new LevelSettings(
                 "faweregentempworld",


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #1894

## Description
<!-- Please describe what this pull request does. -->

The level data for the main world was used instead of the actual world, leading to wrong regen results in other worlds.
I also brought the 1.17 code in line with the other versions.

I only tested on 1.19.2, but I don't expect it to behave different on previous versions.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
