### PR TITLE
Archive PR artifacts

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -23,4 +23,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
             name: FastAsyncWorldEdit-SNAPSHOT
-            path: worldedit-bukkit/build/libs/FastAsyncWorldEdit-Bukkit-*-jar
+            path: worldedit-bukkit/build/libs/FastAsyncWorldEdit-Bukkit-*.jar

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,4 +18,9 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Build on ${{ matrix.os }}
-        run: ./gradlew clean build
+        run: ./gradlew clean build --no-daemon
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v3
+        with:
+            name: FastAsyncWorldEdit-SNAPSHOT
+            path: worldedit-bukkit/build/libs/FastAsyncWorldEdit-Bukkit-*-jar


### PR DESCRIPTION
Noticed in https://github.com/IntellectualSites/FastAsyncWorldEdit/pull/2267#issuecomment-1576221266, that PR builds are no longer generated.
This PR restores the behavior.