### PR TITLE
Remove weak reference and replace with a simple not equal

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/PlotSquaredFeature.java
@@ -23,7 +23,6 @@ import com.sk89q.worldedit.world.World;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 
-import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -183,17 +182,17 @@ public class PlotSquaredFeature extends FaweMaskManager {
     private final class PlotSquaredMask extends FaweMask {
 
         private final Plot plot;
-        private final WeakReference<Set<Plot>> connectedPlots;
+        private final Set<Plot> connectedPlots;
 
         private PlotSquaredMask(Region region, Plot plot) {
             super(region);
             this.plot = plot;
-            connectedPlots = new WeakReference<>(plot.getConnectedPlots());
+            connectedPlots = plot.getConnectedPlots();
         }
 
         @Override
         public boolean isValid(Player player, MaskType type) {
-            if (!connectedPlots.refersTo(plot.getConnectedPlots()) || (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot))) {
+            if (connectedPlots != plot.getConnectedPlots() || (Settings.Done.RESTRICT_BUILDING && DoneFlag.isDone(plot))) {
                 return false;
             }
             return isAllowed(player, plot, type);


### PR DESCRIPTION
## Overview
Fixes #2188 

## Description
Since 2.6.1 added some issue for plot squared mask with unlinked plot mask. Now without weak reference the code work again as expected.
Side information. I tested it locally

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
