### PR TITLE
fix: invalidate cached FaweMask when a plot is unlinked

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
@@ -23,6 +23,7 @@ import com.sk89q.worldedit.world.World;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -179,20 +180,20 @@ public class PlotSquaredFeature extends FaweMaskManager {
         return new PlotSquaredMask(maskedRegion, finalPlot);
     }
 
-    private final class  PlotSquaredMask extends FaweMask {
+    private final class PlotSquaredMask extends FaweMask {
 
         private final Plot plot;
-        private final int hash;
+        private final WeakReference<Set<Plot>> connectedPlots;
 
         private PlotSquaredMask(Region region, Plot plot) {
             super(region);
             this.plot = plot;
-            hash = plot.getConnectedPlots().hashCode();
+            connectedPlots = new WeakReference<>(plot.getConnectedPlots());
         }
 
         @Override
         public boolean isValid(Player player, MaskType type) {
-            if (plot.getConnectedPlots().hashCode() != hash Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
+            if (!connectedPlots.refersTo(plot.getConnectedPlots()) || (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot))) {
                 return false;
             }
             return isAllowed(player, plot, type);

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
@@ -176,15 +176,28 @@ public class PlotSquaredFeature extends FaweMaskManager {
             maskedRegion = new RegionIntersection(world, weRegions);
         }
 
-        return new FaweMask(maskedRegion) {
-            @Override
-            public boolean isValid(Player player, MaskType type) {
-                if (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(finalPlot)) {
-                    return false;
-                }
-                return isAllowed(player, finalPlot, type);
+        return new PlotSquaredMask(maskedRegion, finalPlot);
+    }
+
+    private final class  PlotSquaredMask extends FaweMask {
+
+        private final Plot plot;
+        private final int hash;
+
+        private PlotSquaredMask(Region region, Plot plot) {
+            super(region);
+            this.plot = plot;
+            hash = plot.getConnectedPlots().hashCode();
+        }
+
+        @Override
+        public boolean isValid(Player player, MaskType type) {
+            if (plot.getConnectedPlots().hashCode() != hash Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot)) {
+                return false;
             }
-        };
+            return isAllowed(player, plot, type);
+        }
+
     }
 
 }


### PR DESCRIPTION
 - Fixes IntellectualSites/PlotSquared#3998
