### PR TITLE
Linear Patterns require flooring division

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/Linear2DBlockPattern.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/Linear2DBlockPattern.java
@@ -7,6 +7,8 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
+import static java.lang.Math.floorDiv;
+
 public class Linear2DBlockPattern extends AbstractPattern {
 
     private final Pattern[] patternsArray;
@@ -37,7 +39,8 @@ public class Linear2DBlockPattern extends AbstractPattern {
 
     @Override
     public boolean apply(Extent extent, BlockVector3 get, BlockVector3 set) throws WorldEditException {
-        int index = (get.getBlockX() / this.xScale + get.getBlockZ() / this.zScale) % patternsArray.length;
+        int index = (floorDiv(get.getBlockX(), this.xScale)
+                + floorDiv(get.getBlockZ(), this.zScale)) % patternsArray.length;
         if (index < 0) {
             index += patternsArray.length;
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/Linear3DBlockPattern.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/Linear3DBlockPattern.java
@@ -7,6 +7,8 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
+import static java.lang.Math.floorDiv;
+
 public class Linear3DBlockPattern extends AbstractPattern {
 
     private final Pattern[] patternsArray;
@@ -41,8 +43,8 @@ public class Linear3DBlockPattern extends AbstractPattern {
 
     @Override
     public boolean apply(Extent extent, BlockVector3 get, BlockVector3 set) throws WorldEditException {
-        int index = (get.getBlockX() / this.xScale
-                + get.getBlockY() / this.yScale + get.getBlockZ() / this.zScale) % patternsArray.length;
+        int index = (floorDiv(get.getBlockX(), this.xScale)
+                + floorDiv(get.getBlockY(), this.yScale) + floorDiv(get.getBlockZ(), this.zScale)) % patternsArray.length;
         if (index < 0) {
             index += patternsArray.length;
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

Integer division is truncating, so e.g., both `1 / 2` and `-1 / 2` is `0`. However, we want the latter to be `-1` instead. This can be achieved by using `floorDiv`.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
