### PR TITLE
chore: Address kotlin String#capitalize() deprecation

### DIFF
--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -23,6 +23,7 @@ import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.the
 import org.gradle.plugins.signing.SigningExtension
+import java.util.*
 import javax.inject.Inject
 
 fun Project.applyLibrariesConfiguration() {
@@ -204,7 +205,7 @@ fun Project.applyLibrariesConfiguration() {
                 from(libsComponent)
 
                 group = "com.fastasyncworldedit"
-                artifactId = "FastAsyncWorldEdit-Libs-${project.name.capitalize()}"
+                artifactId ="FastAsyncWorldEdit-Libs-${project.name.replaceFirstChar(Char::titlecase)}"
                 version = version
 
                 pom {

--- a/buildSrc/src/main/kotlin/LibsConfig.kt
+++ b/buildSrc/src/main/kotlin/LibsConfig.kt
@@ -23,7 +23,6 @@ import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.the
 import org.gradle.plugins.signing.SigningExtension
-import java.util.*
 import javax.inject.Inject
 
 fun Project.applyLibrariesConfiguration() {
@@ -205,7 +204,7 @@ fun Project.applyLibrariesConfiguration() {
                 from(libsComponent)
 
                 group = "com.fastasyncworldedit"
-                artifactId ="FastAsyncWorldEdit-Libs-${project.name.replaceFirstChar(Char::titlecase)}"
+                artifactId = "FastAsyncWorldEdit-Libs-${project.name.replaceFirstChar(Char::titlecase)}"
                 version = version
 
                 pom {


### PR DESCRIPTION
 - Fixes #2283
 - Don't bother with the longer version that allows Locales, we don't need that