### PR TITLE
fix: vastly superier handling of queue chunks

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightGetBlocks.java
@@ -72,9 +72,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -91,6 +93,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             .getInstance()
             .getBukkitImplAdapter());
     private final ReadWriteLock sectionLock = new ReentrantReadWriteLock();
+    private final ReentrantLock callLock = new ReentrantLock();
     private final ServerLevel serverLevel;
     private final int chunkX;
     private final int chunkZ;
@@ -98,14 +101,15 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     private final int maxHeight;
     private final int minSectionPosition;
     private final int maxSectionPosition;
+    private final ConcurrentHashMap<Integer, PaperweightGetBlocks_Copy> copies = new ConcurrentHashMap<>();
     private LevelChunkSection[] sections;
     private LevelChunk levelChunk;
     private DataLayer[] blockLight;
     private DataLayer[] skyLight;
     private boolean createCopy = false;
-    private PaperweightGetBlocks_Copy copy = null;
     private boolean forceLoadSections = true;
     private boolean lightUpdate = false;
+    private int copyKey = 0;
 
     public PaperweightGetBlocks(World world, int chunkX, int chunkZ) {
         this(((CraftWorld) world).getHandle(), chunkX, chunkZ);
@@ -138,13 +142,27 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempting to set if chunk GET should create copy, but it is not call-locked.");
+        }
         this.createCopy = createCopy;
+        return ++this.copyKey;
     }
 
     @Override
-    public IChunkGet getCopy() {
-        return copy;
+    public IChunkGet getCopy(final int key) {
+        return copies.remove(key);
+    }
+
+    @Override
+    public void lockCall() {
+        this.callLock.lock();
+    }
+
+    @Override
+    public void unlockCall() {
+        this.callLock.unlock();
     }
 
     @Override
@@ -393,8 +411,17 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     @Override
     @SuppressWarnings("rawtypes")
     public synchronized <T extends Future<T>> T call(IChunkSet set, Runnable finalizer) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempted to call chunk GET but chunk was not call-locked.");
+        }
         forceLoadSections = false;
-        copy = createCopy ? new PaperweightGetBlocks_Copy(getChunk()) : null;
+        PaperweightGetBlocks_Copy copy = createCopy ? new PaperweightGetBlocks_Copy(levelChunk) : null;
+        if (createCopy) {
+            if (copies.containsKey(copyKey)) {
+                throw new IllegalStateException("Copy key already used.");
+            }
+            copies.put(copyKey, copy);
+        }
         try {
             ServerLevel nmsWorld = serverLevel;
             LevelChunk nmsChunk = ensureLoaded(nmsWorld, chunkX, chunkZ);
@@ -831,9 +858,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (super.sections[layer] != null) {
             synchronized (super.sectionLocks[layer]) {
                 if (super.sections[layer].isFull() && super.blocks[layer] != null) {
-                    char[] blocks = new char[4096];
-                    System.arraycopy(super.blocks[layer], 0, blocks, 0, 4096);
-                    return blocks;
+                    return super.blocks[layer];
                 }
             }
         }
@@ -946,9 +971,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
     public LevelChunkSection[] getSections(boolean force) {
         force &= forceLoadSections;
-        sectionLock.readLock().lock();
         LevelChunkSection[] tmp = sections;
-        sectionLock.readLock().unlock();
         if (tmp == null || force) {
             try {
                 sectionLock.writeLock().lock();

--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightGetBlocks_Copy.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.chunk.ChunkBiomeContainer;
 import net.minecraft.world.level.chunk.LevelChunk;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -99,7 +100,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        return -1;
     }
 
     @Override
@@ -196,6 +198,10 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public char[] load(int layer) {
         layer -= getMinSectionPosition();
+        if (blocks[layer] == null) {
+            blocks[layer] = new char[4096];
+            Arrays.fill(blocks[layer], (char) BlockTypesCache.ReservedIDs.AIR);
+        }
         return blocks[layer];
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks.java
@@ -14,7 +14,6 @@ import com.fastasyncworldedit.core.queue.implementation.blocks.CharGetBlocks;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.Iterables;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.ListTag;
 import com.sk89q.jnbt.StringTag;
@@ -66,7 +65,6 @@ import javax.annotation.Nonnull;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -76,13 +74,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBlocks {
 
@@ -95,6 +94,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             .getInstance()
             .getBukkitImplAdapter());
     private final ReadWriteLock sectionLock = new ReentrantReadWriteLock();
+    private final ReentrantLock callLock = new ReentrantLock();
     private final ServerLevel serverLevel;
     private final int chunkX;
     private final int chunkZ;
@@ -104,14 +104,15 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     private final int maxSectionPosition;
     private final Registry<Biome> biomeRegistry;
     private final IdMap<Holder<Biome>> biomeHolderIdMap;
+    private final ConcurrentHashMap<Integer, PaperweightGetBlocks_Copy> copies = new ConcurrentHashMap<>();
     private LevelChunkSection[] sections;
     private LevelChunk levelChunk;
     private DataLayer[] blockLight;
     private DataLayer[] skyLight;
     private boolean createCopy = false;
-    private PaperweightGetBlocks_Copy copy = null;
     private boolean forceLoadSections = true;
     private boolean lightUpdate = false;
+    private int copyKey = 0;
 
     public PaperweightGetBlocks(World world, int chunkX, int chunkZ) {
         this(((CraftWorld) world).getHandle(), chunkX, chunkZ);
@@ -146,13 +147,27 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempting to set if chunk GET should create copy, but it is not call-locked.");
+        }
         this.createCopy = createCopy;
+        return ++this.copyKey;
     }
 
     @Override
-    public IChunkGet getCopy() {
-        return copy;
+    public IChunkGet getCopy(final int key) {
+        return copies.remove(key);
+    }
+
+    @Override
+    public void lockCall() {
+        this.callLock.lock();
+    }
+
+    @Override
+    public void unlockCall() {
+        this.callLock.unlock();
     }
 
     @Override
@@ -387,8 +402,17 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     @Override
     @SuppressWarnings("rawtypes")
     public synchronized <T extends Future<T>> T call(IChunkSet set, Runnable finalizer) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempted to call chunk GET but chunk was not call-locked.");
+        }
         forceLoadSections = false;
-        copy = createCopy ? new PaperweightGetBlocks_Copy(getChunk()) : null;
+        PaperweightGetBlocks_Copy copy = createCopy ? new PaperweightGetBlocks_Copy(levelChunk) : null;
+        if (createCopy) {
+            if (copies.containsKey(copyKey)) {
+                throw new IllegalStateException("Copy key already used.");
+            }
+            copies.put(copyKey, copy);
+        }
         try {
             ServerLevel nmsWorld = serverLevel;
             LevelChunk nmsChunk = ensureLoaded(nmsWorld, chunkX, chunkZ);
@@ -882,9 +906,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (super.sections[layer] != null) {
             synchronized (super.sectionLocks[layer]) {
                 if (super.sections[layer].isFull() && super.blocks[layer] != null) {
-                    char[] blocks = new char[4096];
-                    System.arraycopy(super.blocks[layer], 0, blocks, 0, 4096);
-                    return blocks;
+                    return super.blocks[layer];
                 }
             }
         }
@@ -1004,9 +1026,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
     public LevelChunkSection[] getSections(boolean force) {
         force &= forceLoadSections;
-        sectionLock.readLock().lock();
         LevelChunkSection[] tmp = sections;
-        sectionLock.readLock().unlock();
         if (tmp == null || force) {
             try {
                 sectionLock.writeLock().lock();

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightGetBlocks_Copy.java
@@ -11,7 +11,6 @@ import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_18_R2.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
-import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
@@ -24,6 +23,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.PalettedContainer;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -101,7 +101,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        return -1;
     }
 
     @Override
@@ -187,6 +188,10 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public char[] load(int layer) {
         layer -= getMinSectionPosition();
+        if (blocks[layer] == null) {
+            blocks[layer] = new char[4096];
+            Arrays.fill(blocks[layer], (char) BlockTypesCache.ReservedIDs.AIR);
+        }
         return blocks[layer];
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightGetBlocks.java
@@ -75,9 +75,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -95,6 +97,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             .getInstance()
             .getBukkitImplAdapter());
     private final ReadWriteLock sectionLock = new ReentrantReadWriteLock();
+    private final ReentrantLock callLock = new ReentrantLock();
     private final ServerLevel serverLevel;
     private final int chunkX;
     private final int chunkZ;
@@ -104,14 +107,15 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     private final int maxSectionPosition;
     private final Registry<Biome> biomeRegistry;
     private final IdMap<Holder<Biome>> biomeHolderIdMap;
+    private final ConcurrentHashMap<Integer, PaperweightGetBlocks_Copy> copies = new ConcurrentHashMap<>();
     private LevelChunkSection[] sections;
     private LevelChunk levelChunk;
     private DataLayer[] blockLight;
     private DataLayer[] skyLight;
     private boolean createCopy = false;
-    private PaperweightGetBlocks_Copy copy = null;
     private boolean forceLoadSections = true;
     private boolean lightUpdate = false;
+    private int copyKey = 0;
 
     public PaperweightGetBlocks(World world, int chunkX, int chunkZ) {
         this(((CraftWorld) world).getHandle(), chunkX, chunkZ);
@@ -146,13 +150,27 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempting to set if chunk GET should create copy, but it is not call-locked.");
+        }
         this.createCopy = createCopy;
+        return ++this.copyKey;
     }
 
     @Override
-    public IChunkGet getCopy() {
-        return copy;
+    public IChunkGet getCopy(final int key) {
+        return copies.remove(key);
+    }
+
+    @Override
+    public void lockCall() {
+        this.callLock.lock();
+    }
+
+    @Override
+    public void unlockCall() {
+        this.callLock.unlock();
     }
 
     @Override
@@ -388,8 +406,17 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     @Override
     @SuppressWarnings("rawtypes")
     public synchronized <T extends Future<T>> T call(IChunkSet set, Runnable finalizer) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempted to call chunk GET but chunk was not call-locked.");
+        }
         forceLoadSections = false;
-        copy = createCopy ? new PaperweightGetBlocks_Copy(getChunk()) : null;
+        PaperweightGetBlocks_Copy copy = createCopy ? new PaperweightGetBlocks_Copy(levelChunk) : null;
+        if (createCopy) {
+            if (copies.containsKey(copyKey)) {
+                throw new IllegalStateException("Copy key already used.");
+            }
+            copies.put(copyKey, copy);
+        }
         try {
             ServerLevel nmsWorld = serverLevel;
             LevelChunk nmsChunk = ensureLoaded(nmsWorld, chunkX, chunkZ);
@@ -882,9 +909,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (super.sections[layer] != null) {
             synchronized (super.sectionLocks[layer]) {
                 if (super.sections[layer].isFull() && super.blocks[layer] != null) {
-                    char[] blocks = new char[4096];
-                    System.arraycopy(super.blocks[layer], 0, blocks, 0, 4096);
-                    return blocks;
+                    return super.blocks[layer];
                 }
             }
         }
@@ -1004,9 +1029,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
     public LevelChunkSection[] getSections(boolean force) {
         force &= forceLoadSections;
-        sectionLock.readLock().lock();
         LevelChunkSection[] tmp = sections;
-        sectionLock.readLock().unlock();
         if (tmp == null || force) {
             try {
                 sectionLock.writeLock().lock();

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightGetBlocks_Copy.java
@@ -26,6 +26,7 @@ import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -105,7 +106,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        return -1;
     }
 
     @Override
@@ -199,6 +201,10 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public char[] load(int layer) {
         layer -= getMinSectionPosition();
+        if (blocks[layer] == null) {
+            blocks[layer] = new char[4096];
+            Arrays.fill(blocks[layer], (char) BlockTypesCache.ReservedIDs.AIR);
+        }
         return blocks[layer];
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightGetBlocks.java
@@ -75,9 +75,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -95,6 +97,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             .getInstance()
             .getBukkitImplAdapter());
     private final ReadWriteLock sectionLock = new ReentrantReadWriteLock();
+    private final ReentrantLock callLock = new ReentrantLock();
     private final ServerLevel serverLevel;
     private final int chunkX;
     private final int chunkZ;
@@ -104,14 +107,15 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     private final int maxSectionPosition;
     private final Registry<Biome> biomeRegistry;
     private final IdMap<Holder<Biome>> biomeHolderIdMap;
+    private final ConcurrentHashMap<Integer, PaperweightGetBlocks_Copy> copies = new ConcurrentHashMap<>();
     private LevelChunkSection[] sections;
     private LevelChunk levelChunk;
     private DataLayer[] blockLight;
     private DataLayer[] skyLight;
     private boolean createCopy = false;
-    private PaperweightGetBlocks_Copy copy = null;
     private boolean forceLoadSections = true;
     private boolean lightUpdate = false;
+    private int copyKey = 0;
 
     public PaperweightGetBlocks(World world, int chunkX, int chunkZ) {
         this(((CraftWorld) world).getHandle(), chunkX, chunkZ);
@@ -146,13 +150,27 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempting to set if chunk GET should create copy, but it is not call-locked.");
+        }
         this.createCopy = createCopy;
+        return ++this.copyKey;
     }
 
     @Override
-    public IChunkGet getCopy() {
-        return copy;
+    public IChunkGet getCopy(final int key) {
+        return copies.remove(key);
+    }
+
+    @Override
+    public void lockCall() {
+        this.callLock.lock();
+    }
+
+    @Override
+    public void unlockCall() {
+        this.callLock.unlock();
     }
 
     @Override
@@ -387,8 +405,17 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     @Override
     @SuppressWarnings("rawtypes")
     public synchronized <T extends Future<T>> T call(IChunkSet set, Runnable finalizer) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempted to call chunk GET but chunk was not call-locked.");
+        }
         forceLoadSections = false;
-        copy = createCopy ? new PaperweightGetBlocks_Copy(getChunk()) : null;
+        PaperweightGetBlocks_Copy copy = createCopy ? new PaperweightGetBlocks_Copy(levelChunk) : null;
+        if (createCopy) {
+            if (copies.containsKey(copyKey)) {
+                throw new IllegalStateException("Copy key already used.");
+            }
+            copies.put(copyKey, copy);
+        }
         try {
             ServerLevel nmsWorld = serverLevel;
             LevelChunk nmsChunk = ensureLoaded(nmsWorld, chunkX, chunkZ);
@@ -880,9 +907,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (super.sections[layer] != null) {
             synchronized (super.sectionLocks[layer]) {
                 if (super.sections[layer].isFull() && super.blocks[layer] != null) {
-                    char[] blocks = new char[4096];
-                    System.arraycopy(super.blocks[layer], 0, blocks, 0, 4096);
-                    return blocks;
+                    return super.blocks[layer];
                 }
             }
         }
@@ -1002,9 +1027,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
     public LevelChunkSection[] getSections(boolean force) {
         force &= forceLoadSections;
-        sectionLock.readLock().lock();
         LevelChunkSection[] tmp = sections;
-        sectionLock.readLock().unlock();
         if (tmp == null || force) {
             try {
                 sectionLock.writeLock().lock();

--- a/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightGetBlocks_Copy.java
@@ -26,6 +26,7 @@ import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -105,7 +106,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        return -1;
     }
 
     @Override
@@ -199,6 +201,10 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public char[] load(int layer) {
         layer -= getMinSectionPosition();
+        if (blocks[layer] == null) {
+            blocks[layer] = new char[4096];
+            Arrays.fill(blocks[layer], (char) BlockTypesCache.ReservedIDs.AIR);
+        }
         return blocks[layer];
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -54,9 +54,11 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -74,6 +76,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             .getInstance()
             .getBukkitImplAdapter());
     private final ReadWriteLock sectionLock = new ReentrantReadWriteLock();
+    private final ReentrantLock callLock = new ReentrantLock();
     private final ServerLevel serverLevel;
     private final int chunkX;
     private final int chunkZ;
@@ -83,14 +86,15 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     private final int maxSectionPosition;
     private final Registry<Biome> biomeRegistry;
     private final IdMap<Holder<Biome>> biomeHolderIdMap;
+    private final ConcurrentHashMap<Integer, PaperweightGetBlocks_Copy> copies = new ConcurrentHashMap<>();
     private LevelChunkSection[] sections;
     private LevelChunk levelChunk;
     private DataLayer[] blockLight;
     private DataLayer[] skyLight;
     private boolean createCopy = false;
-    private PaperweightGetBlocks_Copy copy = null;
     private boolean forceLoadSections = true;
     private boolean lightUpdate = false;
+    private int copyKey = 0;
 
     public PaperweightGetBlocks(World world, int chunkX, int chunkZ) {
         this(((CraftWorld) world).getHandle(), chunkX, chunkZ);
@@ -125,13 +129,27 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempting to set if chunk GET should create copy, but it is not call-locked.");
+        }
         this.createCopy = createCopy;
+        return ++this.copyKey;
     }
 
     @Override
-    public IChunkGet getCopy() {
-        return copy;
+    public IChunkGet getCopy(final int key) {
+        return copies.remove(key);
+    }
+
+    @Override
+    public void lockCall() {
+        this.callLock.lock();
+    }
+
+    @Override
+    public void unlockCall() {
+        this.callLock.unlock();
     }
 
     @Override
@@ -366,8 +384,17 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     @Override
     @SuppressWarnings("rawtypes")
     public synchronized <T extends Future<T>> T call(IChunkSet set, Runnable finalizer) {
+        if (!callLock.isHeldByCurrentThread()) {
+            throw new IllegalStateException("Attempted to call chunk GET but chunk was not call-locked.");
+        }
         forceLoadSections = false;
-        copy = createCopy ? new PaperweightGetBlocks_Copy(levelChunk) : null;
+        PaperweightGetBlocks_Copy copy = createCopy ? new PaperweightGetBlocks_Copy(levelChunk) : null;
+        if (createCopy) {
+            if (copies.containsKey(copyKey)) {
+                throw new IllegalStateException("Copy key already used.");
+            }
+            copies.put(copyKey, copy);
+        }
         try {
             ServerLevel nmsWorld = serverLevel;
             LevelChunk nmsChunk = ensureLoaded(nmsWorld, chunkX, chunkZ);
@@ -859,9 +886,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (super.sections[layer] != null) {
             synchronized (super.sectionLocks[layer]) {
                 if (super.sections[layer].isFull() && super.blocks[layer] != null) {
-                    char[] blocks = new char[4096];
-                    System.arraycopy(super.blocks[layer], 0, blocks, 0, 4096);
-                    return blocks;
+                    return super.blocks[layer];
                 }
             }
         }
@@ -981,9 +1006,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
     public LevelChunkSection[] getSections(boolean force) {
         force &= forceLoadSections;
-        sectionLock.readLock().lock();
         LevelChunkSection[] tmp = sections;
-        sectionLock.readLock().unlock();
         if (tmp == null || force) {
             try {
                 sectionLock.writeLock().lock();

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks_Copy.java
@@ -26,6 +26,7 @@ import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -105,7 +106,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        return -1;
     }
 
     @Override
@@ -199,6 +201,10 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public char[] load(int layer) {
         layer -= getMinSectionPosition();
+        if (blocks[layer] == null) {
+            blocks[layer] = new char[4096];
+            Arrays.fill(blocks[layer], (char) BlockTypesCache.ReservedIDs.AIR);
+        }
         return blocks[layer];
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkGet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkGet.java
@@ -50,12 +50,30 @@ public interface IChunkGet extends IBlocks, Trimable, InputExtent, ITileInput {
 
     boolean isCreateCopy();
 
-    void setCreateCopy(boolean createCopy);
+    /**
+     * Not for external API use. Internal use only.
+     */
+    int setCreateCopy(boolean createCopy);
 
     @Nullable
-    default IChunkGet getCopy() {
+    default IChunkGet getCopy(int key) {
         return null;
     }
+
+    /**
+     * Lock the {@link IChunkGet#call(IChunkSet, Runnable)} method to the current thread using a reentrant lock. Also locks
+     * related methods e.g. {@link IChunkGet#setCreateCopy(boolean)}
+     *
+     * @since TODO
+     */
+    default void lockCall() {}
+
+    /**
+     * Unlock {@link IChunkGet#call(IChunkSet, Runnable)} (and other related methods) to executions from other threads
+     *
+     * @since TODO
+     */
+    default void unlockCall() {}
 
     /**
      * Flush the block lighting array (section*blocks) to the chunk GET between the given section indices. Negative allowed.

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IQueueChunk.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IQueueChunk.java
@@ -36,4 +36,18 @@ public interface IQueueChunk<T extends Future<T>> extends IChunk, Callable<T> {
         }
     }
 
+    /**
+     * Get if the thank has any running tasks, locked locks, etc.
+     */
+    default boolean hasRunning() {
+        return false;
+    }
+
+    /**
+     * Prevent set operations to the chunk, should typically be used when a chunk is submitted before the edit is necessarily
+     * completed.
+     */
+    default void lockSet() {
+    }
+
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharBlocks.java
@@ -121,6 +121,7 @@ public abstract class CharBlocks implements IBlocks {
     public synchronized IChunkSet reset() {
         for (int i = 0; i < sectionCount; i++) {
             sections[i] = EMPTY;
+            blocks[i] = null;
         }
         return null;
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/NullChunkGet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/NullChunkGet.java
@@ -69,7 +69,8 @@ public final class NullChunkGet implements IChunkGet {
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        return -1;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -25,8 +25,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Future;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * An abstract {@link IChunk} class that implements basic get/set blocks.
@@ -43,8 +41,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
     public static ChunkHolder newInstance() {
         return POOL.poll();
     }
-
-    private final Lock calledLock = new ReentrantLock();
 
     private volatile IChunkGet chunkExisting; // The existing chunk (e.g. a clipboard, or the world, before changes)
     private volatile IChunkSet chunkSet; // The blocks to be set to the chunkExisting
@@ -68,7 +64,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public synchronized void recycle() {
-        calledLock.lock();
         delegate = NULL;
         if (chunkSet != null) {
             chunkSet.recycle();
@@ -77,7 +72,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
         chunkExisting = null;
         extent = null;
         POOL.offer(this);
-        calledLock.unlock();
     }
 
     public long initAge() {
@@ -88,68 +82,49 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
         return delegate;
     }
 
-    /**
-     * If the chunk is currently being "called", this method will block until completed.
-     */
-    private void checkAndWaitOnCalledLock() {
-        if (!calledLock.tryLock()) {
-            calledLock.lock();
-        }
-        calledLock.unlock();
-    }
-
     @Override
     public boolean setTile(int x, int y, int z, CompoundTag tag) {
-        checkAndWaitOnCalledLock();
         return delegate.set(this).setTile(x, y, z, tag);
     }
 
     @Override
     public CompoundTag getTile(int x, int y, int z) {
-        checkAndWaitOnCalledLock();
         return delegate.set(this).getTile(x, y, z);
     }
 
     @Override
     public void setEntity(CompoundTag tag) {
-        checkAndWaitOnCalledLock();
         delegate.set(this).setEntity(tag);
     }
 
     @Override
     public void removeEntity(UUID uuid) {
-        checkAndWaitOnCalledLock();
         delegate.set(this).removeEntity(uuid);
     }
 
     @Override
     public Set<UUID> getEntityRemoves() {
-        checkAndWaitOnCalledLock();
         return delegate.set(this).getEntityRemoves();
     }
 
     @Override
     public BiomeType[][] getBiomes() {
-        checkAndWaitOnCalledLock();
         // Uses set as this method is only used to retrieve biomes that have been set to the extent/chunk.
         return delegate.set(this).getBiomes();
     }
 
     @Override
     public char[][] getLight() {
-        checkAndWaitOnCalledLock();
         return delegate.set(this).getLight();
     }
 
     @Override
     public char[][] getSkyLight() {
-        checkAndWaitOnCalledLock();
         return delegate.set(this).getSkyLight();
     }
 
     @Override
     public void setBlocks(int layer, char[] data) {
-        checkAndWaitOnCalledLock();
         delegate.set(this).setBlocks(layer, data);
     }
 
@@ -174,12 +149,10 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public void setFastMode(boolean fastmode) {
-        checkAndWaitOnCalledLock();
         this.fastmode = fastmode;
     }
 
     public void setBitMask(int bitMask) {
-        checkAndWaitOnCalledLock();
         this.bitMask = bitMask;
     }
 
@@ -189,7 +162,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public boolean hasBiomes(final int layer) {
-        checkAndWaitOnCalledLock();
         // No need to go through delegate. hasBiomes is SET only.
         return chunkSet != null && chunkSet.hasBiomes(layer);
     }
@@ -200,14 +172,13 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public CompoundTag getEntity(UUID uuid) {
-        checkAndWaitOnCalledLock();
         return delegate.get(this).getEntity(uuid);
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
-        checkAndWaitOnCalledLock();
+    public int setCreateCopy(boolean createCopy) {
         this.createCopy = createCopy;
+        return -1;
     }
 
     @Override
@@ -217,19 +188,16 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public void setLightingToGet(char[][] lighting, int minSectionPosition, int maxSectionPosition) {
-        checkAndWaitOnCalledLock();
         delegate.setLightingToGet(this, lighting);
     }
 
     @Override
     public void setSkyLightingToGet(char[][] lighting, int minSectionPosition, int maxSectionPosition) {
-        checkAndWaitOnCalledLock();
         delegate.setSkyLightingToGet(this, lighting);
     }
 
     @Override
     public void setHeightmapToGet(HeightMapType type, int[] data) {
-        checkAndWaitOnCalledLock();
         delegate.setHeightmapToGet(this, type, data);
     }
 
@@ -254,7 +222,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
     }
 
     public void flushLightToGet() {
-        checkAndWaitOnCalledLock();
         delegate.flushLightToGet(this);
     }
 
@@ -921,19 +888,16 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public Map<BlockVector3, CompoundTag> getTiles() {
-        checkAndWaitOnCalledLock();
         return delegate.get(this).getTiles();
     }
 
     @Override
     public Set<CompoundTag> getEntities() {
-        checkAndWaitOnCalledLock();
         return delegate.get(this).getEntities();
     }
 
     @Override
     public boolean hasSection(int layer) {
-        checkAndWaitOnCalledLock();
         return chunkExisting != null && chunkExisting.hasSection(layer);
     }
 
@@ -958,6 +922,7 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
             if (result) {
                 delegate = NULL;
                 chunkExisting = null;
+                chunkSet.recycle();
                 chunkSet = null;
                 return true;
             }
@@ -985,7 +950,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public boolean isEmpty() {
-        checkAndWaitOnCalledLock();
         return chunkSet == null || chunkSet.isEmpty();
     }
 
@@ -993,7 +957,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
      * Get or create the existing part of this chunk.
      */
     public final IChunkGet getOrCreateGet() {
-        checkAndWaitOnCalledLock();
         if (chunkExisting == null) {
             chunkExisting = newWrappedGet();
             chunkExisting.trim(false);
@@ -1005,7 +968,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
      * Get or create the settable part of this chunk.
      */
     public final IChunkSet getOrCreateSet() {
-        checkAndWaitOnCalledLock();
         if (chunkSet == null) {
             chunkSet = newWrappedSet();
         }
@@ -1026,7 +988,7 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
      * - The purpose of wrapping is to allow different extents to intercept / alter behavior
      * - e.g., caching, optimizations, filtering
      */
-    private synchronized IChunkGet newWrappedGet() {
+    private IChunkGet newWrappedGet() {
         return extent.getCachedGet(chunkX, chunkZ);
     }
 
@@ -1048,42 +1010,42 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public synchronized T call() {
-        calledLock.lock();
         if (chunkSet != null && !chunkSet.isEmpty()) {
-            this.delegate = GET;
             chunkSet.setBitMask(bitMask);
-            try {
-                IChunkSet copy = chunkSet.createCopy();
-                chunkSet = null;
-                return this.call(copy, () -> {
-                    // Do nothing
-                });
-            } catch (Throwable t) {
-                calledLock.unlock();
-                throw t;
-            }
+            IChunkSet copy = chunkSet.createCopy();
+            return this.call(copy, () -> {
+                // Do nothing
+            });
         }
+        recycle();
         return null;
     }
 
+    /**
+     * This method should never be called from outside ChunkHolder
+     */
     @Override
     public synchronized T call(IChunkSet set, Runnable finalize) {
         if (set != null) {
             IChunkGet get = getOrCreateGet();
-            boolean postProcess = !(getExtent().getPostProcessor() instanceof EmptyBatchProcessor);
-            get.setCreateCopy(postProcess);
-            final IChunkSet iChunkSet = getExtent().processSet(this, get, set);
-            Runnable finalizer;
-            if (postProcess) {
-                finalizer = () -> {
-                    getExtent().postProcess(this, get.getCopy(), iChunkSet);
-                    finalize.run();
-                };
-            } else {
-                finalizer = finalize;
+            try {
+                get.lockCall();
+                boolean postProcess = !(getExtent().getPostProcessor() instanceof EmptyBatchProcessor);
+                final IChunkSet iChunkSet = getExtent().processSet(this, get, set);
+                Runnable finalizer;
+                if (postProcess) {
+                    int copyKey = get.setCreateCopy(true);
+                    finalizer = () -> {
+                        getExtent().postProcess(this, get.getCopy(copyKey), iChunkSet);
+                        finalize.run();
+                    };
+                } else {
+                    finalizer = finalize;
+                }
+                return get.call(set, finalizer);
+            } finally {
+                get.unlockCall();
             }
-            calledLock.unlock();
-            return get.call(set, finalizer);
         }
         return null;
     }
@@ -1107,103 +1069,86 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     @Override
     public boolean setBiome(int x, int y, int z, BiomeType biome) {
-        checkAndWaitOnCalledLock();
         return delegate.setBiome(this, x, y, z, biome);
     }
 
     @Override
     public <B extends BlockStateHolder<B>> boolean setBlock(int x, int y, int z, B block) {
-        checkAndWaitOnCalledLock();
         return delegate.setBlock(this, x, y, z, block);
     }
 
     @Override
     public BiomeType getBiomeType(int x, int y, int z) {
-        checkAndWaitOnCalledLock();
         return delegate.getBiome(this, x, y, z);
     }
 
     @Override
     public BlockState getBlock(int x, int y, int z) {
-        checkAndWaitOnCalledLock();
         return delegate.getBlock(this, x, y, z);
     }
 
     @Override
     public BaseBlock getFullBlock(int x, int y, int z) {
-        checkAndWaitOnCalledLock();
         return delegate.getFullBlock(this, x, y, z);
     }
 
     @Override
     public void setSkyLight(int x, int y, int z, int value) {
-        checkAndWaitOnCalledLock();
         delegate.setSkyLight(this, x, y, z, value);
     }
 
     @Override
     public void setHeightMap(HeightMapType type, int[] heightMap) {
-        checkAndWaitOnCalledLock();
         delegate.setHeightMap(this, type, heightMap);
     }
 
     @Override
     public void removeSectionLighting(int layer, boolean sky) {
-        checkAndWaitOnCalledLock();
         delegate.removeSectionLighting(this, layer, sky);
     }
 
     @Override
     public void setFullBright(int layer) {
-        checkAndWaitOnCalledLock();
         delegate.setFullBright(this, layer);
     }
 
     @Override
     public void setBlockLight(int x, int y, int z, int value) {
-        checkAndWaitOnCalledLock();
         delegate.setBlockLight(this, x, y, z, value);
     }
 
     @Override
     public void setLightLayer(int layer, char[] toSet) {
-        checkAndWaitOnCalledLock();
         delegate.setLightLayer(this, layer, toSet);
     }
 
     @Override
     public void setSkyLightLayer(int layer, char[] toSet) {
-        checkAndWaitOnCalledLock();
         delegate.setSkyLightLayer(this, layer, toSet);
     }
 
     @Override
     public int getSkyLight(int x, int y, int z) {
-        checkAndWaitOnCalledLock();
         return delegate.getSkyLight(this, x, y, z);
     }
 
     @Override
     public int getEmittedLight(int x, int y, int z) {
-        checkAndWaitOnCalledLock();
         return delegate.getEmittedLight(this, x, y, z);
     }
 
     @Override
     public int getBrightness(int x, int y, int z) {
-        checkAndWaitOnCalledLock();
         return delegate.getBrightness(this, x, y, z);
     }
 
     @Override
     public int getOpacity(int x, int y, int z) {
-        checkAndWaitOnCalledLock();
         return delegate.getOpacity(this, x, y, z);
     }
 
     @Override
     public int[] getHeightMap(HeightMapType type) {
-        checkAndWaitOnCalledLock();
         return delegate.getHeightMap(this, type);
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/NullChunk.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/NullChunk.java
@@ -184,7 +184,8 @@ public final class NullChunk implements IQueueChunk {
     }
 
     @Override
-    public void setCreateCopy(boolean createCopy) {
+    public int setCreateCopy(boolean createCopy) {
+        return -1;
     }
 
     @Override


### PR DESCRIPTION
 - remove ChunkHolder locking concept as this is no longer needed
 - previously we obtained the copy from chunk GET on finalize, meaning the copy could be replaced by a "newer" one (bad)
 - work around this issue by introducing concept of "unique" keys to map chunk GET copies to
 - correctly handle resetting of various chunk-related classes to actually allow pooling to work
 - remove chunks as they are submitted when flushing a SingleThreadQueueExtenting
 - Fixes #2459
 - Addresses #2448
 - Fixes #2388
