### PR TITLE
Fix "cleared" ellipsoid/cylinder regions still passing isDefined check

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/CylinderRegionSelector.java
@@ -254,6 +254,8 @@ public class CylinderRegionSelector implements RegionSelector, CUIRegion {
     @Override
     public void clear() {
         region = new CylinderRegion(region.getWorld());
+        selectedCenter = false;
+        selectedRadius = false;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/selector/EllipsoidRegionSelector.java
@@ -227,6 +227,8 @@ public class EllipsoidRegionSelector implements RegionSelector, CUIRegion {
     public void clear() {
         region.setCenter(BlockVector3.ZERO);
         region.setRadius(Vector3.ZERO);
+        started = false;
+        selectedRadius = false;
     }
 
     @Override


### PR DESCRIPTION
## Overview
When you clear (`//sel`) a region it should effectively remove your selection. For all selection types except for Ellipsoid/Sphere & Cylinder this is true, but for these two types it simply sets their radii to 0 and center to 0,0,0 whilst leaving them in a state to pass their `isDefined()` checks.

For the Ellipsoid regions, you can still operate on the cleared region, so `//set 1` will set a 1x1x1 cube of stone at 0,0,0

## Description
This fix sets the boolean used to check if the region selection is defined to `false` in the `clear()` method so the user will correctly receieve the "Make a region selection first" error should they try to operate on the region after clearing it.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
