### PR TITLE
Fix off by one error for negative coordinates when using -r with //deform

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -3025,9 +3025,9 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
 
                 // transform
                 expression.evaluate(new double[]{scaled.getX(), scaled.getY(), scaled.getZ()}, timeout);
-                int xv = (int) (x.getValue() * unit.getX() + zero2.getX());
-                int yv = (int) (y.getValue() * unit.getY() + zero2.getY());
-                int zv = (int) (z.getValue() * unit.getZ() + zero2.getZ());
+                int xv = (int) Math.floor(x.getValue() * unit.getX() + zero2.getX());
+                int yv = (int) Math.floor(y.getValue() * unit.getY() + zero2.getY());
+                int zv = (int) Math.floor(z.getValue() * unit.getZ() + zero2.getZ());
 
                 BlockState get;
                 if (yv >= minY && yv <= maxY) {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2087.

## Description
<!-- Please describe what this pull request does. -->

The source of the bug was the rounding of coordinates after deform.
It came down to the differences of rounding negative doubles using casts `(int)` and rounding using `Math.floor()`

Example:
```
(int)( 1.8) = 1
(int)(-1.8) = -1
(int)Math.floor( 1.8) = 1
(int)Math.floor(-1.8) = -2
```

Looking at the original WorldEdit implementation, `Math.floor()` calls are present there too. They were missing in FAWE which resulted in the bug. So this PR simply adds them back in.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
