### PR TITLE
fix: EntityType.getName() is null

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/IBukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/IBukkitAdapter.java
@@ -343,7 +343,7 @@ public interface IBukkitAdapter {
      * @return WorldEdit EntityType
      */
     default EntityType adapt(org.bukkit.entity.EntityType entityType) {
-        return EntityTypes.get(entityType.getName().toLowerCase(Locale.ROOT));
+        return entityType.getName() == null ? null : EntityTypes.get(entityType.getName().toLowerCase(Locale.ROOT));
     }
 
     /**


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->
Fixes the following NPE:
```
Could not pass event CreatureSpawnEvent to WorldGuard v7.0.7+216b061
java.lang.NullPointerException: Cannot invoke "String.toLowerCase(java.util.Locale)" because the return value of "org.bukkit.entity.EntityType.getName()" is null
        at com.fastasyncworldedit.bukkit.adapter.IBukkitAdapter.adapt(IBukkitAdapter.java:346) ~[FastAsyncWorldEdit-Bukkit-2.4.4-SNAPSHOT-266.jar:?]
        at com.fastasyncworldedit.bukkit.adapter.IDelegateBukkitImplAdapter.adapt(IDelegateBukkitImplAdapter.java:271) ~[FastAsyncWorldEdit-Bukkit-2.4.4-SNAPSHOT-266.jar:?]
        at com.sk89q.worldedit.bukkit.BukkitAdapter.adapt(BukkitAdapter.java:395) ~[FastAsyncWorldEdit-Bukkit-2.4.4-SNAPSHOT-266.jar:?]
        at com.sk89q.worldguard.bukkit.listener.WorldGuardEntityListener.onCreatureSpawn(WorldGuardEntityListener.java:623) ~[worldguard-bukkit-7.0.7-dist.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor255.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:75) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:git-Paper-134]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:670) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.callCreatureSpawnEvent(CraftEventFactory.java:739) ~[paper-1.19.2.jar:git-Paper-134]
        at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.doEntityAddEventCalling(CraftEventFactory.java:644) ~[paper-1.19.2.jar:git-Paper-134]
        at net.minecraft.server.level.ServerLevel.addEntity(ServerLevel.java:1448) ~[?:?]
        at net.minecraft.server.level.ServerLevel.addFreshEntity(ServerLevel.java:1356) ~[?:?]
```

## Description
Adds a null type check to the EntityType adapter.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
