### PR TITLE
fix: don't "double-up" a setblocks if a region is being set

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
@@ -193,6 +193,7 @@ public class ParallelQueueExtent extends PassthroughExtent {
     public int setBlocks(Set<BlockVector3> vset, Pattern pattern) {
         if (vset instanceof Region) {
             this.changes = setBlocks((Region) vset, pattern);
+            return this.changes;
         }
         // TODO optimize parallel
         for (BlockVector3 blockVector3 : vset) {


### PR DESCRIPTION
 - Fixes #2294
