### PR TITLE
Solve NullPointerException caused by wrong config

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -1235,10 +1235,10 @@ public class LocalSession implements TextureHolder {
                 navWandItem = ItemTypes.parse(config.navigationWand);
             }
             synchronized (this.tools) {
-                if (tools.get(navWandItem.getInternalId()) == null && NavigationWand.INSTANCE.canUse(actor)) {
+                if (navWandItem != null && tools.get(navWandItem.getInternalId()) == null && NavigationWand.INSTANCE.canUse(actor)) {
                     tools.put(navWandItem.getInternalId(), NavigationWand.INSTANCE);
                 }
-                if (tools.get(wandItem.getInternalId()) == null && SelectionWand.INSTANCE.canUse(actor)) {
+                if (wandItem != null && tools.get(wandItem.getInternalId()) == null && SelectionWand.INSTANCE.canUse(actor)) {
                     tools.put(wandItem.getInternalId(), SelectionWand.INSTANCE);
                 }
             }


### PR DESCRIPTION
## Bug

### Overview

A NullPointerException could be thrown if the config file `worldedit-config.yml` has invalid data in `wand-item` or `navigation-wand.item`. It will be thrown if a player enters the game (PlayerJoinEvent) or a players changes game mode (PlayerGameModeChangeEvent)

### Replicate

1. Start a Bukkit or relative server with the last version of FAWE with this bug (2.7.1 as of today)
2. Edit the config an set `wand-item` or `navigation-wand.item` to a wrong value like `minecraft:-1`
3. Restarts the server and Join.
You should see an Exception in the console 

### Risk

This bug could lead to skipping code. In the last example if you do not have the last version it will not be announced to an admin player. I did not find any pottencial risk, but in a future might produce a fatal unintended error.

## Solution

### Code

I just added some null checker in the `if` statement in the method `loadDefaults` in `/main/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java#L1227`

## Submitter Checklist

- [x] Make sure you are opening from a topic branch (/feature/fix/docs/ branch (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with @since TODO.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
