### PR TITLE
Fix FAWE using exclusive build height from PlotSquared

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
@@ -158,8 +158,10 @@ public class PlotSquaredFeature extends FaweMaskManager {
 
         Region maskedRegion;
         if (regions.size() == 1) {
-            int min = area != null ? area.getMinBuildHeight() : player.getWorld().getMinY();
-            int max = area != null ? Math.min(player.getWorld().getMaxY(), area.getMaxBuildHeight()) : player.getWorld().getMaxY();
+            final World world = player.getWorld();
+            int min = area != null ? area.getMinBuildHeight() : world.getMinY();
+            // PlotSquared uses exclusive max height, WorldEdit uses inclusive max height -> subtract 1
+            int max = area != null ? Math.min(world.getMaxY(), area.getMaxBuildHeight() - 1) : world.getMaxY();
 
             final CuboidRegion region = regions.iterator().next();
             final BlockVector3 pos1 = BlockVector3.at(region.getMinimumX(), min, region.getMinimumZ());


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2120 

## Description
<!-- Please describe what this pull request does. -->

(FastAsync)WorldEdit uses inclusive heights maximums whereas PlotSquared uses exclusive values. Using the values provided by PlotSquared therefore requires a subtraction by one.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
