### PR TITLE
chore: remove firework-chunk-loading prevention and default tick limiter to false

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/listener/ChunkListener.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/listener/ChunkListener.java
@@ -371,48 +371,6 @@ public abstract class ChunkListener implements Listener {
         }
     }
 
-    /**
-     * Prevent firework from loading chunks.
-     */
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onChunkLoad(ChunkLoadEvent event) {
-        if (!Settings.settings().TICK_LIMITER.FIREWORKS_LOAD_CHUNKS) {
-            Chunk chunk = event.getChunk();
-            Entity[] entities = chunk.getEntities();
-            World world = chunk.getWorld();
-
-            Exception e = new Exception();
-            int start = 14;
-            int end = 22;
-            int depth = Math.min(end, getDepth(e));
-
-            for (int frame = start; frame < depth; frame++) {
-                StackTraceElement elem = getElement(e, frame);
-                if (elem == null) {
-                    return;
-                }
-                String className = elem.getClassName();
-                int len = className.length();
-                if (len > 15 && className.charAt(len - 15) == 'E' && className
-                        .endsWith("EntityFireworks")) {
-                    for (Entity ent : world.getEntities()) {
-                        if (ent.getType() == EntityType.FIREWORK) {
-                            Vector velocity = ent.getVelocity();
-                            double vertical = Math.abs(velocity.getY());
-                            if (Math.abs(velocity.getX()) > vertical
-                                    || Math.abs(velocity.getZ()) > vertical) {
-                                LOGGER.warn(
-                                        "[FAWE `tick-limiter`] Detected and cancelled rogue FireWork at {}",
-                                        ent.getLocation());
-                                ent.remove();
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     @EventHandler(priority = EventPriority.LOWEST)
     public void onItemSpawn(ItemSpawnEvent event) {
         if (physicsFreeze) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -695,7 +695,7 @@ public class Settings extends Config {
     public static class TICK_LIMITER {
 
         @Comment("Enable the limiter")
-        public boolean ENABLED = true;
+        public boolean ENABLED = false;
         @Comment("The interval in ticks")
         public int INTERVAL = 20;
         @Comment("Max falling blocks per interval (per chunk)")
@@ -704,12 +704,6 @@ public class Settings extends Config {
         public int PHYSICS_MS = 10;
         @Comment("Max item spawns per interval (per chunk)")
         public int ITEMS = 256;
-        @Comment({
-                "Whether fireworks can load chunks",
-                " - Fireworks usually travel vertically so do not load any chunks",
-                " - Horizontal fireworks can be hacked in to crash a server"
-        })
-        public boolean FIREWORKS_LOAD_CHUNKS = false;
 
     }
 


### PR DESCRIPTION
 - It's very resource-intensive and probably doesn't work anyway
 - Tick limiter should not be enabled by default, it confuses a lot of people with the console logs