### PR TITLE
fix: Do not tab complete if command not owned by FAWE

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -672,6 +672,13 @@ public class WorldEditPlugin extends JavaPlugin {
             String label = buffer.substring(0, firstSpace);
             // Strip leading slash, if present.
             label = label.startsWith("/") ? label.substring(1) : label;
+
+            // If command not owned by FAWE, do not tab complete
+            Plugin owner = platform.getDynamicCommands().getCommandOwner(label);
+            if (owner != WorldEditPlugin.this) {
+                return;
+            }
+
             final Optional<org.enginehub.piston.Command> command
                     = WorldEdit.getInstance().getPlatformManager().getPlatformCommandManager().getCommandManager().getCommand(
                     label);


### PR DESCRIPTION
## Overview
Stops FAWE from trying to fill in tab completes for commands it doesn't own

Fixes #1912

## Description
Adds a check if the command owner for the command is FAWE

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
