### PR TITLE
Address incompatibilities after CraftChunk changes in spigot

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_19_4/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/build.gradle.kts
@@ -9,6 +9,6 @@ repositories {
 }
 
 dependencies {
-    paperDevBundle("1.19.4-R0.1-20230331.112431-38")
+    paperDevBundle("1.19.4-R0.1-20230412.010331-64")
     compileOnly("io.papermc:paperlib")
 }

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightFaweAdapter.java
@@ -306,54 +306,6 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
         return SideEffectSet.defaults().getSideEffectsToApply();
     }
 
-    public boolean setBlock(org.bukkit.Chunk chunk, int x, int y, int z, BlockStateHolder state, boolean update) {
-        CraftChunk craftChunk = (CraftChunk) chunk;
-        LevelChunk levelChunk = craftChunk.getHandle();
-        Level level = levelChunk.getLevel();
-
-        BlockPos blockPos = new BlockPos(x, y, z);
-        net.minecraft.world.level.block.state.BlockState blockState = ((PaperweightBlockMaterial) state.getMaterial()).getState();
-        LevelChunkSection[] levelChunkSections = levelChunk.getSections();
-        int y4 = y >> 4;
-        LevelChunkSection section = levelChunkSections[y4];
-
-        net.minecraft.world.level.block.state.BlockState existing;
-        if (section == null) {
-            existing = ((PaperweightBlockMaterial) BlockTypes.AIR.getDefaultState().getMaterial()).getState();
-        } else {
-            existing = section.getBlockState(x & 15, y & 15, z & 15);
-        }
-
-        levelChunk.removeBlockEntity(blockPos); // Force delete the old tile entity
-
-        CompoundBinaryTag compoundTag = state instanceof BaseBlock ? state.getNbt() : null;
-        if (compoundTag != null || existing instanceof TileEntityBlock) {
-            level.setBlock(blockPos, blockState, 0);
-            // remove tile
-            if (compoundTag != null) {
-                // We will assume that the tile entity was created for us,
-                // though we do not do this on the Forge version
-                BlockEntity blockEntity = level.getBlockEntity(blockPos);
-                if (blockEntity != null) {
-                    net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) fromNativeBinary(compoundTag);
-                    tag.put("x", IntTag.valueOf(x));
-                    tag.put("y", IntTag.valueOf(y));
-                    tag.put("z", IntTag.valueOf(z));
-                    blockEntity.load(tag); // readTagIntoTileEntity - load data
-                }
-            }
-        } else {
-            if (existing == blockState) {
-                return true;
-            }
-            levelChunk.setBlockState(blockPos, blockState, false);
-        }
-        if (update) {
-            level.getMinecraftWorld().sendBlockUpdated(blockPos, existing, blockState, 0);
-        }
-        return true;
-    }
-
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(org.bukkit.World world) {
         return new PaperweightFaweWorldNativeAccess(

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightFaweWorldNativeAccess.java
@@ -102,7 +102,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
         }
         // Since FAWE is.. Async we need to do it on the main thread (wooooo.. :( )
         cachedChanges.add(new CachedChange(levelChunk, blockPos, blockState));
-        cachedChunksToSend.add(new IntPair(levelChunk.bukkitChunk.getX(), levelChunk.bukkitChunk.getZ()));
+        cachedChunksToSend.add(new IntPair(levelChunk.locX, levelChunk.locZ));
         boolean nextTick = lastTick.get() > currentTick;
         if (nextTick || cachedChanges.size() >= 1024) {
             if (nextTick) {

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/regen/PaperweightRegen.java
@@ -60,6 +60,7 @@ import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.PrimaryLevelData;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.craftbukkit.v1_19_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R3.generator.CustomChunkGenerator;
@@ -440,7 +441,11 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
     @Override
     protected void populate(LevelChunk levelChunk, Random random, BlockPopulator blockPopulator) {
         // BlockPopulator#populate has to be called synchronously for TileEntity access
-        TaskManager.taskManager().task(() -> blockPopulator.populate(freshWorld.getWorld(), random, levelChunk.getBukkitChunk()));
+        TaskManager.taskManager().task(() -> {
+            final CraftWorld world = freshWorld.getWorld();
+            final Chunk chunk = world.getChunkAt(levelChunk.locX, levelChunk.locZ);
+            blockPopulator.populate(world, random, chunk);
+        });
     }
 
     @Override


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2175

## Description
<!-- Please describe what this pull request does. -->

This updates the paper dev bundle for 1.19.4 and addresses the changes to how CraftChunk is used. I also removed a method that was marked as unused which was based on the old CraftChunk#getHandle method.
To avoid unnecessary compatibility issues, we're using a MethodHandle which is selected based on the available methods.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
