### PR TITLE
Fix wrong bit flipping of FAST_PLACEMENT limit for fawe

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -152,7 +152,7 @@ public class Settings extends Config {
                 );
                 limit.INVENTORY_MODE = Math.min(limit.INVENTORY_MODE, newLimit.INVENTORY_MODE);
                 limit.SPEED_REDUCTION = Math.min(limit.SPEED_REDUCTION, newLimit.SPEED_REDUCTION);
-                limit.FAST_PLACEMENT |= newLimit.FAST_PLACEMENT;
+                limit.FAST_PLACEMENT &= newLimit.FAST_PLACEMENT;
                 limit.CONFIRM_LARGE &= newLimit.CONFIRM_LARGE;
                 limit.RESTRICT_HISTORY_TO_REGIONS &= newLimit.RESTRICT_HISTORY_TO_REGIONS;
                 if (limit.STRIP_NBT == null) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -152,7 +152,7 @@ public class Settings extends Config {
                 );
                 limit.INVENTORY_MODE = Math.min(limit.INVENTORY_MODE, newLimit.INVENTORY_MODE);
                 limit.SPEED_REDUCTION = Math.min(limit.SPEED_REDUCTION, newLimit.SPEED_REDUCTION);
-                limit.FAST_PLACEMENT &= newLimit.FAST_PLACEMENT;
+                limit.FAST_PLACEMENT |= newLimit.FAST_PLACEMENT;
                 limit.CONFIRM_LARGE &= newLimit.CONFIRM_LARGE;
                 limit.RESTRICT_HISTORY_TO_REGIONS &= newLimit.RESTRICT_HISTORY_TO_REGIONS;
                 if (limit.STRIP_NBT == null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
@@ -461,7 +461,7 @@ public final class EditSessionBuilder {
         if (extent == null) {
             IQueueExtent<IQueueChunk> queue = null;
             World unwrapped = WorldWrapper.unwrap(world);
-            boolean placeChunks = (this.fastMode || this.limit.FAST_PLACEMENT) && (wnaMode == null || !wnaMode);
+            boolean placeChunks = (this.fastMode && this.limit.FAST_PLACEMENT) && (wnaMode == null || !wnaMode);
 
             if (placeChunks) {
                 wnaMode = false;


### PR DESCRIPTION
## Overview
Fixes #2121 

## Description
In both cases when `FAST_PLACEMENT` is true or false in the config. The boolean will never be false. Of this and fastmode is the cause while every time place chunks in [EditSessionBuilder.compile()](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/da4d966d9e54873ad4b255dce4729fce0739c002/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java#L464) will be triggered.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
