### PR TITLE
fix: clear player's history away from main thread if lock locked

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -144,7 +144,7 @@ public class LocalSession implements TextureHolder {
         }
     });
     private transient volatile Integer historyNegativeIndex;
-    private transient final Lock historyWriteLock = new ReentrantLock(true);
+    private transient final ReentrantLock historyWriteLock = new ReentrantLock(true);
     private final transient Int2ObjectOpenHashMap<Tool> tools = new Int2ObjectOpenHashMap<>(0);
     private transient Mask sourceMask;
     private transient TextureUtil texture;
@@ -406,7 +406,7 @@ public class LocalSession implements TextureHolder {
      */
     public void clearHistory() {
         //FAWE start
-        if (Fawe.isMainThread() && !historyWriteLock.tryLock()) {
+        if (Fawe.isMainThread() && historyWriteLock.isLocked()) {
             // Do not make main thread wait if we cannot immediately clear history (on player logout usually)
             TaskManager.taskManager().async(this::clearHistoryTask);
             return;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -406,12 +406,16 @@ public class LocalSession implements TextureHolder {
      */
     public void clearHistory() {
         //FAWE start
-        if (Fawe.isMainThread() && historyWriteLock.isLocked()) {
+        if (Fawe.isMainThread() && !historyWriteLock.tryLock()) {
             // Do not make main thread wait if we cannot immediately clear history (on player logout usually)
             TaskManager.taskManager().async(this::clearHistoryTask);
             return;
         }
-        clearHistoryTask();
+        try {
+            clearHistoryTask();
+        } finally {
+            historyWriteLock.unlock();
+        }
     }
 
     private void clearHistoryTask() {


### PR DESCRIPTION
 - fixes #2448