### PR TITLE
Unify the limit permission

### DIFF
--- a/worldedit-bukkit/src/main/resources/plugin.yml
+++ b/worldedit-bukkit/src/main/resources/plugin.yml
@@ -21,7 +21,7 @@ permissions:
     default: op
     children:
       fawe.bypass.regions: true
-      fawe.limit.*: true
+      fawe.limit.unlimited: true
   fawe.tips:
     default: op
   fawe.admin:

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -102,7 +102,7 @@ public class Settings extends Config {
 
     public FaweLimit getLimit(Actor actor) {
         FaweLimit limit;
-        if (actor.hasPermission("fawe.bypass") || actor.hasPermission("fawe.limit.unlimited")) {
+        if (actor.hasPermission("fawe.limit.unlimited")) {
             return FaweLimit.MAX.copy();
         }
         limit = new FaweLimit();


### PR DESCRIPTION
## Overview

I have modified the limit permission so that the permission check is more accurate and the wording is more correct. This also makes it easier to assign permissions and disable the limit bypass for admins (especially the block blacklist of WE and FAWE).

## Description
<!-- Please describe what this pull request does. -->

- We down't need the `fawe.limit.*` permission as default permission if we have already checks for `fawe.limit.unlimited`.
- It's enough if only the granted permission is checked.

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
