### PR TITLE
Don't error when NPC-annotated "entity" leaves the server

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/BukkitPermissionAttachmentManager.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/BukkitPermissionAttachmentManager.java
@@ -36,10 +36,6 @@ public class BukkitPermissionAttachmentManager {
         if (p == null) {
             return;
         }
-        if (p.hasMetadata("NPC") && noopAttachment != null) {
-            p.removeAttachment(noopAttachment);
-            return;
-        }
         PermissionAttachment attach = attachments.remove(p);
         if (attach != null) {
             p.removeAttachment(attach);


### PR DESCRIPTION
## Overview
Fixes #1966

## Description
The Noop-PermissibleAttachment is never added to the entity - but rather shared by reference - therefore can't be removed and throws error in certain edge cases (#1966)

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
