### PR TITLE
fix: Improve edit processing

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/Fawe.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/Fawe.java
@@ -339,9 +339,10 @@ public class Fawe {
                 Settings.settings().QUEUE.TARGET_SIZE,
                 Settings.settings().QUEUE.PARALLEL_THREADS
         );
-        if (Settings.settings().QUEUE.TARGET_SIZE < 2 * Settings.settings().QUEUE.PARALLEL_THREADS) {
+        if (Settings.settings().QUEUE.TARGET_SIZE < 4 * Settings.settings().QUEUE.PARALLEL_THREADS) {
             LOGGER.error(
-                    "queue.target_size is {}, and queue.parallel_threads is {}. It is HIGHLY recommended that queue" + ".target_size be at least twice queue.parallel_threads or higher.",
+                    "queue.target_size is {}, and queue.parallel_threads is {}. It is HIGHLY recommended that queue" +
+                            ".target_size be at least four times queue.parallel_threads or greater.",
                     Settings.settings().QUEUE.TARGET_SIZE,
                     Settings.settings().QUEUE.PARALLEL_THREADS
             );

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -520,10 +520,10 @@ public class Settings extends Config {
                 " - A smaller value will reduce memory usage",
                 " - A value too small may break some operations (deform?)",
                 " - Values smaller than the configurated parallel-threads are not accepted",
-                " - It is recommended this option be at least 2x greater than parallel-threads"
+                " - It is recommended this option be at least 4x greater than parallel-threads"
 
         })
-        public int TARGET_SIZE = 64;
+        public int TARGET_SIZE = 8 * Runtime.getRuntime().availableProcessors();
         @Comment({
                 "Force FAWE to start placing chunks regardless of whether an edit is finished processing",
                 " - A larger value will use slightly less CPU time",

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/BlockVector3ChunkMap.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/BlockVector3ChunkMap.java
@@ -9,7 +9,20 @@ import java.util.Map;
 
 public class BlockVector3ChunkMap<T> implements IAdaptedMap<BlockVector3, T, Integer, T> {
 
-    private final Int2ObjectArrayMap<T> map = new Int2ObjectArrayMap<>();
+    private final Int2ObjectArrayMap<T> map;
+
+    public BlockVector3ChunkMap() {
+        map = new Int2ObjectArrayMap<>();
+    }
+
+    /**
+     * Create a new instance that is a copy of an existing map
+     *
+     * @param map existing map to copy
+     */
+    public BlockVector3ChunkMap(BlockVector3ChunkMap<T> map) {
+        this.map = new Int2ObjectArrayMap<>(map.getParent());
+    }
 
     @Override
     public Map<Integer, T> getParent() {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkSet.java
@@ -117,7 +117,7 @@ public interface IChunkSet extends IBlocks, OutputExtent {
     boolean hasBiomes(int layer);
 
     /**
-     * Create an entirely distinct copy of this SET instance. All mutable data must be copied to sufficiently prevetn leakage
+     * Create an entirely distinct copy of this SET instance. All mutable data must be copied to sufficiently prevent leakage
      * between the copy and the original.
      *
      * @return distinct new {@link IChunkSet instance}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkSet.java
@@ -8,6 +8,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
@@ -114,5 +115,16 @@ public interface IChunkSet extends IBlocks, OutputExtent {
      * @return if the layer has biomes stored to be set to the world
      */
     boolean hasBiomes(int layer);
+
+    /**
+     * Create an entirely distinct copy of this SET instance. All mutable data must be copied to sufficiently prevetn leakage
+     * between the copy and the original.
+     *
+     * @return distinct new {@link IChunkSet instance}
+     */
+    @Nonnull
+    default IChunkSet createCopy() {
+        return this;
+    }
 
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
@@ -53,7 +53,6 @@ public abstract class QueueHandler implements Trimable, Runnable {
      */
     private long last;
     private long allocate = 50;
-    private double targetTPS = 18;
 
     public QueueHandler() {
         TaskManager.taskManager().repeat(this, 1);
@@ -87,7 +86,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
 
     private long getAllocate() {
         long now = System.currentTimeMillis();
-        targetTPS = 18 - Math.max(Settings.settings().QUEUE.EXTRA_TIME_MS * 0.05, 0);
+        double targetTPS = 18 - Math.max(Settings.settings().QUEUE.EXTRA_TIME_MS * 0.05, 0);
         long diff = 50 + this.last - (this.last = now);
         long absDiff = Math.abs(diff);
         if (diff == 0) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
@@ -275,8 +275,8 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
      * Get a new IChunk from either the pool, or create a new one<br> + Initialize it at the
      * coordinates
      *
-     * @param chunkX
-     * @param chunkZ
+     * @param chunkX X chunk coordinate
+     * @param chunkZ Z chunk coordinate
      * @return IChunk
      */
     private ChunkHolder poolOrCreate(int chunkX, int chunkZ) {
@@ -309,19 +309,11 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
             // If queueing is enabled AND either of the following
             //  - memory is low & queue size > num threads + 8
             //  - queue size > target size and primary queue has less than num threads submissions
-            if (enabledQueue && ((lowMem && size > Settings.settings().QUEUE.PARALLEL_THREADS + 8) || (size > Settings.settings().QUEUE.TARGET_SIZE && Fawe
-                    .instance()
-                    .getQueueHandler()
-                    .isUnderutilized()))) {
+            int targetSize = lowMem ? Settings.settings().QUEUE.PARALLEL_THREADS + 8 : Settings.settings().QUEUE.TARGET_SIZE;
+            if (enabledQueue && size > targetSize && (lowMem || Fawe.instance().getQueueHandler().isUnderutilized())) {
                 chunk = chunks.removeFirst();
                 final Future future = submitUnchecked(chunk);
                 if (future != null && !future.isDone()) {
-                    final int targetSize;
-                    if (lowMem) {
-                        targetSize = Settings.settings().QUEUE.PARALLEL_THREADS + 8;
-                    } else {
-                        targetSize = Settings.settings().QUEUE.TARGET_SIZE;
-                    }
                     pollSubmissions(targetSize, lowMem);
                     submissions.add(future);
                 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
@@ -369,7 +369,7 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
                 tiles != null ? new BlockVector3ChunkMap<>(tiles) : null,
                 entities != null ? new HashSet<>(entities) : null,
                 entityRemoves != null ? new HashSet<>(entityRemoves) : null,
-                heightMaps != null ? new HashMap<>(heightMaps) : null,
+                heightMaps != null ? new EnumMap<>(heightMaps) : null,
                 defaultOrdinal(),
                 fastMode,
                 bitMask

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.IntStream;
 
 public class CharSetBlocks extends CharBlocks implements IChunkSet {
 
@@ -306,8 +305,12 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
                 || (heightMaps != null && !heightMaps.isEmpty())) {
             return false;
         }
-        //noinspection SimplifyStreamApiCallChains - this is faster than using #noneMatch
-        return !IntStream.range(minSectionPosition, maxSectionPosition + 1).anyMatch(this::hasSection);
+        for (int i =  minSectionPosition; i <= maxSectionPosition; i++) {
+            if (hasSection(i)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
@@ -316,6 +319,9 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
         tiles = null;
         entities = null;
         entityRemoves = null;
+        light = null;
+        skyLight = null;
+        heightMaps = null;
         super.reset();
         return null;
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/ThreadUnsafeCharBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/ThreadUnsafeCharBlocks.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -304,7 +305,7 @@ public class ThreadUnsafeCharBlocks implements IChunkSet, IBlocks {
     @Override
     public void setHeightMap(HeightMapType type, int[] heightMap) {
         if (heightMaps == null) {
-            heightMaps = new HashMap<>();
+            heightMaps = new EnumMap<>(HeightMapType.class);
         }
         heightMaps.put(type, heightMap);
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/ThreadUnsafeCharBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/ThreadUnsafeCharBlocks.java
@@ -1,17 +1,20 @@
 package com.fastasyncworldedit.core.queue.implementation.blocks;
 
+import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
-import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
 import com.fastasyncworldedit.core.math.BlockVector3ChunkMap;
+import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.IChunkSet;
-import com.fastasyncworldedit.core.queue.Pool;
 import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,44 +23,159 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.IntStream;
 
-public class CharSetBlocks extends CharBlocks implements IChunkSet {
+/**
+ * Equivalent to {@link CharSetBlocks} without any attempt to make thread-safe for improved performance.
+ * This is currently only used as a "copy" of {@link CharSetBlocks} to provide to
+ * {@link com.fastasyncworldedit.core.queue.IBatchProcessor} instances for processing without overlapping the continuing edit.
+ *
+ * @since TODO
+ */
+public class ThreadUnsafeCharBlocks implements IChunkSet, IBlocks {
 
-    private static final Pool<CharSetBlocks> POOL = FaweCache.INSTANCE.registerPool(
-            CharSetBlocks.class,
-            CharSetBlocks::new,
-            Settings.settings().QUEUE.POOL
-    );
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
 
-    public static CharSetBlocks newInstance() {
-        return POOL.poll();
-    }
+    private final char defaultOrdinal;
+    private char[][] blocks;
+    private int minSectionPosition;
+    private int maxSectionPosition;
+    private int sectionCount;
+    private BiomeType[][] biomes;
+    private char[][] light;
+    private char[][] skyLight;
+    private BlockVector3ChunkMap<CompoundTag> tiles;
+    private HashSet<CompoundTag> entities;
+    private HashSet<UUID> entityRemoves;
+    private Map<HeightMapType, int[]> heightMaps;
+    private boolean fastMode;
+    private int bitMask;
 
-    public BiomeType[][] biomes;
-    public char[][] light;
-    public char[][] skyLight;
-    public BlockVector3ChunkMap<CompoundTag> tiles;
-    public HashSet<CompoundTag> entities;
-    public HashSet<UUID> entityRemoves;
-    public Map<HeightMapType, int[]> heightMaps;
-    private boolean fastMode = false;
-    private int bitMask = -1;
-
-    private CharSetBlocks() {
-        // Expand as we go
-        super(0, 15);
+    /**
+     * New instance given the data stored in a {@link CharSetBlocks} instance.
+     *
+     * @since TODO
+     */
+    ThreadUnsafeCharBlocks(
+            char[][] blocks,
+            int minSectionPosition,
+            int maxSectionPosition,
+            BiomeType[][] biomes,
+            int sectionCount,
+            char[][] light,
+            char[][] skyLight,
+            BlockVector3ChunkMap<CompoundTag> tiles,
+            HashSet<CompoundTag> entities,
+            HashSet<UUID> entityRemoves,
+            Map<HeightMapType, int[]> heightMaps,
+            char defaultOrdinal,
+            boolean fastMode,
+            int bitMask
+    ) {
+        this.blocks = blocks;
+        this.minSectionPosition = minSectionPosition;
+        this.maxSectionPosition = maxSectionPosition;
+        this.biomes = biomes;
+        this.sectionCount = sectionCount;
+        this.light = light;
+        this.skyLight = skyLight;
+        this.tiles = tiles;
+        this.entities = entities;
+        this.entityRemoves = entityRemoves;
+        this.heightMaps = heightMaps;
+        this.defaultOrdinal = defaultOrdinal;
+        this.fastMode = fastMode;
+        this.bitMask = bitMask;
     }
 
     @Override
-    public synchronized void recycle() {
-        reset();
-        POOL.offer(this);
+    public boolean hasSection(int layer) {
+        layer -= minSectionPosition;
+        return layer >= 0 && layer < blocks.length && blocks[layer] != null && blocks[layer].length == FaweCache.INSTANCE.BLOCKS_PER_LAYER;
     }
 
     @Override
-    public BiomeType[][] getBiomes() {
-        return biomes;
+    public char[] load(int layer) {
+        updateSectionIndexRange(layer);
+        layer -= minSectionPosition;
+        return blocks[layer];
+    }
+
+    @Nullable
+    @Override
+    public char[] loadIfPresent(int layer) {
+        layer -= minSectionPosition;
+        return blocks[layer];
+    }
+
+    @Override
+    public Map<BlockVector3, CompoundTag> getTiles() {
+        return tiles == null ? Collections.emptyMap() : tiles;
+    }
+
+    @Override
+    public CompoundTag getTile(int x, int y, int z) {
+        return tiles.get(x, y, z);
+    }
+
+    @Override
+    public Set<CompoundTag> getEntities() {
+        return entities == null ? Collections.emptySet() : entities;
+    }
+
+    @Override
+    public Map<HeightMapType, int[]> getHeightMaps() {
+        return heightMaps == null ? new HashMap<>() : heightMaps;
+    }
+
+    @Override
+    public void removeSectionLighting(int layer, boolean sky) {
+        updateSectionIndexRange(layer);
+        layer -= minSectionPosition;
+        if (light == null) {
+            light = new char[sectionCount][];
+        }
+        if (light[layer] == null) {
+            light[layer] = new char[4096];
+        }
+        Arrays.fill(light[layer], (char) 0);
+        if (sky) {
+            if (skyLight == null) {
+                skyLight = new char[sectionCount][];
+            }
+            if (skyLight[layer] == null) {
+                skyLight[layer] = new char[4096];
+            }
+            Arrays.fill(skyLight[layer], (char) 0);
+        }
+    }
+
+    @Override
+    public boolean trim(boolean aggressive, int layer) {
+        return false;
+    }
+
+    @Override
+    public int getSectionCount() {
+        return sectionCount;
+    }
+
+    @Override
+    public int getMaxSectionPosition() {
+        return maxSectionPosition;
+    }
+
+    @Override
+    public int getMinSectionPosition() {
+        return minSectionPosition;
+    }
+
+    public char get(int x, int y, int z) {
+        int layer = (y >> 4);
+        if (!hasSection(layer)) {
+            return defaultOrdinal;
+        }
+        final int index = (y & 15) << 8 | z << 4 | x;
+        return blocks[layer - minSectionPosition][index];
     }
 
     @Override
@@ -72,28 +190,8 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     }
 
     @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
-        return tiles == null ? Collections.emptyMap() : tiles;
-    }
-
-    @Override
-    public CompoundTag getTile(int x, int y, int z) {
-        return tiles == null ? null : tiles.get(x, y, z);
-    }
-
-    @Override
-    public Set<CompoundTag> getEntities() {
-        return entities == null ? Collections.emptySet() : entities;
-    }
-
-    @Override
-    public Set<UUID> getEntityRemoves() {
-        return entityRemoves == null ? Collections.emptySet() : entityRemoves;
-    }
-
-    @Override
-    public Map<HeightMapType, int[]> getHeightMaps() {
-        return heightMaps == null ? new HashMap<>() : heightMaps;
+    public BlockState getBlock(int x, int y, int z) {
+        return BlockTypesCache.states[get(x, y, z)];
     }
 
     @Override
@@ -111,6 +209,23 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     }
 
     @Override
+    public boolean setBiome(BlockVector3 position, BiomeType biome) {
+        return setBiome(position.getX(), position.getY(), position.getZ(), biome);
+    }
+
+    public void set(int x, int y, int z, char value) {
+        final int layer = y >> 4;
+        final int index = (y & 15) << 8 | z << 4 | x;
+        try {
+            blocks[layer][index] = value;
+        } catch (ArrayIndexOutOfBoundsException exception) {
+            LOGGER.error("Tried setting block at coordinates (" + x + "," + y + "," + z + ")");
+            assert Fawe.platform() != null;
+            LOGGER.error("Layer variable was = {}", layer, exception);
+        }
+    }
+
+    @Override
     public <T extends BlockStateHolder<T>> boolean setBlock(int x, int y, int z, T holder) {
         updateSectionIndexRange(y >> 4);
         set(x, y, z, holder.getOrdinalChar());
@@ -122,22 +237,34 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     public void setBlocks(int layer, char[] data) {
         updateSectionIndexRange(layer);
         layer -= minSectionPosition;
-        this.sections[layer] = data == null ? EMPTY : FULL;
         this.blocks[layer] = data;
     }
 
     @Override
-    public <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 position, T block)
-            throws WorldEditException {
-        return setBlock(position.getX(), position.getY(), position.getZ(), block);
+    public boolean isEmpty() {
+        if (biomes != null
+                || light != null
+                || skyLight != null
+                || (entities != null && !entities.isEmpty())
+                || (tiles != null && !tiles.isEmpty())
+                || (entityRemoves != null && !entityRemoves.isEmpty())
+                || (heightMaps != null && !heightMaps.isEmpty())) {
+            return false;
+        }
+        for (int i =  minSectionPosition; i <= maxSectionPosition; i++) {
+            if (hasSection(i)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
     public boolean setTile(int x, int y, int z, CompoundTag tile) {
+        updateSectionIndexRange(y >> 4);
         if (tiles == null) {
             tiles = new BlockVector3ChunkMap<>();
         }
-        updateSectionIndexRange(y >> 4);
         tiles.put(x, y, z, tile);
         return true;
     }
@@ -203,38 +330,6 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     }
 
     @Override
-    public char[][] getLight() {
-        return light;
-    }
-
-    @Override
-    public char[][] getSkyLight() {
-        return skyLight;
-    }
-
-    @Override
-    public void removeSectionLighting(int layer, boolean sky) {
-        updateSectionIndexRange(layer);
-        layer -= minSectionPosition;
-        if (light == null) {
-            light = new char[sectionCount][];
-        }
-        if (light[layer] == null) {
-            light[layer] = new char[4096];
-        }
-        Arrays.fill(light[layer], (char) 0);
-        if (sky) {
-            if (skyLight == null) {
-                skyLight = new char[sectionCount][];
-            }
-            if (skyLight[layer] == null) {
-                skyLight[layer] = new char[4096];
-            }
-            Arrays.fill(skyLight[layer], (char) 0);
-        }
-    }
-
-    @Override
     public void setFullBright(int layer) {
         updateSectionIndexRange(layer);
         layer -= minSectionPosition;
@@ -252,11 +347,6 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
         }
         Arrays.fill(light[layer], (char) 15);
         Arrays.fill(skyLight[layer], (char) 15);
-    }
-
-    @Override
-    public boolean setBiome(BlockVector3 position, BiomeType biome) {
-        return setBiome(position.getX(), position.getY(), position.getZ(), biome);
     }
 
     @Override
@@ -296,41 +386,56 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     }
 
     @Override
-    public boolean isEmpty() {
-        if (biomes != null
-                || light != null
-                || skyLight != null
-                || (entities != null && !entities.isEmpty())
-                || (tiles != null && !tiles.isEmpty())
-                || (entityRemoves != null && !entityRemoves.isEmpty())
-                || (heightMaps != null && !heightMaps.isEmpty())) {
-            return false;
-        }
-        //noinspection SimplifyStreamApiCallChains - this is faster than using #noneMatch
-        return !IntStream.range(minSectionPosition, maxSectionPosition + 1).anyMatch(this::hasSection);
+    public Set<UUID> getEntityRemoves() {
+        return entityRemoves == null ? Collections.emptySet() : entityRemoves;
+    }
+
+    @Override
+    public BiomeType[][] getBiomes() {
+        return biomes;
+    }
+
+    @Override
+    public boolean hasBiomes() {
+        return IChunkSet.super.hasBiomes();
+    }
+
+    @Override
+    public char[][] getLight() {
+        return light;
+    }
+
+    @Override
+    public char[][] getSkyLight() {
+        return skyLight;
+    }
+
+    @Override
+    public boolean hasLight() {
+        return IChunkSet.super.hasLight();
     }
 
     @Override
     public IChunkSet reset() {
-        biomes = null;
-        tiles = null;
-        entities = null;
-        entityRemoves = null;
-        super.reset();
-        return null;
+        blocks = new char[sectionCount][];
+        biomes = new BiomeType[sectionCount][];
+        light = new char[sectionCount][];
+        skyLight = new char[sectionCount][];
+        tiles.clear();
+        entities.clear();
+        entityRemoves.clear();
+        heightMaps.clear();
+        return this;
     }
 
     @Override
     public boolean hasBiomes(int layer) {
         layer -= minSectionPosition;
-        if (layer < 0 || layer >= sections.length) {
-            return false;
-        }
-        return biomes != null && biomes[layer] != null;
+        return layer >= 0 && layer < biomes.length && biomes[layer] != null && biomes[layer].length > 0;
     }
 
     @Override
-    public ThreadUnsafeCharBlocks createCopy() {
+    public IChunkSet createCopy() {
         char[][] blocksCopy = new char[sectionCount][];
         for (int i = 0; i < sectionCount; i++) {
             if (blocks[i] != null) {
@@ -350,8 +455,8 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
                 }
             }
         }
-        char[][] lightCopy = createLightCopy(light, sectionCount);
-        char[][] skyLightCopy = createLightCopy(skyLight, sectionCount);
+        char[][] lightCopy = CharSetBlocks.createLightCopy(light, sectionCount);
+        char[][] skyLightCopy = CharSetBlocks.createLightCopy(skyLight, sectionCount);
         return new ThreadUnsafeCharBlocks(
                 blocksCopy,
                 minSectionPosition,
@@ -364,36 +469,15 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
                 entities != null ? new HashSet<>(entities) : null,
                 entityRemoves != null ? new HashSet<>(entityRemoves) : null,
                 heightMaps != null ? new HashMap<>(heightMaps) : null,
-                defaultOrdinal(),
+                defaultOrdinal,
                 fastMode,
                 bitMask
         );
     }
 
-    static char[][] createLightCopy(char[][] lightArr, int sectionCount) {
-        if (lightArr == null) {
-            return null;
-        } else {
-            char[][] lightCopy = new char[sectionCount][];
-            for (int i = 0; i < sectionCount; i++) {
-                if (lightArr[i] != null) {
-                    lightCopy[i] = new char[lightArr[i].length];
-                    System.arraycopy(lightArr[i], 0, lightCopy[i], 0, lightArr[i].length);
-                }
-            }
-            return lightCopy;
-        }
-    }
-
     @Override
-    public char[] load(final int layer) {
-        updateSectionIndexRange(layer);
-        return super.load(layer);
-    }
-
-    @Override
-    protected char defaultOrdinal() {
-        return BlockTypesCache.ReservedIDs.__RESERVED__;
+    public boolean trim(boolean aggressive) {
+        return false;
     }
 
     // Checks and updates the various section arrays against the new layer index
@@ -405,18 +489,8 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
             int diff = minSectionPosition - layer;
             sectionCount += diff;
             char[][] tmpBlocks = new char[sectionCount][];
-            Section[] tmpSections = new Section[sectionCount];
-            Object[] tmpSectionLocks = new Object[sectionCount];
             System.arraycopy(blocks, 0, tmpBlocks, diff, blocks.length);
-            System.arraycopy(sections, 0, tmpSections, diff, sections.length);
-            System.arraycopy(sectionLocks, 0, tmpSectionLocks, diff, sections.length);
-            for (int i = 0; i < diff; i++) {
-                tmpSections[i] = EMPTY;
-                tmpSectionLocks[i] = new Object();
-            }
             blocks = tmpBlocks;
-            sections = tmpSections;
-            sectionLocks = tmpSectionLocks;
             minSectionPosition = layer;
             if (biomes != null) {
                 BiomeType[][] tmpBiomes = new BiomeType[sectionCount][64];
@@ -437,18 +511,8 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
             int diff = layer - maxSectionPosition;
             sectionCount += diff;
             char[][] tmpBlocks = new char[sectionCount][];
-            Section[] tmpSections = new Section[sectionCount];
-            Object[] tmpSectionLocks = new Object[sectionCount];
             System.arraycopy(blocks, 0, tmpBlocks, 0, blocks.length);
-            System.arraycopy(sections, 0, tmpSections, 0, sections.length);
-            System.arraycopy(sectionLocks, 0, tmpSectionLocks, 0, sections.length);
-            for (int i = sectionCount - diff; i < sectionCount; i++) {
-                tmpSections[i] = EMPTY;
-                tmpSectionLocks[i] = new Object();
-            }
             blocks = tmpBlocks;
-            sections = tmpSections;
-            sectionLocks = tmpSectionLocks;
             maxSectionPosition = layer;
             if (biomes != null) {
                 BiomeType[][] tmpBiomes = new BiomeType[sectionCount][64];

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -1044,7 +1044,7 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
         if (chunkSet != null && !chunkSet.isEmpty()) {
             chunkSet.setBitMask(bitMask);
             try {
-                return this.call(chunkSet, () -> {
+                return this.call(chunkSet.createCopy(), () -> {
                     this.delegate = NULL;
                     chunkSet = null;
                     calledLock.unlock(stamp);


### PR DESCRIPTION
Create a copy of SET chunk before processing
 - Completely nullifies issue of writing to SET between processing submission and processing completion
 - Leads to larger memory footprint, but that is acceptable
 - Leads to performance improvement in processing as there is no need to perform any multi-threading protection operations
 - Fixes #1861
 - Fixes #2074 (gonna go ahead and say it does, this is really the only thing I can think of to do with the issue, and it's super rare anyway (never replicated by anyone else))## Overview
 - *tack on some changes (increased default/recommended target size)
 - *tack on some changes (minor cleanup)
 - *tack on some changes (improve a couple of CharSetBlocks methods)