### PR TITLE
Properly scale the random in SimpleRandomCollection

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/collection/SimpleRandomCollection.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/collection/SimpleRandomCollection.java
@@ -36,7 +36,7 @@ public class SimpleRandomCollection<E> extends RandomCollection<E> {
 
     @Override
     public E next(int x, int y, int z) {
-        return map.ceilingEntry(getRandom().nextDouble(x, y, z)).getValue();
+        return map.ceilingEntry(getRandom().nextDouble(x, y, z) * this.total).getValue();
     }
 
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2219

## Description
<!-- Please describe what this pull request does. -->

SimpleRandomCollection always selected an entry in the range `[0, 1)`. This is wrong however, as it has to scale to `[0, total)`.
This problem likely wasn't discovered before because most uses of the random pattern make use of `FastRandomCollection` instead.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
