### PR TITLE
Update & Fix TownyFeature support.

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
@@ -70,8 +70,8 @@ public class TownyFeature extends BukkitMaskManager implements Listener {
         final TownBlock myplot = mycoord.getTownBlockOrNull(); // Will not be null, because of the isWilderness() test above.
         boolean isMember = isAllowed(player, myplot);
         if (isMember) {
-            final loc1 = mycoord.getLowerMostCornerLocation();
-            final loc2 = mycoord.getUpperMostCornerLocation();
+            final Location loc1 = mycoord.getLowerMostCornerLocation();
+            final Location loc2 = mycoord.getUpperMostCornerLocation();
             final BlockVector3 pos1 = BlockVector3.at(loc1.getX(), loc1.getY(), loc1.getZ());
             final BlockVector3 pos2 = BlockVector3.at(loc2.getX(), loc2.getY(), loc2.getZ());
             return new FaweMask(new CuboidRegion(pos1, pos2)) {

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
@@ -2,9 +2,7 @@ package com.fastasyncworldedit.bukkit.regions;
 
 import com.fastasyncworldedit.core.regions.FaweMask;
 import com.palmergames.bukkit.towny.Towny;
-import com.palmergames.bukkit.towny.TownyUniverse;
-import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
-import com.palmergames.bukkit.towny.object.PlayerCache;
+import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
@@ -69,22 +69,13 @@ public class TownyFeature extends BukkitMaskManager implements Listener {
         }
         final TownBlock myplot = mycoord.getTownBlockOrNull(); // Will not be null, because of the isWilderness() test above.
         boolean isMember = isAllowed(player, myplot);
-        try {
-            if (isMember) {
-                final Chunk chunk = location.getChunk();
-                final BlockVector3 pos1 = BlockVector3
-                        .at(chunk.getX() * 16, 0, chunk.getZ() * 16);
-                final BlockVector3 pos2 = BlockVector3.at(
-                        chunk.getX() * 16 + 15, 156, chunk.getZ() * 16
-                                + 15);
-                return new FaweMask(new CuboidRegion(pos1, pos2)) {
-                    @Override
-                    public boolean isValid(com.sk89q.worldedit.entity.Player player, MaskType type) {
-                        return isAllowed(BukkitAdapter.adapt(player), myplot);
-                    }
-                };
-            }
-        } catch (Exception ignored) {
+        if (isMember) {
+            return new FaweMask(new CuboidRegion(mycoord.getLowerMostCornerLocation(), mycoord.getUpperMostCornerLocation())) {
+                @Override
+                public boolean isValid(com.sk89q.worldedit.entity.Player player, MaskType type) {
+                    return isAllowed(BukkitAdapter.adapt(player), myplot);
+                }
+            };
         }
         return null;
     }

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/TownyFeature.java
@@ -70,7 +70,11 @@ public class TownyFeature extends BukkitMaskManager implements Listener {
         final TownBlock myplot = mycoord.getTownBlockOrNull(); // Will not be null, because of the isWilderness() test above.
         boolean isMember = isAllowed(player, myplot);
         if (isMember) {
-            return new FaweMask(new CuboidRegion(mycoord.getLowerMostCornerLocation(), mycoord.getUpperMostCornerLocation())) {
+            final loc1 = mycoord.getLowerMostCornerLocation();
+            final loc2 = mycoord.getUpperMostCornerLocation();
+            final BlockVector3 pos1 = BlockVector3.at(loc1.getX(), loc1.getY(), loc1.getZ());
+            final BlockVector3 pos2 = BlockVector3.at(loc2.getX(), loc2.getY(), loc2.getZ());
+            return new FaweMask(new CuboidRegion(pos1, pos2)) {
                 @Override
                 public boolean isValid(com.sk89q.worldedit.entity.Player player, MaskType type) {
                     return isAllowed(BukkitAdapter.adapt(player), myplot);


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Adds support for TrustedResidents in townblocks and towns, Replaces methods which throw exceptions.

Closes #2249 

## Description
<!-- Please describe what this pull request does. -->

TrustedResidents are players which have been given specific rights to act as a townblock owner or town owner, as such they would be able to build/destroy in the areas that FAWE would be used.

Also Closes #2249 by doing the following:
- This commit changes the TownyFeature from only affecting blocks between
y level 0 and 150, changing it to support the lower and upper bounds of
the WorldCoord (top to bottom of the world.)

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
