### PR TITLE
Replace instanceof AliasedParser check for .getMatchedAliases() Try-Catch

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
@@ -121,10 +121,11 @@ public abstract class AbstractFactory<E> {
      */
     public boolean containsAlias(String alias) {
         return parsers.stream().anyMatch(p -> {
-            if (!(p instanceof AliasedParser)) {
+            try {
+                return ((AliasedParser) p).getMatchedAliases().contains(alias);
+            } catch (Exception e) {
                 return false;
             }
-            return ((AliasedParser) p).getMatchedAliases().contains(alias);
         });
     }
 


### PR DESCRIPTION
## Overview
The instanceof AliasedParser check frustrates attempts at Masks/Patterns which are compatible with both FAWE and WE.

I do hope I have missed an alternate (and maybe obvious?) way to implement Parsers without using the FAWE RichParser/Aliased Parser, but from what I can tell this singular check is a blocker.

The current code causes the parseFromInput() part of custom parsers to not run, which is an issue that has been flagged a couple times in the Discord support channel.

## Description
This change will still only match parsers which contain a getMatchedAliases() method so everything that currently passes the check will continue to do so.

By swapping the instanceof check for this, we can allow WE compatible parsers with their own Rich/argument parsing implementation to function when FAWE is present on a server.

This doesn't change functionality of other existing FAWE parsers.

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
