### PR TITLE
Fix reading block states in no redo mode

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
@@ -126,8 +126,6 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
 
                 @Override
                 public void readCombined(FaweInputStream in, MutableBlockChange change, boolean dir) throws IOException {
-                    int from1 = in.read();
-                    int from2 = in.read();
                     change.ordinal = in.readVarInt();
                 }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2118

## Description
<!-- Please describe what this pull request does. -->

Writing changes was not in sync with reading changes when using mode 1 or 2.
I assume that this code wasn't properly updated when updating to 1.13, but it remained unnoticed as likely no one set store-redo to false ever before.

I tested basic `//undo` operations in mode 1 and mode 2.

(old code <https://github.com/boy0001/FastAsyncWorldedit/blob/a693d23489da13f2a59fe31794abd9c74b4ac352/core/src/main/java/com/boydti/fawe/object/changeset/FaweStreamChangeSet.java#L127-L138>)

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
