### PR TITLE
Adding note about "worldedit.anyblock" permission

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -400,6 +400,7 @@ public class Settings extends Config {
                 "of a waterlogged fence). For blocking/remapping of all occurrences of a property like waterlogged, see",
                 "remap-properties below.",
                 "To generate a blank list, substitute the default content with a set of square brackets [] instead.",
+                "The 'worldedit.anyblock' permission is not considered here.",
                 "Example block property blocking:",
                 " - \"minecraft:conduit[waterlogged=true]\"",
                 " - \"minecraft:piston[extended=false,facing=west]\"",


### PR DESCRIPTION
## Overview

I would like to include the note that the known WorldEdit bypass permission of the block blacklist (`worldedit.anyblock`) is not considered in the FAWE setting `limits.<group>disallowed-blocks`. Since for the user the border between WorldEdit and FAWE is blurred, this is not very clear at this point.

## Description

The `worldedit.anyblock` permission is only in use for the blacklist in `worldedit-config.yml`. This makes sense, but should be explicitly mentioned here.

https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/7288393a39e4438731440b2c4e9a4526e123021d/worldedit-core/src/main/java/com/sk89q/worldedit/EditSessionBuilder.java#L591
https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/7288393a39e4438731440b2c4e9a4526e123021d/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/DefaultBlockParser.java#L516

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
