### PR TITLE
Use unsynchronized buffered OutputStream for history

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/io/FaweOutputStream.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/io/FaweOutputStream.java
@@ -20,6 +20,13 @@ public class FaweOutputStream extends DataOutputStream {
         return parent;
     }
 
+    // overwritten to un-synchronized
+    @Override
+    public void write(final int b) throws IOException {
+        out.write(b);
+        written++;
+    }
+
     public void write(int b, int amount) throws IOException {
         for (int i = 0; i < amount; i++) {
             write(b);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
@@ -273,6 +273,9 @@ public class MainUtil {
         return buffer;
     }
 
+    /**
+     * Note: The returned stream is not thread safe.
+     */
     public static FaweOutputStream getCompressedOS(OutputStream os, int amount, int buffer) throws IOException {
         os.write((byte) 10 + amount);
         os = new FastBufferedOutputStream(os, buffer);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import it.unimi.dsi.fastutil.io.FastBufferedInputStream;
+import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
 import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.lz4.LZ4BlockOutputStream;
 import net.jpountz.lz4.LZ4Compressor;
@@ -40,7 +41,6 @@ import javax.imageio.ImageIO;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -275,7 +275,7 @@ public class MainUtil {
 
     public static FaweOutputStream getCompressedOS(OutputStream os, int amount, int buffer) throws IOException {
         os.write((byte) 10 + amount);
-        os = new BufferedOutputStream(os, buffer);
+        os = new FastBufferedOutputStream(os, buffer);
         if (amount == 0) {
             return new FaweOutputStream(os);
         }
@@ -296,7 +296,7 @@ public class MainUtil {
                 os = new LZ4BlockOutputStream(os, buffer, factory.highCompressor());
             }
         }
-        os = new BufferedOutputStream(os, buffer);
+        os = new FastBufferedOutputStream(os, buffer);
         return new FaweOutputStream(os);
     }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`BufferedOutputStream` has a fair amount of overhead as it's thread safe. However, we don't require thread safety here, so we can use an alternative implementation from fastutil which performs better. In my tests, the time spent writing history is halved.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
