### PR TITLE
 fix: avoid recursive LegacyMapper initialization

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java
@@ -455,7 +455,7 @@ public class DefaultBlockParser extends InputParser<BaseBlock> {
                 state = item.getType().getBlockType().getDefaultState();
                 nbt = item.getNbtData();
             } else {
-                BlockType type = BlockTypes.parse(typeString.toLowerCase(Locale.ROOT));
+                BlockType type = BlockTypes.parse(typeString.toLowerCase(Locale.ROOT), context);
 
                 if (type != null) {
                     state = type.getDefaultState();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypes.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypes.java
@@ -23,6 +23,7 @@ import com.fastasyncworldedit.core.command.SuggestInputParseException;
 import com.fastasyncworldedit.core.util.JoinedCharSequence;
 import com.fastasyncworldedit.core.util.StringMan;
 import com.sk89q.worldedit.extension.input.InputParseException;
+import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 
 import javax.annotation.Nullable;
@@ -1948,6 +1949,9 @@ public final class BlockTypes {
      */
 
     public static BlockType parse(final String type) throws InputParseException {
+        return parse(type, new ParserContext());
+    }
+    public static BlockType parse(final String type, final ParserContext context) throws InputParseException {
         final String inputLower = type.toLowerCase(Locale.ROOT);
         String input = inputLower;
 
@@ -1958,13 +1962,14 @@ public final class BlockTypes {
         if (result != null) {
             return result;
         }
-
-        try {
-            BlockStateHolder<BlockState> block = LegacyMapper.getInstance().getBlockFromLegacy(input);
-            if (block != null) {
-                return block.getBlockType();
+        if (context.isTryingLegacy()) {
+            try {
+                BlockStateHolder<BlockState> block = LegacyMapper.getInstance().getBlockFromLegacy(input);
+                if (block != null) {
+                    return block.getBlockType();
+                }
+            } catch (NumberFormatException | IndexOutOfBoundsException ignored) {
             }
-        } catch (NumberFormatException | IndexOutOfBoundsException ignored) {
         }
 
         throw new SuggestInputParseException("Does not match a valid block type: " + inputLower, inputLower, () -> Stream.of(


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

When using a FAWE version that doesn't support the server version, FAWE started causing issues and spamming the logs because the LegacyMapper wasn't initialized correctly, and while initializing, the parse method was used, causing another initialization (and so on). While it will still fail to load correctly, it won't spam the logs anymore over and over again.

The parsing logic in BlockTypes should probably removed altogether, but that needs some investigation on what's needed, so using the parser context seems to be a quick and easy solution.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
