### PR TITLE
fix: regions not trimming Y correctly when restricted

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
@@ -85,7 +85,7 @@ public interface IBatchProcessor {
             }
             for (int layer = maxLayer; layer < set.getMaxSectionPosition(); layer++) {
                 if (set.hasSection(layer)) {
-                    if (layer == minLayer) {
+                    if (layer == maxLayer) {
                         char[] arr = set.loadIfPresent(layer);
                         if (arr != null) {
                             int index = ((maxY + 1) & 15) << 8;


### PR DESCRIPTION
## Overview
Fixes issue where remaining blocks outside of layer are not removed in restricted areas.

## Description
Modifies one if statement to be correctly checking maxLayer value rather than minLayer value

### Submitter Checklist

- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- Not Applicable: New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).