### PR TITLE
Make custom toArray methods fulfill the method contract

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
@@ -6,6 +6,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.zaxxer.sparsebits.SparseBitSet;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -235,12 +236,15 @@ public class LocalBlockVectorSet implements BlockVector3Set {
         return toArray((Object[]) null);
     }
 
+    @SuppressWarnings("unchecked")
     @Nonnull
     @Override
     public <T> T[] toArray(T[] array) {
         int size = size();
-        if (array == null || array.length < size) {
-            array = (T[]) new BlockVector3[size];
+        if (array.length < size) {
+            array = Arrays.copyOf(array, size);
+        } else if (array.length > size) {
+            array[size] = null; // mark as end to comply with the method contract
         }
         int index = 0;
         for (int i = 0; i < size; i++) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/registry/state/PropertyKeySet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/registry/state/PropertyKeySet.java
@@ -73,7 +73,16 @@ public class PropertyKeySet implements Set<PropertyKey> {
     @Nonnull
     @Override
     public <T> T[] toArray(@Nonnull T[] a) {
-        T[] array = Arrays.copyOf(a, this.bits.cardinality());
+        T[] array;
+        final int cardinality = this.bits.cardinality();
+        if (cardinality > a.length) {
+            array = Arrays.copyOf(a, cardinality);
+        } else {
+            array = a;
+            if (a.length > cardinality) {
+                array[cardinality] = null; // mark as end to comply with the method contract
+            }
+        }
         Iterator<PropertyKey> iter = iterator();
         for (int i = 0; i < array.length && iter.hasNext(); i++) {
             array[i] = (T) iter.next();


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

According to the javadocs of [`Collection#toArray(T[])`](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/util/Collection.html#toArray(T%5B%5D)):

> If this collection fits in the specified array with room to spare (i.e., the array has more elements than this collection), the element in the array immediately following the end of the collection is set to null.

This wasn't done in those two cases, so let's fix that. I don't think it even matters in our cases, but having correct implementations is good anyways.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
