### PR TITLE
Fix region restrictions with methods non-overriden

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/FaweRegionExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/FaweRegionExtent.java
@@ -96,13 +96,7 @@ public abstract class FaweRegionExtent extends ResettableExtent implements IBatc
 
     @Override
     public BiomeType getBiome(BlockVector3 position) {
-        if (!contains(position)) {
-            if (!limit.MAX_FAILS()) {
-                WEManager.weManager().cancelEditSafe(this, FaweCache.OUTSIDE_REGION);
-            }
-            return null;
-        }
-        return super.getBiome(position);
+        return getBiomeType(position.getX(), position.getY(), position.getZ());
     }
 
     @Override
@@ -118,24 +112,34 @@ public abstract class FaweRegionExtent extends ResettableExtent implements IBatc
 
     @Override
     public BaseBlock getFullBlock(BlockVector3 position) {
-        if (!contains(position)) {
+        return getFullBlock(position.getX(), position.getY(), position.getZ());
+    }
+
+    @Override
+    public BaseBlock getFullBlock(int x, int y, int z) {
+        if (!contains(x, y, z)) {
             if (!limit.MAX_FAILS()) {
                 WEManager.weManager().cancelEditSafe(this, FaweCache.OUTSIDE_REGION);
             }
             return BlockTypes.AIR.getDefaultState().toBaseBlock();
         }
-        return super.getFullBlock(position);
+        return super.getFullBlock(x, y, z);
     }
 
     @Override
     public BlockState getBlock(BlockVector3 position) {
-        if (!contains(position)) {
+        return getBlock(position.getX(), position.getY(), position.getZ());
+    }
+
+    @Override
+    public BlockState getBlock(int x, int y, int z) {
+        if (!contains(x, y, z)) {
             if (!limit.MAX_FAILS()) {
                 WEManager.weManager().cancelEditSafe(this, FaweCache.OUTSIDE_REGION);
             }
             return BlockTypes.AIR.getDefaultState();
         }
-        return super.getBlock(position);
+        return super.getBlock(x, y, z);
     }
 
     @Nullable


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes https://github.com/IntellectualSites/fastasyncvoxelsniper/issues/195

## Description
<!-- Please describe what this pull request does. -->
FAWE handles internally region restrictions through ExditSession. However, FAWE does not override methods correctlty with direct coordinates (x, y, z) in ``FaweRegionExtent``. Thus, the block may be returned without any process of the region restriction extents.

_Example:_
```java
ExtentTraverser<Extent> traverser = new ExtentTraverser<>(editSession.getExtent());
while (traverser != null && traverser.exists()) {
    Extent extent = traverser.get();
    if (extent instanceof SingleRegionExtent singleRegionExtent) {
        System.out.println(singleRegionExtent.getRegions().iterator().next().toString());

        // Polished andeside, inside plot.
        System.out.println(singleRegionExtent.getBlock(-3938, 64, 1571));
        System.out.println(singleRegionExtent.getBlock(BlockVector3.at(-3938, 64, 1571)));

        // Brick slab, the plot border.
        System.out.println(singleRegionExtent.getBlock(-3938, 65, 1570));
        System.out.println(singleRegionExtent.getBlock(BlockVector3.at(-3938, 65, 1570)));
    }
    traverser = traverser.next();
}
```

```java
[21:19:44 INFO]: minecraft:polished_andesite
[21:19:44 INFO]: minecraft:polished_andesite
[21:19:44 INFO]: minecraft:brick_slab[type=bottom,waterlogged=false]
[21:19:44 INFO]: minecraft:air
```
_Perhaps such a fix could be deployed to other extents that have the same issue._

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
