### PR TITLE
Show affected biomes in `//copy -b`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,8 +75,8 @@ applyCommonConfiguration()
 
 tasks {
     runServer {
-        minecraftVersion("1.19")
-        pluginJars(project(":worldedit-bukkit").file("build/libs/FastAsyncWorldEdit-Bukkit-$version.jar"))
+        minecraftVersion("1.19.2")
+        pluginJars(project(":worldedit-bukkit").file("build/libs/FastAsyncWorldEdit-Bukkit-${rootVersion}-SNAPSHOT.jar"))
 
     }
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
@@ -201,7 +201,7 @@ public class BiomeCommands {
 
         RegionFunction replace = new BiomeReplace(editSession, target);
         if (mask != null) {
-            replace = new RegionMaskingFilter(editSession, mask, replace);
+            replace = new RegionMaskingFilter(mask, replace);
         }
         RegionVisitor visitor = new RegionVisitor(region, replace);
         Operations.completeLegacy(visitor);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
@@ -806,7 +806,7 @@ public interface Extent extends InputExtent, OutputExtent {
         checkNotNull(pattern);
 
         BlockReplace replace = new BlockReplace(this, pattern);
-        RegionMaskingFilter filter = new RegionMaskingFilter(this, mask, replace);
+        RegionMaskingFilter filter = new RegionMaskingFilter(mask, replace);
         //FAWE start > add extent to RegionVisitor to allow chunk preloading
         RegionVisitor visitor = new RegionVisitor(region, filter, this);
         //FAWE end

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/RegionMaskingFilter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/RegionMaskingFilter.java
@@ -35,24 +35,32 @@ public class RegionMaskingFilter implements RegionFunction {
 
     private final RegionFunction function;
     private final Mask mask;
-    //FAWE start
-    private final Extent extent;
-    //FAWE end
 
     /**
      * Create a new masking filter.
      *
      * @param mask     the mask
      * @param function the function
+     * @deprecated Extent is not used
      */
-    //FAWE start - Extent
+    //FAWE start - Extent (unused -> to be removed)
     public RegionMaskingFilter(Extent extent, Mask mask, RegionFunction function) {
         checkNotNull(function);
         checkNotNull(mask);
-        //FAWE start
-        checkNotNull(extent);
-        this.extent = extent;
-        //FAWE end
+        this.mask = mask;
+        this.function = function;
+    }
+    // FAWE end - Extent
+
+    /**
+     * Create a new masking filter.
+     *
+     * @param mask the mask
+     * @param function the function
+     */
+    public RegionMaskingFilter(Mask mask, RegionFunction function) {
+        checkNotNull(function);
+        checkNotNull(mask);
         this.mask = mask;
         this.function = function;
     }


### PR DESCRIPTION
## Overview
Fixes #1999 

## Description
- Fixes the counting for affected biomes
- Align RegionMaskingFilter with upstream, as FAWE changes are not used at all
- 	Fix runServer configuration for gradle plugin

tbh, I'm not sure if that's correct. The biome for every block is counted - is that the case for normal WE as well?
![grafik](https://user-images.githubusercontent.com/27054324/202872422-076a9c09-5f37-4334-8e62-93a565eacad5.png)


## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
