### PR TITLE
Ensure regen step not running on the main thread

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/Regenerator.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/Regenerator.java
@@ -253,10 +253,13 @@ public abstract class Regenerator<IChunkAccess, ProtoChunk extends IChunkAccess,
                     e.printStackTrace();
                 }
             } else { // Concurrency.NONE or generateConcurrent == false
-                // run sequential
-                for (long xz : coords) {
-                    chunkStatus.processChunkSave(xz, worldlimits.get(radius).get(xz));
-                }
+                // run sequential but submit to different thread
+                // running regen on the main thread otherwise triggers async-only events on the main thread
+                executor.submit(() -> {
+                    for (long xz : coords) {
+                        chunkStatus.processChunkSave(xz, worldlimits.get(radius).get(xz));
+                    }
+                }).get(); // wait until finished this step
             }
         }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2178

## Description
<!-- Please describe what this pull request does. -->

Plugins might call the regen code synchronously, in which case we still need to make sure worldgen is run on a different thread, as there are events triggered which require to be called asynchronously.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
