### PR TITLE
Bump run paper to 1.19.3 and replace path with better solution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,8 +85,9 @@ applyCommonConfiguration()
 
 tasks {
     runServer {
-        minecraftVersion("1.19")
-        pluginJars(project(":worldedit-bukkit").file("build/libs/FastAsyncWorldEdit-Bukkit-$version.jar"))
+        minecraftVersion("1.19.3")
+        pluginJars(*project(":worldedit-bukkit").getTasksByName("shadowJar", false).map { (it as Jar).archiveFile }
+                .toTypedArray())
 
     }
 }


### PR DESCRIPTION
## Overview
Currently FAWE use for run paper 1.19 and a "static" path for get the jar file. In some cases that is not working.

## Description
I replaced the old way to get the jar after shadow with a better one that selects in many cases the jar for out of the box running/debugging.
## Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
