### PR TITLE
Simplify command dispatch to ensure command order

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformCommandManager.java
@@ -678,31 +678,26 @@ public final class PlatformCommandManager {
 
         Actor actor = event.getActor();
         String args = event.getArguments();
-        TaskManager.taskManager().taskNow(() -> {
-            if (!Fawe.isMainThread()) {
-                Thread.currentThread().setName("FAWE Thread for player: " + actor.getName());
+        int space0 = args.indexOf(' ');
+        String arg0 = space0 == -1 ? args : args.substring(0, space0);
+        Optional<Command> optional = commandManager.getCommand(arg0);
+        if (optional.isEmpty()) {
+            return;
+        }
+        Command cmd = optional.get();
+        PermissionCondition queued = cmd.getCondition().as(PermissionCondition.class).orElse(null);
+        if (queued != null && !queued.isQueued()) {
+            TaskManager.taskManager().taskNow(() -> handleCommandOnCurrentThread(event), Fawe.isMainThread());
+            return;
+        } else {
+            actor.decline();
+        }
+        actor.runAction(() -> {
+            SessionKey key = actor.getSessionKey();
+            if (key.isActive()) {
+                PlatformCommandManager.this.handleCommandOnCurrentThread(event);
             }
-            int space0 = args.indexOf(' ');
-            String arg0 = space0 == -1 ? args : args.substring(0, space0);
-            Optional<Command> optional = commandManager.getCommand(arg0);
-            if (!optional.isPresent()) {
-                return;
-            }
-            Command cmd = optional.get();
-            PermissionCondition queued = cmd.getCondition().as(PermissionCondition.class).orElse(null);
-            if (queued != null && !queued.isQueued()) {
-                handleCommandOnCurrentThread(event);
-                return;
-            } else {
-                actor.decline();
-            }
-            actor.runAction(() -> {
-                SessionKey key = actor.getSessionKey();
-                if (key.isActive()) {
-                    PlatformCommandManager.this.handleCommandOnCurrentThread(event);
-                }
-            }, false, true);
-        }, Fawe.isMainThread());
+        }, false, true);
     }
 
     public void handleCommandOnCurrentThread(CommandEvent event) {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2130

I suspect #1928 was the same problem.

## Description
<!-- Please describe what this pull request does. -->

Before, FAWE submitted a task to the CraftScheduler just to actually handle it on a FAWE thread pool anyways. We can simplify that by skipping the first thread switch.

For commands that skip the queue, we still use the old behavior of submitting a task to the CraftScheduler.

I also removed the thread renaming part. It was pretty much useless this way, so I don't see any benefit in keeping it.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
