### PR TITLE
Update paperweight version for 1.19.4

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_19_4/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/build.gradle.kts
@@ -9,6 +9,6 @@ repositories {
 }
 
 dependencies {
-    paperDevBundle("1.19.4-R0.1-20230317.182750-6")
+    paperDevBundle("1.19.4-R0.1-20230331.112431-38")
     compileOnly("io.papermc:paperlib")
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2d08187</samp>

### Summary
📦🆙🚀

<!--
1.  📦 - This emoji can be used to indicate a dependency update, as it suggests a package or bundle of software.
2.  🆙 - This emoji can be used to indicate an upgrade or improvement, as it suggests moving up to a higher level or quality.
3.  🚀 - This emoji can be used to indicate a performance boost or enhancement, as it suggests launching or speeding up something.
-->
Updated the `paperDevBundle` dependency for the `adapter-1_19_4` module to the latest Paper version. This improves compatibility and performance with the 1.19.4 Minecraft server.

> _`paperDevBundle`_
> _Updated to latest Paper_
> _Winter of fixes_

### Walkthrough
* Update the paperDevBundle dependency to the latest version of Paper for 1.19.4 ([link](https://github.com/IntellectualSites/FastAsyncWorldEdit/pull/2166/files?diff=unified&w=0#diff-90a95e0e16de7665eb22aa2d2d5826beb8f6bc8cfc0ed06f0c35d5f6b9423139L12-R12))

