### PR TITLE
fix: Ensure BaseBlock is not returned when a BlockState is wanted in BlockTransformExtent (#2161

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/transform/BlockTransformExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/transform/BlockTransformExtent.java
@@ -555,10 +555,11 @@ public class BlockTransformExtent extends ResettableExtent {
 
         int transformedId = transformState(state, transform);
         BlockState transformed = BlockState.getFromInternalId(transformedId);
-        if (block.hasNbtData()) {
+        boolean baseBlock = block instanceof BaseBlock;
+        if (baseBlock && block.hasNbtData()) {
             return (B) transformBaseBlockNBT(transformed, block.getNbtData(), transform);
         }
-        return (B) (block instanceof BaseBlock ? transformed.toBaseBlock() : transformed);
+        return (B) (baseBlock? transformed.toBaseBlock() : transformed);
         //FAWE end
     }
 


### PR DESCRIPTION
 -  NBT will be handled appropriately at another point
 - Tested 😮
 - Fixes #2085