### PR TITLE
Remove PlayerMoveEvent listener and deprecate MovableTool

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/listener/BrushListener.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/listener/BrushListener.java
@@ -1,6 +1,5 @@
 package com.fastasyncworldedit.bukkit.listener;
 
-import com.fastasyncworldedit.core.command.tool.MovableTool;
 import com.fastasyncworldedit.core.command.tool.ResettableTool;
 import com.fastasyncworldedit.core.command.tool.scroll.ScrollTool;
 import com.sk89q.worldedit.LocalSession;
@@ -8,7 +7,6 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitPlayer;
 import com.sk89q.worldedit.command.tool.Tool;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -16,7 +14,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
-import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.plugin.Plugin;
 
 public class BrushListener implements Listener {
@@ -45,24 +42,6 @@ public class BrushListener implements Listener {
             }
             if (scrollable.increment(player, ri)) {
                 bukkitPlayer.getInventory().setHeldItemSlot(oldSlot);
-            }
-        }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onPlayerMove(PlayerMoveEvent event) {
-        Location from = event.getFrom();
-        Location to = event.getTo();
-        if ((from.getYaw() != to.getYaw() && from.getPitch() != to.getPitch()) || from.getBlockX() != to.getBlockX() || from.getBlockZ() != to
-                .getBlockZ() || from.getBlockY() != to.getBlockY()) {
-            Player bukkitPlayer = event.getPlayer();
-            com.sk89q.worldedit.entity.Player player = BukkitAdapter.adapt(bukkitPlayer);
-            LocalSession session = player.getSession();
-            Tool tool = session.getTool(player);
-            if (tool != null) {
-                if (tool instanceof MovableTool) {
-                    ((MovableTool) tool).move(player);
-                }
             }
         }
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/MovableTool.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/MovableTool.java
@@ -2,8 +2,16 @@ package com.fastasyncworldedit.core.command.tool;
 
 import com.sk89q.worldedit.entity.Player;
 
+/**
+ * @deprecated This interface has no functionality anymore
+ */
+@Deprecated(forRemoval = true, since = "TODO")
 public interface MovableTool {
 
+    /**
+     * @deprecated This interface has no functionality anymore
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
     boolean move(Player player);
 
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

As the `move` method in `MovableTool` has only one implementation unconditionally returning false without doing anything else, we can deprecated the interface for removal.

The PlayerMoveEvent listener also is somewhat expensive, so removing it will help the performance on larger servers.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
