### PR TITLE
Avoid many threads blocking on AbstractChangeSet#processSet

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -31,6 +31,8 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
+import jdk.jfr.Category;
+import jdk.jfr.Event;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
@@ -39,19 +41,26 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * This batch processor writes changes to a concrete implementation.
+ * {@link #processSet(IChunk, IChunkGet, IChunkSet)} is synchronized to guarantee consistency.
+ * To avoid many blocking threads on this method, changes are enqueued in {@link #queue}.
+ * This allows to keep other threads free for other work.
+ */
 public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private final World world;
     private final AtomicInteger lastException = new AtomicInteger();
-    protected AtomicInteger waitingCombined = new AtomicInteger(0);
-    protected AtomicInteger waitingAsync = new AtomicInteger(0);
-
-    protected boolean closed;
+    private final AtomicInteger workers = new AtomicInteger(); // int as drainQueue(true) allows multiple workers
+    private final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
+    protected volatile boolean closed;
 
     public AbstractChangeSet(World world) {
         this.world = world;
@@ -62,19 +71,21 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     }
 
     public void closeAsync() {
+        @Category("FAWE")
+        class CloseCall extends Event {
+            public boolean closed;
+        }
+        final CloseCall closeCall = new CloseCall();
+        closeCall.closed = closed;
+        closeCall.commit();
         if (closed) {
             return;
         }
-        waitingAsync.incrementAndGet();
         TaskManager.taskManager().async(() -> {
-            waitingAsync.decrementAndGet();
-            synchronized (waitingAsync) {
-                waitingAsync.notifyAll();
-            }
             try {
                 close();
             } catch (IOException e) {
-                e.printStackTrace();
+                LOGGER.catching(e);
             }
         });
     }
@@ -82,20 +93,10 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     @Override
     public void flush() {
         try {
-            if (!Fawe.isMainThread()) {
-                while (waitingAsync.get() > 0) {
-                    synchronized (waitingAsync) {
-                        waitingAsync.wait(1000);
-                    }
-                }
-            }
-            while (waitingCombined.get() > 0) {
-                synchronized (waitingCombined) {
-                    waitingCombined.wait(1000);
-                }
-            }
-        } catch (InterruptedException e) {
-            e.printStackTrace();
+            // drain with this thread too
+            drainQueue(true);
+        } catch (Exception e) {
+            LOGGER.catching(e);
         }
     }
 
@@ -125,7 +126,7 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     }
 
     @Override
-    public synchronized IChunkSet processSet(IChunk chunk, IChunkGet get, IChunkSet set) {
+    public final synchronized IChunkSet processSet(IChunk chunk, IChunkGet get, IChunkSet set) {
         int bx = chunk.getX() << 4;
         int bz = chunk.getZ() << 4;
 
@@ -306,12 +307,12 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
             BaseBlock to = change.getCurrent();
             add(loc, from, to);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.catching(e);
         }
     }
 
     public boolean isEmpty() {
-        return waitingCombined.get() == 0 && waitingAsync.get() == 0 && size() == 0;
+        return queue.isEmpty() && workers.get() == 0 && size() == 0;
     }
 
     public void add(BlockVector3 loc, BaseBlock from, BaseBlock to) {
@@ -353,7 +354,7 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
             add(x, y, z, combinedFrom, combinedTo);
 
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.catching(e);
         }
     }
 
@@ -362,7 +363,6 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     }
 
     public Future<?> addWriteTask(final Runnable writeTask, final boolean completeNow) {
-        AbstractChangeSet.this.waitingCombined.incrementAndGet();
         Runnable wrappedTask = () -> {
             try {
                 writeTask.run();
@@ -372,25 +372,57 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
                 } else {
                     int hash = t.getMessage().hashCode();
                     if (lastException.getAndSet(hash) != hash) {
-                        t.printStackTrace();
-                    }
-                }
-            } finally {
-                if (AbstractChangeSet.this.waitingCombined.decrementAndGet() <= 0) {
-                    synchronized (AbstractChangeSet.this.waitingAsync) {
-                        AbstractChangeSet.this.waitingAsync.notifyAll();
-                    }
-                    synchronized (AbstractChangeSet.this.waitingCombined) {
-                        AbstractChangeSet.this.waitingCombined.notifyAll();
+                        LOGGER.catching(t);
                     }
                 }
             }
         };
         if (completeNow) {
             wrappedTask.run();
-            return Futures.immediateCancelledFuture();
+            return Futures.immediateVoidFuture();
         } else {
-            return Fawe.instance().getQueueHandler().submit(wrappedTask);
+            CompletableFuture<?> task = new CompletableFuture<>();
+            queue.add(() -> {
+                wrappedTask.run();
+                task.complete(null);
+            });
+            // make sure changes are processed
+            triggerWorker();
+            return task;
+        }
+    }
+
+    private void triggerWorker() {
+        if (workers.get() > 0) {
+            return; // fast path to avoid additional tasks: a worker is already draining the queue
+        }
+        // create a new worker to drain the current queue
+        Fawe.instance().getQueueHandler().submit(() -> drainQueue(false));
+    }
+
+    private void drainQueue(boolean ignoreRunningState) {
+        if (!ignoreRunningState) {
+            if (!workers.compareAndSet(0, 1)) {
+                return; // already running on other thread or we WANT blocking behavior
+            }
+            workers.incrementAndGet(); // count this additional worker
+        }
+        @Category("FAWE")
+        class DrainQueue extends Event {
+
+        }
+        final DrainQueue drainQueue = new DrainQueue();
+        try {
+            while (true) {
+                var next = queue.poll();
+                if (next == null) {
+                    return; // drained
+                }
+                next.run();
+            }
+        } finally {
+            workers.decrementAndGet();
+            drainQueue.commit();
         }
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -407,11 +407,8 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
             }
         }
         try {
-            while (true) {
-                var next = queue.poll();
-                if (next == null) {
-                    return; // drained
-                }
+            Runnable next;
+            while ((next = queue.poll()) != null) { // process all tasks in the queue
                 next.run();
             }
         } finally {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractDelegateChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractDelegateChangeSet.java
@@ -25,8 +25,6 @@ public class AbstractDelegateChangeSet extends AbstractChangeSet {
     public AbstractDelegateChangeSet(AbstractChangeSet parent) {
         super(parent.getWorld());
         this.parent = parent;
-        this.waitingCombined = parent.waitingCombined;
-        this.waitingAsync = parent.waitingAsync;
     }
 
     public final AbstractChangeSet getParent() {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
@@ -258,7 +258,7 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
         if (blockSize > 0) {
             return false;
         }
-        if (waitingCombined.get() != 0 || waitingAsync.get() != 0) {
+        if (!super.isEmpty()) {
             return false;
         }
         flush();

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
@@ -624,6 +624,11 @@ public abstract class AbstractDelegateExtent implements Extent {
     }
 
     @Override
+    public <B extends BlockStateHolder<B>> int setBlocks(final Region region, final B block) throws MaxChangedBlocksException {
+        return extent.setBlocks(region, block);
+    }
+
+    @Override
     public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
         return setBlock(x, y, z, getBlock(x, y, z).toBaseBlock(tile));
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
@@ -624,11 +624,6 @@ public abstract class AbstractDelegateExtent implements Extent {
     }
 
     @Override
-    public <B extends BlockStateHolder<B>> int setBlocks(final Region region, final B block) throws MaxChangedBlocksException {
-        return extent.setBlocks(region, block);
-    }
-
-    @Override
     public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
         return setBlock(x, y, z, getBlock(x, y, z).toBaseBlock(tile));
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

Previously, write tasks for the history were submitted to the thread pool separately, causing different threads to process the tasks. However, the `processSet` method is synchronized to ensure only one thread at a time actually writes to history.
This results in many threads being blocked and competing for the monitor.

With this change, we collect the tasks in a queue and only process the tasks on one thread instead.
After enqueueing a task, we check if another thread is already processing the queue.

This does not bring immediate performance improvements in form of speed, however it reduces CPU usage due to reduced contention. Additionally, it doesn't take up threads in the thread pool that block most of the time, allowing better performance when working on multiple FAWE actions concurrently.

Alternatives considered:
- Wait for virtual threads, create one vthread per task, switch to locks to prevent pinning -> maybe in future?
- Have a *new* thread for writing -> would further increase the already high number of FAWE threads

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
