### PR TITLE
Clean up starlight usage

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightFaweAdapter.java
@@ -55,6 +55,7 @@ import com.sk89q.worldedit.world.block.BlockTypesCache;
 import com.sk89q.worldedit.world.entity.EntityType;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
+import io.papermc.lib.PaperLib;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.WritableRegistry;
@@ -663,17 +664,11 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public RelighterFactory getRelighterFactory() {
-        try {
-            Class.forName("ca.spottedleaf.starlight.common.light.StarLightEngine");
-            if (PaperweightStarlightRelighter.isUsable()) {
-                return new PaperweightStarlightRelighterFactory();
-            }
-        } catch (ThreadDeath td) {
-            throw td;
-        } catch (Throwable ignored) {
-
+        if (PaperLib.isPaper()) {
+            return new PaperweightStarlightRelighterFactory();
+        } else {
+            return new NMSRelighterFactory();
         }
-        return new NMSRelighterFactory();
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_19/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_19/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R1/PaperweightFaweAdapter.java
@@ -653,17 +653,11 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public RelighterFactory getRelighterFactory() {
-        try {
-            Class.forName("ca.spottedleaf.starlight.common.light.StarLightEngine");
-            if (PaperweightStarlightRelighter.isUsable()) {
-                return new PaperweightStarlightRelighterFactory();
-            }
-        } catch (ThreadDeath td) {
-            throw td;
-        } catch (Throwable ignored) {
-
+        if (PaperLib.isPaper()) {
+            return new PaperweightStarlightRelighterFactory();
+        } else {
+            return new NMSRelighterFactory();
         }
-        return new NMSRelighterFactory();
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_19/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R1/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_19/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R1/PaperweightStarlightRelighter.java
@@ -14,16 +14,12 @@ import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ThreadedLevelLightEngine;
 import net.minecraft.server.level.TicketType;
 import net.minecraft.util.Unit;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import org.apache.logging.log4j.Logger;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -35,7 +31,6 @@ import java.util.function.IntConsumer;
 
 public class PaperweightStarlightRelighter implements Relighter {
 
-    public static final MethodHandle RELIGHT;
     private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final int CHUNKS_PER_BATCH = 1024; // 32 * 32
     private static final int CHUNKS_PER_BATCH_SQRT_LOG2 = 5; // for shifting
@@ -43,26 +38,6 @@ public class PaperweightStarlightRelighter implements Relighter {
     private static final TicketType<Unit> FAWE_TICKET = TicketType.create("fawe_ticket", (a, b) -> 0);
     private static final int LIGHT_LEVEL = ChunkMap.MAX_VIEW_DISTANCE + ChunkStatus.getDistance(ChunkStatus.LIGHT);
 
-    static {
-        MethodHandle tmp = null;
-        try {
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            tmp = lookup.findVirtual(
-                    ThreadedLevelLightEngine.class,
-                    "relight",
-                    MethodType.methodType(
-                            int.class, // return type
-                            // params
-                            Set.class,
-                            Consumer.class,
-                            IntConsumer.class
-                    )
-            );
-        } catch (NoSuchMethodException | IllegalAccessException e) {
-            LOGGER.error("Failed to locate 'relight' method in ThreadedLevelLightEngine. Is everything up to date?", e);
-        }
-        RELIGHT = tmp;
-    }
 
     private final ServerLevel serverLevel;
     private final ReentrantLock lock = new ReentrantLock();
@@ -74,10 +49,6 @@ public class PaperweightStarlightRelighter implements Relighter {
     public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<IQueueChunk> queue) {
         this.serverLevel = serverLevel;
         this.delegate = new NMSRelighter(queue);
-    }
-
-    public static boolean isUsable() {
-        return RELIGHT != null;
     }
 
     @Override
@@ -169,14 +140,9 @@ public class PaperweightStarlightRelighter implements Relighter {
             IntConsumer processCallback
     ) {
         try {
-            int unused = (int) RELIGHT.invokeExact(
-                    serverLevel.getChunkSource().getLightEngine(),
-                    coords,
-                    chunkCallback, // callback per chunk
-                    processCallback // callback for all chunks
-            );
-        } catch (Throwable throwable) {
-            LOGGER.error("Error occurred on relighting", throwable);
+            serverLevel.getChunkSource().getLightEngine().relight(coords, chunkCallback, processCallback);
+        } catch (Exception e) {
+            LOGGER.error("Error occurred on relighting", e);
         }
     }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

Before Tuinity was integrated into Paper, we had to look up the starlight relight method dynamically.
Tuinity was merged during the 1.17.1 time, so I excluded the 1.17 adapter from the changes

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
