### PR TITLE
Remove usages of JoinedCharSequence

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/JoinedCharSequence.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/JoinedCharSequence.java
@@ -1,5 +1,9 @@
 package com.fastasyncworldedit.core.util;
 
+/**
+ * @deprecated Unused, will be removed in the future. Use String concatenation instead.
+ */
+@Deprecated(forRemoval = true, since = "TODO")
 public class JoinedCharSequence implements CharSequence {
 
     private char join;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypes.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypes.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldedit.world.block;
 
 import com.fastasyncworldedit.core.command.SuggestInputParseException;
-import com.fastasyncworldedit.core.util.JoinedCharSequence;
 import com.fastasyncworldedit.core.util.StringMan;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
@@ -1923,23 +1922,19 @@ public final class BlockTypes {
     public static final BlockType ZOMBIE_WALL_HEAD = init();
 
     private static Field[] fieldsTmp;
-    private static JoinedCharSequence joined;
     private static int initIndex = 0;
 
     public static BlockType init() {
         if (fieldsTmp == null) {
             fieldsTmp = BlockTypes.class.getDeclaredFields();
             BlockTypesCache.$NAMESPACES.isEmpty(); // initialize cache
-            joined = new JoinedCharSequence();
         }
         String name = fieldsTmp[initIndex++].getName().toLowerCase(Locale.ROOT);
-        CharSequence fullName = joined.init(BlockType.REGISTRY.getDefaultNamespace(), ':', name);
-        return BlockType.REGISTRY.getMap().get(fullName);
+        return BlockType.REGISTRY.get(name);
     }
 
     static {
         fieldsTmp = null;
-        joined = null;
     }
 
     /*

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemTypes.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemTypes.java
@@ -19,7 +19,6 @@
 
 package com.sk89q.worldedit.world.item;
 
-import com.fastasyncworldedit.core.util.JoinedCharSequence;
 import com.fastasyncworldedit.core.world.block.ItemTypesCache;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 
@@ -2362,7 +2361,6 @@ public final class ItemTypes {
     }
 
     private static Field[] fieldsTmp;
-    private static JoinedCharSequence joined;
     private static int initIndex = 0;
 
     private static ItemType init() {
@@ -2370,11 +2368,9 @@ public final class ItemTypes {
             if (fieldsTmp == null) {
                 fieldsTmp = ItemTypes.class.getDeclaredFields();
                 ItemTypesCache.init(); // force class to load
-                joined = new JoinedCharSequence();
             }
             String name = fieldsTmp[initIndex++].getName().toLowerCase(Locale.ROOT);
-            CharSequence fullName = joined.init(ItemType.REGISTRY.getDefaultNamespace(), ':', name);
-            return ItemType.REGISTRY.getMap().get(fullName);
+            return ItemType.REGISTRY.get(name);
         } catch (Throwable e) {
             e.printStackTrace();
             throw e;
@@ -2383,7 +2379,6 @@ public final class ItemTypes {
 
     static {
         fieldsTmp = null;
-        joined = null;
     }
 
     @Nullable


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

## Description
<!-- Please describe what this pull request does. -->

JoinedCharSequence was used to avoid String concatenation. However, String concatenation was heavily improved years ago, and String provides may provide faster `hashCode` and `equals` methods, therefore I propose to drop usages of that class. Also, none of the usages are in hot paths, so even slower code might be preferable over such hacky solutions.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
