### PR TITLE
fix: correctly handle creation of extents in EditSessionBuilder

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java
@@ -531,16 +531,14 @@ public final class EditSessionBuilder {
             }
             if (allowedRegions == null && Settings.settings().REGION_RESTRICTIONS) {
                 if (actor != null && !actor.hasPermission("fawe.bypass.regions")) {
-                    if (actor instanceof Player) {
-                        Player player = (Player) actor;
+                    if (actor instanceof Player player) {
                         allowedRegions = player.getAllowedRegions();
                     }
                 }
             }
             if (disallowedRegions == null && Settings.settings().REGION_RESTRICTIONS && Settings.settings().REGION_RESTRICTIONS_OPTIONS.ALLOW_BLACKLISTS) {
                 if (actor != null && !actor.hasPermission("fawe.bypass.regions")) {
-                    if (actor instanceof Player) {
-                        Player player = (Player) actor;
+                    if (actor instanceof Player player) {
                         disallowedRegions = player.getDisallowedRegions();
                     }
                 }
@@ -560,6 +558,9 @@ public final class EditSessionBuilder {
                         regionExtent = new MultiRegionExtent(this.extent, this.limit, allowedRegions, null);
                     }
                 }
+            }
+            if (placeChunks && regionExtent != null) {
+                queue.addProcessor(regionExtent);
             }
             // There's no need to do the below (and it'll also just be a pain to implement) if we're not placing chunks
             if (placeChunks) {
@@ -597,10 +598,9 @@ public final class EditSessionBuilder {
                 this.extent = regionExtent;
             }
             if (this.limit != null && this.limit.STRIP_NBT != null && !this.limit.STRIP_NBT.isEmpty()) {
+                this.extent = new StripNBTExtent(this.extent, this.limit.STRIP_NBT);
                 if (placeChunks) {
-                    queue.addProcessor(new StripNBTExtent(this.extent, this.limit.STRIP_NBT));
-                } else {
-                    this.extent = new StripNBTExtent(this.extent, this.limit.STRIP_NBT);
+                    queue.addProcessor((IBatchProcessor) this.extent);
                 }
             }
             if (this.limit != null && !this.limit.isUnlimited()) {
@@ -613,10 +613,9 @@ public final class EditSessionBuilder {
                 }
                 Set<PropertyRemap<?>> remaps = this.limit.REMAP_PROPERTIES;
                 if (!limitBlocks.isEmpty() || (remaps != null && !remaps.isEmpty())) {
+                    this.extent = new DisallowedBlocksExtent(this.extent, limitBlocks, remaps);
                     if (placeChunks) {
-                        queue.addProcessor(new DisallowedBlocksExtent(this.extent, limitBlocks, remaps));
-                    } else {
-                        this.extent = new DisallowedBlocksExtent(this.extent, limitBlocks, remaps);
+                        queue.addProcessor((IBatchProcessor) this.extent);
                     }
                 }
             }


### PR DESCRIPTION
 - Add regionExtent process to the queue (fixes #2227)
 - Correctly wrap extents in each other
