### PR TITLE
Avoid Unsafe usage where possible

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightPlatformAdapter.java
@@ -85,11 +85,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     private static final MethodHandle methodGetVisibleChunk;
 
-    private static final int CHUNKSECTION_BASE;
-    private static final int CHUNKSECTION_SHIFT;
-
     private static final Field fieldLock;
-    private static final long fieldLockOffset;
 
     private static final Field fieldGameEventDispatcherSections;
     private static final MethodHandle methodremoveBlockEntityTicker;
@@ -127,15 +123,12 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             getVisibleChunkIfPresent.setAccessible(true);
             methodGetVisibleChunk = MethodHandles.lookup().unreflect(getVisibleChunkIfPresent);
 
-            Unsafe unsafe = ReflectionUtils.getUnsafe();
             if (!PaperLib.isPaper()) {
-
                 fieldLock = PalettedContainer.class.getDeclaredField(Refraction.pickName("lock", "m"));
-                fieldLockOffset = unsafe.objectFieldOffset(fieldLock);
+                fieldLock.setAccessible(true);
             } else {
                 // in paper, the used methods are synchronized properly
                 fieldLock = null;
-                fieldLockOffset = -1;
             }
 
             fieldGameEventDispatcherSections = LevelChunk.class.getDeclaredField(Refraction.pickName(
@@ -152,13 +145,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
             fieldRemove = BlockEntity.class.getDeclaredField(Refraction.pickName("remove", "p"));
             fieldRemove.setAccessible(true);
-
-            CHUNKSECTION_BASE = unsafe.arrayBaseOffset(LevelChunkSection[].class);
-            int scale = unsafe.arrayIndexScale(LevelChunkSection[].class);
-            if ((scale & (scale - 1)) != 0) {
-                throw new Error("data type scale not a power of two");
-            }
-            CHUNKSECTION_SHIFT = 31 - Integer.numberOfLeadingZeros(scale);
         } catch (RuntimeException e) {
             throw e;
         } catch (Throwable rethrow) {
@@ -173,9 +159,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             LevelChunkSection value,
             int layer
     ) {
-        long offset = ((long) layer << CHUNKSECTION_SHIFT) + CHUNKSECTION_BASE;
         if (layer >= 0 && layer < sections.length) {
-            return ReflectionUtils.getUnsafe().compareAndSwapObject(sections, offset, expected, value);
+            return ReflectionUtils.compareAndSet(sections, expected, value, layer);
         }
         return false;
     }
@@ -190,14 +175,13 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         }
         try {
             synchronized (section) {
-                Unsafe unsafe = ReflectionUtils.getUnsafe();
                 PalettedContainer<net.minecraft.world.level.block.state.BlockState> blocks = section.getStates();
-                Semaphore currentLock = (Semaphore) unsafe.getObject(blocks, fieldLockOffset);
+                Semaphore currentLock = (Semaphore) fieldLock.get(blocks);
                 if (currentLock instanceof DelegateSemaphore delegateSemaphore) {
                     return delegateSemaphore;
                 }
                 DelegateSemaphore newLock = new DelegateSemaphore(1, currentLock);
-                unsafe.putObject(blocks, fieldLockOffset, newLock);
+                fieldLock.set(blocks, newLock);
                 return newLock;
             }
         } catch (Throwable e) {

--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/regen/PaperweightRegen.java
@@ -332,7 +332,7 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
             }
         };
 
-        ReflectionUtils.unsafeSet(chunkSourceField, freshWorld, freshChunkProvider);
+        chunkSourceField.set(freshWorld, freshChunkProvider);
         //let's start then
         structureManager = server.getStructureManager();
         threadedLevelLightEngine = freshChunkProvider.getLightEngine();

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightPlatformAdapter.java
@@ -92,14 +92,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     private static final MethodHandle methodGetVisibleChunk;
 
-    private static final int CHUNKSECTION_BASE;
-    private static final int CHUNKSECTION_SHIFT;
-
     private static final Field fieldThreadingDetector;
-    private static final long fieldThreadingDetectorOffset;
-
     private static final Field fieldLock;
-    private static final long fieldLockOffset;
 
     private static final MethodHandle methodRemoveGameEventListener;
     private static final MethodHandle methodremoveTickingBlockEntity;
@@ -136,20 +130,15 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             getVisibleChunkIfPresent.setAccessible(true);
             methodGetVisibleChunk = MethodHandles.lookup().unreflect(getVisibleChunkIfPresent);
 
-            Unsafe unsafe = ReflectionUtils.getUnsafe();
             if (!PaperLib.isPaper()) {
                 fieldThreadingDetector = PalettedContainer.class.getDeclaredField(Refraction.pickName("threadingDetector", "f"));
-                fieldThreadingDetectorOffset = unsafe.objectFieldOffset(fieldThreadingDetector);
-
+                fieldThreadingDetector.setAccessible(true);
                 fieldLock = ThreadingDetector.class.getDeclaredField(Refraction.pickName("lock", "c"));
-                fieldLockOffset = unsafe.objectFieldOffset(fieldLock);
+                fieldLock.setAccessible(true);
             } else {
                 // in paper, the used methods are synchronized properly
                 fieldThreadingDetector = null;
-                fieldThreadingDetectorOffset = -1;
-
                 fieldLock = null;
-                fieldLockOffset = -1;
             }
 
             Method removeGameEventListener = LevelChunk.class.getDeclaredMethod(
@@ -169,13 +158,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
             fieldRemove = BlockEntity.class.getDeclaredField(Refraction.pickName("remove", "p"));
             fieldRemove.setAccessible(true);
-
-            CHUNKSECTION_BASE = unsafe.arrayBaseOffset(LevelChunkSection[].class);
-            int scale = unsafe.arrayIndexScale(LevelChunkSection[].class);
-            if ((scale & (scale - 1)) != 0) {
-                throw new Error("data type scale not a power of two");
-            }
-            CHUNKSECTION_SHIFT = 31 - Integer.numberOfLeadingZeros(scale);
         } catch (RuntimeException e) {
             throw e;
         } catch (Throwable rethrow) {
@@ -190,9 +172,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             LevelChunkSection value,
             int layer
     ) {
-        long offset = ((long) layer << CHUNKSECTION_SHIFT) + CHUNKSECTION_BASE;
         if (layer >= 0 && layer < sections.length) {
-            return ReflectionUtils.getUnsafe().compareAndSwapObject(sections, offset, expected, value);
+            return ReflectionUtils.compareAndSet(sections, expected, value, layer);
         }
         return false;
     }
@@ -207,19 +188,15 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         }
         try {
             synchronized (section) {
-                Unsafe unsafe = ReflectionUtils.getUnsafe();
                 PalettedContainer<net.minecraft.world.level.block.state.BlockState> blocks = section.getStates();
-                ThreadingDetector currentThreadingDetector = (ThreadingDetector) unsafe.getObject(
-                        blocks,
-                        fieldThreadingDetectorOffset
-                );
+                ThreadingDetector currentThreadingDetector = (ThreadingDetector) fieldThreadingDetector.get(blocks);
                 synchronized (currentThreadingDetector) {
-                    Semaphore currentLock = (Semaphore) unsafe.getObject(currentThreadingDetector, fieldLockOffset);
+                    Semaphore currentLock = (Semaphore) fieldLock.get(currentThreadingDetector);
                     if (currentLock instanceof DelegateSemaphore delegateSemaphore) {
                         return delegateSemaphore;
                     }
                     DelegateSemaphore newLock = new DelegateSemaphore(1, currentLock);
-                    unsafe.putObject(currentThreadingDetector, fieldLockOffset, newLock);
+                    fieldLock.set(currentThreadingDetector, newLock);
                     return newLock;
                 }
             }

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/regen/PaperweightRegen.java
@@ -345,7 +345,7 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
             }
         };
 
-        ReflectionUtils.unsafeSet(chunkSourceField, freshWorld, freshChunkProvider);
+        chunkSourceField.set(freshWorld, freshChunkProvider);
         //let's start then
         structureManager = server.getStructureManager();
         threadedLevelLightEngine = freshChunkProvider.getLightEngine();

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightPlatformAdapter.java
@@ -99,14 +99,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     private static final MethodHandle methodGetVisibleChunk;
 
-    private static final int CHUNKSECTION_BASE;
-    private static final int CHUNKSECTION_SHIFT;
-
     private static final Field fieldThreadingDetector;
-    private static final long fieldThreadingDetectorOffset;
-
     private static final Field fieldLock;
-    private static final long fieldLockOffset;
 
     private static final MethodHandle methodRemoveGameEventListener;
     private static final MethodHandle methodremoveTickingBlockEntity;
@@ -149,20 +143,15 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             getVisibleChunkIfPresent.setAccessible(true);
             methodGetVisibleChunk = lookup.unreflect(getVisibleChunkIfPresent);
 
-            Unsafe unsafe = ReflectionUtils.getUnsafe();
             if (!PaperLib.isPaper()) {
                 fieldThreadingDetector = PalettedContainer.class.getDeclaredField(Refraction.pickName("threadingDetector", "f"));
-                fieldThreadingDetectorOffset = unsafe.objectFieldOffset(fieldThreadingDetector);
-
+                fieldThreadingDetector.setAccessible(true);
                 fieldLock = ThreadingDetector.class.getDeclaredField(Refraction.pickName("lock", "c"));
-                fieldLockOffset = unsafe.objectFieldOffset(fieldLock);
+                fieldLock.setAccessible(true);
             } else {
                 // in paper, the used methods are synchronized properly
                 fieldThreadingDetector = null;
-                fieldThreadingDetectorOffset = -1;
-
                 fieldLock = null;
-                fieldLockOffset = -1;
             }
 
             Method removeGameEventListener = LevelChunk.class.getDeclaredMethod(
@@ -185,12 +174,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             fieldRemove = BlockEntity.class.getDeclaredField(Refraction.pickName("remove", "q"));
             fieldRemove.setAccessible(true);
 
-            CHUNKSECTION_BASE = unsafe.arrayBaseOffset(LevelChunkSection[].class);
-            int scale = unsafe.arrayIndexScale(LevelChunkSection[].class);
-            if ((scale & (scale - 1)) != 0) {
-                throw new Error("data type scale not a power of two");
-            }
-            CHUNKSECTION_SHIFT = 31 - Integer.numberOfLeadingZeros(scale);
             boolean chunkRewrite;
             try {
                 ServerLevel.class.getDeclaredMethod("getEntityLookup");
@@ -226,9 +209,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             LevelChunkSection value,
             int layer
     ) {
-        long offset = ((long) layer << CHUNKSECTION_SHIFT) + CHUNKSECTION_BASE;
         if (layer >= 0 && layer < sections.length) {
-            return ReflectionUtils.getUnsafe().compareAndSwapObject(sections, offset, expected, value);
+            return ReflectionUtils.compareAndSet(sections, expected, value, layer);
         }
         return false;
     }
@@ -243,19 +225,15 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         }
         try {
             synchronized (section) {
-                Unsafe unsafe = ReflectionUtils.getUnsafe();
                 PalettedContainer<net.minecraft.world.level.block.state.BlockState> blocks = section.getStates();
-                ThreadingDetector currentThreadingDetector = (ThreadingDetector) unsafe.getObject(
-                        blocks,
-                        fieldThreadingDetectorOffset
-                );
+                ThreadingDetector currentThreadingDetector = (ThreadingDetector) fieldThreadingDetector.get(blocks);
                 synchronized (currentThreadingDetector) {
-                    Semaphore currentLock = (Semaphore) unsafe.getObject(currentThreadingDetector, fieldLockOffset);
+                    Semaphore currentLock = (Semaphore) fieldLock.get(currentThreadingDetector);
                     if (currentLock instanceof DelegateSemaphore delegateSemaphore) {
                         return delegateSemaphore;
                     }
                     DelegateSemaphore newLock = new DelegateSemaphore(1, currentLock);
-                    unsafe.putObject(currentThreadingDetector, fieldLockOffset, newLock);
+                    fieldLock.set(currentThreadingDetector, newLock);
                     return newLock;
                 }
             }

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/regen/PaperweightRegen.java
@@ -372,7 +372,7 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         }
 
 
-        ReflectionUtils.unsafeSet(chunkSourceField, freshWorld, freshChunkProvider);
+        chunkSourceField.set(freshWorld, freshChunkProvider);
         //let's start then
         structureTemplateManager = server.getStructureManager();
         threadedLevelLightEngine = new NoOpLightEngine(freshChunkProvider);

--- a/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightPlatformAdapter.java
@@ -102,14 +102,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     private static final MethodHandle methodGetVisibleChunk;
 
-    private static final int CHUNKSECTION_BASE;
-    private static final int CHUNKSECTION_SHIFT;
-
     private static final Field fieldThreadingDetector;
-    private static final long fieldThreadingDetectorOffset;
-
     private static final Field fieldLock;
-    private static final long fieldLockOffset;
 
     private static final MethodHandle methodRemoveGameEventListener;
     private static final MethodHandle methodremoveTickingBlockEntity;
@@ -158,20 +152,15 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             getVisibleChunkIfPresent.setAccessible(true);
             methodGetVisibleChunk = lookup.unreflect(getVisibleChunkIfPresent);
 
-            Unsafe unsafe = ReflectionUtils.getUnsafe();
             if (!PaperLib.isPaper()) {
                 fieldThreadingDetector = PalettedContainer.class.getDeclaredField(Refraction.pickName("threadingDetector", "f"));
-                fieldThreadingDetectorOffset = unsafe.objectFieldOffset(fieldThreadingDetector);
-
+                fieldThreadingDetector.setAccessible(true);
                 fieldLock = ThreadingDetector.class.getDeclaredField(Refraction.pickName("lock", "c"));
-                fieldLockOffset = unsafe.objectFieldOffset(fieldLock);
+                fieldLock.setAccessible(true);
             } else {
                 // in paper, the used methods are synchronized properly
                 fieldThreadingDetector = null;
-                fieldThreadingDetectorOffset = -1;
-
                 fieldLock = null;
-                fieldLockOffset = -1;
             }
 
             Method removeGameEventListener = LevelChunk.class.getDeclaredMethod(
@@ -194,12 +183,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             fieldRemove = BlockEntity.class.getDeclaredField(Refraction.pickName("remove", "q"));
             fieldRemove.setAccessible(true);
 
-            CHUNKSECTION_BASE = unsafe.arrayBaseOffset(LevelChunkSection[].class);
-            int scale = unsafe.arrayIndexScale(LevelChunkSection[].class);
-            if ((scale & (scale - 1)) != 0) {
-                throw new Error("data type scale not a power of two");
-            }
-            CHUNKSECTION_SHIFT = 31 - Integer.numberOfLeadingZeros(scale);
             boolean chunkRewrite;
             try {
                 ServerLevel.class.getDeclaredMethod("getEntityLookup");
@@ -249,9 +232,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             LevelChunkSection value,
             int layer
     ) {
-        long offset = ((long) layer << CHUNKSECTION_SHIFT) + CHUNKSECTION_BASE;
         if (layer >= 0 && layer < sections.length) {
-            return ReflectionUtils.getUnsafe().compareAndSwapObject(sections, offset, expected, value);
+            return ReflectionUtils.compareAndSet(sections, expected, value, layer);
         }
         return false;
     }
@@ -266,19 +248,15 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         }
         try {
             synchronized (section) {
-                Unsafe unsafe = ReflectionUtils.getUnsafe();
                 PalettedContainer<net.minecraft.world.level.block.state.BlockState> blocks = section.getStates();
-                ThreadingDetector currentThreadingDetector = (ThreadingDetector) unsafe.getObject(
-                        blocks,
-                        fieldThreadingDetectorOffset
-                );
+                ThreadingDetector currentThreadingDetector = (ThreadingDetector) fieldThreadingDetector.get(blocks);
                 synchronized (currentThreadingDetector) {
-                    Semaphore currentLock = (Semaphore) unsafe.getObject(currentThreadingDetector, fieldLockOffset);
+                    Semaphore currentLock = (Semaphore) fieldLock.get(currentThreadingDetector);
                     if (currentLock instanceof DelegateSemaphore delegateSemaphore) {
                         return delegateSemaphore;
                     }
                     DelegateSemaphore newLock = new DelegateSemaphore(1, currentLock);
-                    unsafe.putObject(currentThreadingDetector, fieldLockOffset, newLock);
+                    fieldLock.set(currentThreadingDetector, newLock);
                     return newLock;
                 }
             }

--- a/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/regen/PaperweightRegen.java
@@ -373,7 +373,7 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         }
 
 
-        ReflectionUtils.unsafeSet(chunkSourceField, freshWorld, freshChunkProvider);
+        chunkSourceField.set(freshWorld, freshChunkProvider);
         //let's start then
         structureTemplateManager = server.getStructureManager();
         threadedLevelLightEngine = new NoOpLightEngine(freshChunkProvider);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/ReflectionUtils.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/ReflectionUtils.java
@@ -4,19 +4,19 @@ import sun.misc.Unsafe;
 
 import javax.annotation.Nonnull;
 import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
-import java.util.Comparator;
 
 /**
  * This is an internal class not meant to be used outside the FAWE internals.
  */
 public class ReflectionUtils {
 
+    private static final VarHandle REFERENCE_ARRAY_HANDLE = MethodHandles.arrayElementVarHandle(Object[].class);
     private static Unsafe UNSAFE;
 
     static {
@@ -31,6 +31,21 @@ public class ReflectionUtils {
 
     public static <T> T as(Class<T> t, Object o) {
         return t.isInstance(o) ? t.cast(o) : null;
+    }
+
+    /**
+     * Performs CAS on the array element at the given index.
+     *
+     * @param array         the array in which to compare and set the value
+     * @param expectedValue the value expected to be at the index
+     * @param newValue      the new value to be set at the index if the expected value matches
+     * @param index         the index at which to compare and set the value
+     * @param <T>           the type of elements in the array
+     * @return true if the value at the index was successfully updated to the new value, false otherwise
+     * @see VarHandle#compareAndSet(Object...)
+     */
+    public static <T> boolean compareAndSet(T[] array, T expectedValue, T newValue, int index) {
+        return REFERENCE_ARRAY_HANDLE.compareAndSet(array, index, expectedValue, newValue);
     }
 
     public static void setAccessibleNonFinal(Field field) {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

While reflections got restricted, we can still use them for everything in the unnamed module.
This allows us to get rid of almost all usages of Unsafe.
If Unsafe is ever removed in future Java releases, we are better prepared, using the proper replacements.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
