### PR TITLE
Fix #saturate-Pattern

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/SaturatePattern.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/SaturatePattern.java
@@ -66,7 +66,7 @@ public class SaturatePattern extends AbstractPattern {
         }
         int newColor = TextureUtil.multiplyColor(currentColor, color);
         BlockType newBlock = util.getNearestBlock(newColor);
-        if (newBlock.equals(type)) {
+        if (newBlock == null || newBlock.equals(type)) {
             return false;
         }
         return set.setBlock(extent, newBlock.getDefaultState());

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/TextureUtil.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/TextureUtil.java
@@ -30,7 +30,6 @@ import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -905,29 +904,15 @@ public class TextureUtil implements TextureHolder {
         if (folder.exists()) {
             // Get all the jar files
             File[] files = folder.listFiles((dir, name) -> name.endsWith(".jar"));
-            if (files.length == 0) {
-                new File(Fawe.platform().getDirectory() + "/" + Settings.settings().PATHS.TEXTURES + "/")
-                        .mkdirs();
-                try (BufferedInputStream in = new BufferedInputStream(
-                        new URL("https://piston-data.mojang.com/v1/objects/055b30d860ead928cba3849ba920c88b6950b654/client.jar")
-                                .openStream());
-                     FileOutputStream fileOutputStream = new FileOutputStream(
-                             Fawe.platform().getDirectory() + "/" + Settings.settings().PATHS.TEXTURES + "/1.19.2.jar")) {
-                    byte[] dataBuffer = new byte[1024];
-                    int bytesRead;
-                    while ((bytesRead = in.read(dataBuffer, 0, 1024)) != -1) {
-                        fileOutputStream.write(dataBuffer, 0, bytesRead);
-                    }
-                    fileOutputStream.close();
-                    files = folder.listFiles((dir, name) -> name.endsWith(".jar"));
-                } catch (IOException e) {
-                    LOGGER.error(
-                            "Could not download version jar. Please do so manually by creating a `FastAsyncWorldEdit/textures` " +
-                                    "folder with a `.minecraft/versions` jar or mods in it.");
-                    LOGGER.error("If the file exists, please make sure the server has read access to the directory.");
-                }
+            // We expect the latest version to be already there, due to the download in TextureUtil#<init>
+            if (files == null || files.length == 0) {
+                LOGGER.error("No version jar found in {}. Delete the named folder and restart your server to download the " +
+                        "missing assets.", folder.getPath());
+                LOGGER.error(
+                        "If no asset jar is created, please do so manually by creating a `FastAsyncWorldEdit/textures` " +
+                                "folder with a `.minecraft/versions` jar or mods in it.");
             }
-            if ((files.length > 0)) {
+            if (files != null && (files.length > 0)) {
                 for (File file : files) {
                     ZipFile zipFile = new ZipFile(file);
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/TextureUtil.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/TextureUtil.java
@@ -427,7 +427,7 @@ public class TextureUtil implements TextureHolder {
         HashSet<BlockType> blocks = new HashSet<>();
         for (int typeId = 0; typeId < ids.length; typeId++) {
             if (ids[typeId]) {
-                blocks.add(BlockTypes.get(typeId));
+                blocks.add(BlockTypesCache.values[typeId]);
             }
         }
         return fromBlocks(blocks);
@@ -445,7 +445,7 @@ public class TextureUtil implements TextureHolder {
 
         TextureUtil tu = Fawe.instance().getTextureUtil();
         for (int typeId : tu.getValidBlockIds()) {
-            BlockType block = BlockTypes.get(typeId);
+            BlockType block = BlockTypesCache.values[typeId];
             extent.init(0, 0, 0, block.getDefaultState().toBaseBlock());
             if (mask.test(extent)) {
                 blocks.add(block);
@@ -685,7 +685,7 @@ public class TextureUtil implements TextureHolder {
         if (min == Long.MAX_VALUE) {
             return null;
         }
-        return BlockTypes.get(closest);
+        return BlockTypesCache.values[closest];
     }
 
     /**
@@ -714,7 +714,7 @@ public class TextureUtil implements TextureHolder {
         if (min == Long.MAX_VALUE) {
             return null;
         }
-        return BlockTypes.get(closest);
+        return BlockTypesCache.values[closest];
     }
 
     /**
@@ -737,8 +737,8 @@ public class TextureUtil implements TextureHolder {
                 }
             }
         }
-        layerBuffer[0] = BlockTypes.get(closest[0]);
-        layerBuffer[1] = BlockTypes.get(closest[1]);
+        layerBuffer[0] = BlockTypesCache.values[closest[0]];
+        layerBuffer[1] = BlockTypesCache.values[closest[1]];
         return layerBuffer;
     }
 
@@ -909,7 +909,7 @@ public class TextureUtil implements TextureHolder {
                 new File(Fawe.platform().getDirectory() + "/" + Settings.settings().PATHS.TEXTURES + "/")
                         .mkdirs();
                 try (BufferedInputStream in = new BufferedInputStream(
-                        new URL("https://piston-data.mojang.com/v1/objects/c0898ec7c6a5a2eaa317770203a1554260699994/client.jar")
+                        new URL("https://piston-data.mojang.com/v1/objects/055b30d860ead928cba3849ba920c88b6950b654/client.jar")
                                 .openStream());
                      FileOutputStream fileOutputStream = new FileOutputStream(
                              Fawe.platform().getDirectory() + "/" + Settings.settings().PATHS.TEXTURES + "/1.19.2.jar")) {
@@ -934,7 +934,10 @@ public class TextureUtil implements TextureHolder {
                     // Get all the groups in the current jar
                     // The vanilla textures are in `assets/minecraft`
                     // A jar may contain textures for multiple mods
-                    String modelsDir = "assets/%1$s/models/block/%2$s.json";
+                    String[] modelsDir = {
+                            "assets/%1$s/models/block/%2$s.json",
+                            "assets/%1$s/models/item/%2$s.json"
+                    };
                     String texturesDir = "assets/%1$s/textures/%2$s.png";
 
                     Type typeToken = new TypeToken<Map<String, Object>>() {
@@ -958,10 +961,15 @@ public class TextureUtil implements TextureHolder {
                         String nameSpace = split.length == 1 ? "" : split[0];
 
                         // Read models
-                        String modelFileName = String.format(modelsDir, nameSpace, name);
-                        ZipEntry entry = getEntry(zipFile, modelFileName);
+                        ZipEntry entry = null;
+                        for (final String dir : modelsDir) {
+                            String modelFileName = String.format(dir, nameSpace, name);
+                            if ((entry = getEntry(zipFile, modelFileName)) != null) {
+                                break;
+                            }
+                        }
                         if (entry == null) {
-                            LOGGER.error("Cannot find {} in {}", modelFileName, file);
+                            LOGGER.error("Cannot find {} in {}", modelsDir, file);
                             continue;
                         }
 
@@ -1179,7 +1187,8 @@ public class TextureUtil implements TextureHolder {
         if (min == Long.MAX_VALUE) {
             return null;
         }
-        return BlockTypes.get(closest);
+
+        return BlockTypesCache.values[closest];
     }
 
     private String getFileName(String path) {


### PR DESCRIPTION
## Overview
Fixes #1933 

## Description
1. Updated the asset url to the last release
2. Search through item models as well (No idea why, but many block state models are located in models/item)
3. Change BlockType access by using the BlockTypeCache directly - as the used ids are based on the indexes in the values array of BlockTypeCache. No idea if this changes anything, was just more logical to me.

Example for `#saturate[255][0][120][255]`
![grafik](https://user-images.githubusercontent.com/27054324/189769543-843ee249-c3f7-4d57-b00f-6f22fa1dcce9.png)
![grafik](https://user-images.githubusercontent.com/27054324/189769562-92aec0cf-7f9f-4b9a-b2b2-6fd9126e3b68.png)

Based on my quick testing the changes works so far - Should logs and leaves be replaced as well? For me they don't, but I've never worked with that pattern before, so not that sure what the expected outcome is tbh

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
