### PR TITLE
Add lin-bus dependency

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,18 +6,18 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
-    gradlePluginPortal()
-    maven {
-        name = "EngineHub"
-        url = uri("https://maven.enginehub.org/repo/")
-    }
     maven {
         name = "PaperMC"
-        url = uri("https://repo.papermc.io/repository/maven-public/")
+        url = uri("https://papermc.io/repo/repository/maven-public/")
         content {
             includeGroupByRegex("io\\.papermc\\..*")
         }
+    }
+    mavenCentral()
+    gradlePluginPortal()
+    maven {
+        name = "EngineHub Repository"
+        url = uri("https://maven.enginehub.org/repo/")
     }
 }
 

--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -18,6 +18,9 @@ fun Project.applyCommonConfiguration() {
         maven {
             name = "OSS Sonatype Snapshots"
             url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            mavenContent {
+                snapshotsOnly()
+            }
         }
         maven {
             name = "Athion"

--- a/buildSrc/src/main/kotlin/CommonJavaConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonJavaConfig.kt
@@ -50,6 +50,7 @@ fun Project.applyCommonJavaConfiguration(sourcesJar: Boolean, banSlf4j: Boolean 
 
     // Java 8 turns on doclint which we fail
     tasks.withType<Javadoc>().configureEach {
+        options.encoding = "UTF-8"
         (options as StandardJavadocDocletOptions).apply {
             addStringOption("Xdoclint:none", "-quiet")
             tags(
@@ -57,7 +58,6 @@ fun Project.applyCommonJavaConfiguration(sourcesJar: Boolean, banSlf4j: Boolean 
                     "implSpec:a:Implementation Requirements:",
                     "implNote:a:Implementation Note:"
             )
-            options.encoding = "UTF-8"
             links(
                     "https://jd.adventure.kyori.net/api/latest/",
                     "https://logging.apache.org/log4j/2.x/log4j-api/apidocs/",

--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -41,7 +41,6 @@ fun Project.applyLibrariesConfiguration() {
     val relocations = mapOf(
         "net.kyori.text" to "com.sk89q.worldedit.util.formatting.text",
         "net.kyori.minecraft" to "com.sk89q.worldedit.util.kyori",
-        "net.kyori.adventure.nbt" to "com.sk89q.worldedit.util.nbt"
 
     )
 
@@ -49,13 +48,20 @@ fun Project.applyLibrariesConfiguration() {
         configurations = listOf(project.configurations["shade"])
         archiveClassifier.set("")
 
+        // Yeet module-info's
+        exclude("module-info.class")
+
         dependencies {
             exclude(dependency("com.google.guava:guava"))
             exclude(dependency("com.google.code.gson:gson"))
             exclude(dependency("com.google.errorprone:error_prone_annotations"))
             exclude(dependency("org.checkerframework:checker-qual"))
+            exclude(dependency("org.jetbrains:annotations"))
             exclude(dependency("org.apache.logging.log4j:log4j-api"))
             exclude(dependency("com.google.code.findbugs:jsr305"))
+            exclude {
+                it.moduleGroup == "org.jetbrains.kotlin"
+            }
         }
 
         relocations.forEach { (from, to) ->
@@ -85,6 +91,10 @@ fun Project.applyLibrariesConfiguration() {
         from({
             altConfigFiles("sources")
         })
+
+        // Yeet module-info's
+        exclude("module-info.java")
+
         relocations.forEach { (from, to) ->
             val filePattern = Regex("(.*)${from.replace('.', '/')}((?:/|$).*)")
             val textPattern = Regex.fromLiteral(from)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,8 @@ jlibnoise = "1.0.0"
 jchronic = "0.2.4a"
 lz4-java = "1.8.0"
 lz4-stream = "1.0.0"
+lin-bus-bom = "0.1.0-SNAPSHOT"
+
 ## Internal
 adventure-text-minimessage = "4.2.0-SNAPSHOT"
 text-adapter = "3.0.6"

--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -14,7 +14,7 @@ applyShadowConfiguration()
 repositories {
     maven {
         name = "PaperMC"
-        url = uri("https://repo.papermc.io/repository/maven-public/")
+        url = uri("https://papermc.io/repo/repository/maven-public/")
     }
     maven {
         name = "EngineHub"

--- a/worldedit-core/build.gradle.kts
+++ b/worldedit-core/build.gradle.kts
@@ -27,6 +27,19 @@ dependencies {
     implementation("com.google.guava:guava")
     implementation("com.google.code.gson:gson")
 
+    implementation(libs.jchronic) {
+        exclude(group = "junit", module = "junit")
+    }
+    implementation("com.thoughtworks.paranamer:paranamer:2.6")
+    implementation(libs.jlibnoise)
+    api(platform("org.enginehub.lin-bus:lin-bus-bom:0.1.0-SNAPSHOT"))
+    api("org.enginehub.lin-bus:lin-bus-tree:0.1.0-SNAPSHOT") {
+        exclude(group = "org.jetbrains", module = "annotations")
+    }
+    api("org.enginehub.lin-bus.format:lin-bus-format-snbt:0.1.0-SNAPSHOT") {
+        exclude(group = "org.jetbrains", module = "annotations")
+    }
+
     // Platform expectations
     implementation("org.yaml:snakeyaml")
 

--- a/worldedit-libs/core/build.gradle.kts
+++ b/worldedit-libs/core/build.gradle.kts
@@ -5,12 +5,12 @@ dependencies {
     "shade"(libs.adventureTextSerializerGson)
     "shade"(libs.adventureTextSerializerLegacy)
     "shade"(libs.adventureTextSerializerPlain)
-    "shade"(libs.jchronic) {
-        exclude(group = "junit", module = "junit")
-    }
-    "shade"(libs.jlibnoise)
     "shade"(libs.piston)
     "shade"(libs.pistonRuntime)
     "shade"(libs.pistonImpl)
-    "shade"(libs.adventureNbt)
+    // Linbus
+    "shade"("org.enginehub.lin-bus:lin-bus-common:0.1.0-SNAPSHOT")
+    "shade"("org.enginehub.lin-bus:lin-bus-stream:0.1.0-SNAPSHOT")
+    "shade"("org.enginehub.lin-bus:lin-bus-tree:0.1.0-SNAPSHOT")
+    "shade"("org.enginehub.lin-bus.format:lin-bus-format-snbt:0.1.0-SNAPSHOT")
 }


### PR DESCRIPTION
## Overview
Adds a dependency on EngineHub/lin-bus.

## Description
Adds a dependency on EngineHub/lin-bus which has been used by upstream since July. It updates the ccom.sk89q.jnbt package with the upstream changes required for this change. This change brings us closer to being compatible with the WorldEdit API again.
## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
