### PR TITLE
Allow edits inside of allowed region when executing outside of region.

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/GriefDefenderFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/GriefDefenderFeature.java
@@ -8,6 +8,7 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.util.Location;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -27,9 +28,10 @@ public class GriefDefenderFeature extends BukkitMaskManager implements Listener 
     }
 
     @Override
-    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, MaskType type, boolean isWhitelist) {
+    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, Location position, MaskType type,
+                            boolean isWhitelist) {
         final Player player = BukkitAdapter.adapt(wePlayer);
-        Claim claim = GriefDefender.getCore().getClaimAt(player.getLocation());
+        Claim claim = GriefDefender.getCore().getClaimAt(BukkitAdapter.adapt(position));
         if (claim != null && !claim.isWilderness()) {
             if (isAllowed(player, claim, type)) {
                 final BlockVector3 pos1 = BlockVector3.at(

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/GriefPreventionFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/GriefPreventionFeature.java
@@ -2,13 +2,11 @@ package com.fastasyncworldedit.bukkit.regions;
 
 import com.fastasyncworldedit.core.regions.FaweMask;
 import com.fastasyncworldedit.core.util.TaskManager;
-import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldedit.bukkit.BukkitWorld;
-import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.util.Location;
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import org.apache.logging.log4j.Logger;
@@ -34,9 +32,12 @@ public class GriefPreventionFeature extends BukkitMaskManager implements Listene
     }
 
     @Override
-    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, MaskType type, boolean isWhitelist) {
+    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, Location position, MaskType type,
+                            boolean isWhitelist) {
         final Player player = BukkitAdapter.adapt(wePlayer);
-        final Claim claim = GriefPrevention.instance.dataStore.getClaimAt(player.getLocation(), true, null);
+        final Claim claim = GriefPrevention.instance.dataStore.getClaimAt(
+                BukkitAdapter.adapt(position), true, null
+        );
         if (claim != null) {
             if (isAllowed(player, claim, type)) {
                 claim.getGreaterBoundaryCorner().getBlockX();

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/ResidenceFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/ResidenceFeature.java
@@ -39,9 +39,10 @@ public class ResidenceFeature extends BukkitMaskManager implements Listener {
     }
 
     @Override
-    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, final MaskType type, boolean isWhitelist) {
+    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, com.sk89q.worldedit.util.Location position, final MaskType type,
+                            boolean isWhitelist) {
         final Player player = BukkitAdapter.adapt(wePlayer);
-        final Location location = player.getLocation();
+        final Location location = BukkitAdapter.adapt(position);
         ClaimedResidence residence = Residence.getInstance().getResidenceManager().getByLoc(location);
         if (residence != null) {
             boolean isAllowed;

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
@@ -66,9 +66,11 @@ public class TownyFeature extends BukkitMaskManager implements Listener {
     }
 
     @Override
-    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer, MaskType type, boolean isWhitelist) {
+    public FaweMask getMask(final com.sk89q.worldedit.entity.Player wePlayer,
+                            com.sk89q.worldedit.util.Location position, MaskType type,
+                            boolean isWhitelist) {
         final Player player = BukkitAdapter.adapt(wePlayer);
-        final Location location = player.getLocation();
+        final Location location = BukkitAdapter.adapt(position);
         try {
             final PlayerCache cache = ((Towny) this.towny).getCache(player);
             final WorldCoord mycoord = cache.getLastTownBlock();

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/WorldGuardFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/WorldGuardFeature.java
@@ -157,10 +157,11 @@ public class WorldGuardFeature extends BukkitMaskManager implements Listener {
     }
 
     @Override
-    public FaweMask getMask(com.sk89q.worldedit.entity.Player wePlayer, MaskType type, boolean isWhitelist) {
+    public FaweMask getMask(com.sk89q.worldedit.entity.Player wePlayer, com.sk89q.worldedit.util.Location position, MaskType type,
+                            boolean isWhitelist) {
         final Player player = BukkitAdapter.adapt(wePlayer);
         final LocalPlayer localplayer = this.worldguard.wrapPlayer(player);
-        final Location location = player.getLocation();
+        final Location location = BukkitAdapter.adapt(position);
         final Set<ProtectedRegion> regions = this.getRegions(localplayer, location, isWhitelist);
         if (!regions.isEmpty()) {
             Set<Region> result = new HashSet<>();

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
@@ -19,6 +19,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionIntersection;
+import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.World;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
@@ -127,13 +128,17 @@ public class PlotSquaredFeature extends FaweMaskManager {
     }
 
     @Override
-    public FaweMask getMask(Player player, MaskType type, boolean isWhitelist) {
+    public FaweMask getMask(Player player, Location position, MaskType type, boolean isWhitelist) {
         final PlotPlayer<org.bukkit.entity.Player> pp = PlotPlayer.from(BukkitAdapter.adapt(player));
         if (pp == null) {
             return null;
         }
         final Set<CuboidRegion> regions;
-        Plot plot = pp.getCurrentPlot();
+        // We assume the current players world as the used world - the Location does not contain the world itself
+        Plot plot = com.plotsquared.core.location.Location.at(
+                player.getWorld().getName(),
+                position.toBlockPoint()
+        ).getPlot();
         if (isAllowed(player, plot, type)) {
             regions = plot.getRegions();
         } else {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/regions/FaweMaskManager.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/regions/FaweMaskManager.java
@@ -1,8 +1,8 @@
 package com.fastasyncworldedit.core.regions;
 
 import com.fastasyncworldedit.core.configuration.Settings;
-import com.fastasyncworldedit.core.regions.filter.RegionFilter;
 import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.util.Location;
 
 import java.util.Locale;
 
@@ -26,7 +26,16 @@ public abstract class FaweMaskManager {
     /**
      * Get a {@link FaweMask} for the given player and {@link MaskType}. If isWhitelist is false, will return a "blacklist" mask.
      */
-    public abstract FaweMask getMask(final Player player, MaskType type, boolean isWhitelist);
+    public FaweMask getMask(final Player player, MaskType type, boolean isWhitelist) {
+        return getMask(player, player.getLocation(), type, isWhitelist);
+    }
+
+    /**
+     * Get a {@link FaweMask} for the given player at a given position (e.g. for Brushes)
+     *
+     * @see #getMask(Player, MaskType, boolean)
+     */
+    public abstract FaweMask getMask(final Player player, Location position, MaskType type, boolean isWhitelist);
 
     public boolean isExclusive() {
         return Settings.settings().REGION_RESTRICTIONS_OPTIONS.EXCLUSIVE_MANAGERS.contains(this.key);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/WEManager.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/WEManager.java
@@ -97,10 +97,23 @@ public class WEManager {
      * @return array of allowed regions if whitelist, else of disallowed regions.
      */
     public Region[] getMask(Player player, FaweMaskManager.MaskType type, final boolean isWhitelist) {
+        return getMask(player, player.getLocation(), type, isWhitelist);
+    }
+
+    /**
+     * Get a player's mask.
+     *
+     * @param player      Player to get mask of
+     * @param position    The position to check for firstly (differs from players position for brushes e.g.)
+     * @param type        Mask type; whether to check if the player is an owner of a member of the regions
+     * @param isWhitelist If searching for whitelist or blacklist regions. True if whitelist
+     * @return array of allowed regions if whitelist, else of disallowed regions.
+     * @since TODO
+     */
+    public Region[] getMask(Player player, Location position, FaweMaskManager.MaskType type, final boolean isWhitelist) {
         if (!Settings.settings().REGION_RESTRICTIONS || player.hasPermission("fawe.bypass.regions")) {
             return new Region[]{RegionWrapper.GLOBAL()};
         }
-        Location loc = player.getLocation();
         String world = player.getWorld().getName();
         if (!world.equals(player.getMeta("lastMaskWorld"))) {
             player.deleteMeta("lastMaskWorld");
@@ -123,7 +136,7 @@ public class WEManager {
                         FaweMask mask = iterator.next();
                         if (mask.isValid(player, type)) {
                             Region region = mask.getRegion();
-                            if (region.contains(loc.toBlockPoint())) {
+                            if (region.contains(position.toBlockPoint())) {
                                 regions.add(region);
                             } else {
                                 removed = true;
@@ -148,7 +161,8 @@ public class WEManager {
                     if (manager.isExclusive() && !masks.isEmpty()) {
                         continue;
                     }
-                    final FaweMask mask = manager.getMask(player, FaweMaskManager.MaskType.getDefaultMaskType(), isWhitelist);
+                    final FaweMask mask = manager.getMask(player, position, FaweMaskManager.MaskType.getDefaultMaskType(),
+                            isWhitelist);
                     if (mask != null) {
                         regions.add(mask.getRegion());
                         masks.add(mask);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
@@ -64,6 +64,7 @@ import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.Identifiable;
+import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.eventbus.EventBus;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.world.World;
@@ -111,6 +112,9 @@ public final class EditSessionBuilder {
     @Nullable
     private BlockBag blockBag;
     private boolean tracing;
+
+    @Nullable
+    private Location basePosition;
 
     EditSessionBuilder(EventBus eventBus) {
         this.eventBus = eventBus;
@@ -413,6 +417,20 @@ public final class EditSessionBuilder {
         return setDirty();
     }
 
+    @Nullable
+    public Location basePosition() {
+        return basePosition;
+    }
+
+    /**
+     * Set's the base position for the current EditSession, which is required for calculating affected regions by this session
+     * (useful for remote actions, like brushes)
+     */
+    public EditSessionBuilder basePosition(@Nullable final Location basePosition) {
+        this.basePosition = basePosition;
+        return setDirty();
+    }
+
     /**
      * Compile the builder to the settings given. Prepares history, limits, lighting, etc.
      */
@@ -533,7 +551,7 @@ public final class EditSessionBuilder {
                 if (actor != null && !actor.hasPermission("fawe.bypass.regions")) {
                     if (actor instanceof Player) {
                         Player player = (Player) actor;
-                        allowedRegions = player.getAllowedRegions();
+                        allowedRegions = this.basePosition != null ? player.getAllowedRegions(this.basePosition) : player.getAllowedRegions();
                     }
                 }
             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -67,6 +67,7 @@ import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.util.Countable;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.Identifiable;
+import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.util.SideEffectSet;
 import com.sk89q.worldedit.util.nbt.CompoundBinaryTag;
 import com.sk89q.worldedit.world.World;
@@ -1627,7 +1628,7 @@ public class LocalSession implements TextureHolder {
         return createEditSession(actor, null);
     }
 
-    public EditSession createEditSession(Actor actor, String command) {
+    public EditSession createPositionedEditSession(Actor actor, String command, @Nullable Location position) {
         checkNotNull(actor);
 
         World world = null;
@@ -1649,6 +1650,10 @@ public class LocalSession implements TextureHolder {
         builder.command(command);
         builder.fastMode(!this.sideEffectSet.doesApplyAny());
 
+        if (position != null) {
+            builder.basePosition(position);
+        }
+
         editSession = builder.build();
 
         if (mask != null) {
@@ -1663,6 +1668,10 @@ public class LocalSession implements TextureHolder {
         editSession.setTickingWatchdog(tickingWatchdog);
 
         return editSession;
+    }
+
+    public EditSession createEditSession(Actor actor, String command) {
+        return createPositionedEditSession(actor, command, null);
     }
     //FAWE end
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BrushTool.java
@@ -439,9 +439,9 @@ public class BrushTool
             player.print(
                     Caption.of("fawe.error.no-perm", StringMan.join(current.getPermissions(), ",")));
             return false;
-        }
-        try (EditSession editSession = session.createEditSession(player, current.toString())) {
-            Location target = player.getBlockTrace(getRange(), true, traceMask);
+
+        }Location target = player.getBlockTrace(getRange(), true, traceMask);
+        try (EditSession editSession = session.createPositionedEditSession(player, current.toString(), target)) {
 
             if (target == null) {
                 editSession.cancel();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/entity/Player.java
@@ -356,12 +356,29 @@ public interface Player extends Entity, Actor {
     Region[] getAllowedRegions();
 
     /**
+     * Get the player's current allowed WorldEdit regions intersecting the passed {@link Location} instead of the players
+     * location itself.
+     * @param position The alternative position to use.
+     * @return an array of allowed regions
+     */
+    Region[] getAllowedRegions(Location position);
+
+    /**
      * Get the player's current allowed WorldEdit regions.
      *
      * @param type Mask type; whether to check if the player is an owner of a member of the regions
      * @return an array of allowed regions
      */
     Region[] getAllowedRegions(FaweMaskManager.MaskType type);
+
+    /**
+     * Get the player's current allowed WorldEdit regions intersecting the passed {@link Location} instead of the players
+     * location itself.
+     * @param position The alternative position to use.
+     * @param type Mask type; whether to check if the player is an owner of a member of the regions
+     * @return an array of allowed regions
+     */
+    Region[] getAllowedRegions(Location position, FaweMaskManager.MaskType type);
 
     /**
      * Get the player's current disallowed WorldEdit regions. Effectively a blacklist.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -490,8 +490,18 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
     }
 
     @Override
+    public Region[] getAllowedRegions(Location position) {
+        return this.getAllowedRegions(position, FaweMaskManager.MaskType.getDefaultMaskType());
+    }
+
+    @Override
     public Region[] getAllowedRegions(FaweMaskManager.MaskType type) {
         return WEManager.weManager().getMask(this, type, true);
+    }
+
+    @Override
+    public Region[] getAllowedRegions(Location position, FaweMaskManager.MaskType type) {
+        return WEManager.weManager().getMask(this, position, type, true);
     }
 
     @Override


### PR DESCRIPTION
## Overview

Fixes #2137

## Description

Allows to pass a custom base location to the EditSessionBuilder and various Mask-methods to determine the allowed regions for remote tools like brushes, which should not be based on the player location itself but the target location.

Pending:
- [ ] Blacklisted Regions
- [ ] How should //set / //replace operations be handled, if the command is executed outside the selected region (the selection intersects with an allowed region, but the players stands in a forbidden region -> fails)

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
