### PR TITLE
Use Pattern Matching for instanceof in PropertyKeySet

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/registry/state/PropertyKeySet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/registry/state/PropertyKeySet.java
@@ -18,9 +18,9 @@ public class PropertyKeySet implements Set<PropertyKey> {
 
     public static PropertyKeySet ofCollection(Collection<? extends PropertyKey> collection) {
         PropertyKeySet set = new PropertyKeySet();
-        if (collection instanceof PropertyKeySet) {
+        if (collection instanceof PropertyKeySet pks) {
             // simple copy
-            set.bits.or(((PropertyKeySet) collection).bits);
+            set.bits.or(pks.bits);
             return set;
         }
         for (PropertyKey key : collection) {
@@ -51,10 +51,10 @@ public class PropertyKeySet implements Set<PropertyKey> {
 
     @Override
     public boolean contains(Object o) {
-        if (!(o instanceof PropertyKey)) {
+        if (!(o instanceof PropertyKey pk)) {
             return false;
         }
-        return this.bits.get(((PropertyKey) o).getId());
+        return this.bits.get(pk.getId());
     }
 
     @Nonnull
@@ -92,26 +92,26 @@ public class PropertyKeySet implements Set<PropertyKey> {
 
     @Override
     public boolean remove(Object o) {
-        if (!(o instanceof PropertyKey)) {
+        if (!(o instanceof PropertyKey pk)) {
             return false;
         }
-        if (!this.bits.get(((PropertyKey) o).getId())) {
+        if (!this.bits.get(pk.getId())) {
             return false;
         }
-        this.bits.clear(((PropertyKey) o).getId());
+        this.bits.clear(pk.getId());
         return true;
     }
 
     @Override
     public boolean containsAll(@Nonnull Collection<?> c) {
-        if (c instanceof PropertyKeySet) {
-            return ((PropertyKeySet) c).bits.intersects(this.bits);
+        if (c instanceof PropertyKeySet pks) {
+            return pks.bits.intersects(this.bits);
         }
         for (Object o : c) {
-            if (!(o instanceof PropertyKey)) {
+            if (!(o instanceof PropertyKey pk)) {
                 return false;
             }
-            if (!this.bits.get(((PropertyKey) o).getId())) {
+            if (!this.bits.get(pk.getId())) {
                 return false;
             }
         }
@@ -121,8 +121,8 @@ public class PropertyKeySet implements Set<PropertyKey> {
     @Override
     public boolean addAll(@Nonnull Collection<? extends PropertyKey> c) {
         int cardinality = this.bits.cardinality();
-        if (c instanceof PropertyKeySet) {
-            this.bits.or(((PropertyKeySet) c).bits);
+        if (c instanceof PropertyKeySet pks) {
+            this.bits.or(pks.bits);
         } else {
             for (PropertyKey key : c) {
                 this.bits.set(key.getId());
@@ -135,8 +135,8 @@ public class PropertyKeySet implements Set<PropertyKey> {
     public boolean retainAll(@Nonnull Collection<?> c) {
         int cardinality = this.bits.cardinality();
         BitSet removal;
-        if (c instanceof PropertyKeySet) {
-            removal = ((PropertyKeySet) c).bits;
+        if (c instanceof PropertyKeySet pks) {
+            removal = pks.bits;
         } else {
             removal = new BitSet(this.bits.length());
             for (PropertyKey key : this) {
@@ -152,12 +152,12 @@ public class PropertyKeySet implements Set<PropertyKey> {
     @Override
     public boolean removeAll(@Nonnull Collection<?> c) {
         int cardinality = this.bits.cardinality();
-        if (c instanceof PropertyKeySet) {
-            this.bits.andNot(((PropertyKeySet) c).bits);
+        if (c instanceof PropertyKeySet pks) {
+            this.bits.andNot(pks.bits);
         } else {
             for (Object o : c) { // mh
-                if (o instanceof PropertyKey) {
-                    this.bits.clear(((PropertyKey) o).getId());
+                if (o instanceof PropertyKey pk) {
+                    this.bits.clear(pk.getId());
                 }
             }
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

A simple refactoring of PropertyKeySet to make use of pattern matching in instanceof instead of casting.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
