### PR TITLE
Simplify Java location in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,14 +4,13 @@ pipeline {
         disableConcurrentBuilds()
     }
     stages {
-        stage('Set JDK 17') {
-            steps {
-                tool name: 'Temurin-17.0.6+10', type: 'jdk'
-            }
-        }
         stage('Build') {
             steps {
-                sh './gradlew clean build'
+                withEnv([
+                        "PATH+JAVA=${tool 'Temurin-17.0.6+10'}/bin"
+                ]) {
+                    sh './gradlew clean build'
+                }
             }
         }
         stage('Archive artifacts') {


### PR DESCRIPTION
Simplifies the existing logic by relying on env vars, rather of iterating over the tool list.