### PR TITLE
Streamline fawe thread names

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/Regenerator.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/Regenerator.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;
 
 /**
@@ -158,16 +159,14 @@ public abstract class Regenerator<IChunkAccess, ProtoChunk extends IChunkAccess,
     }
 
     private boolean generate() throws Exception {
+        ThreadFactory factory = new ThreadFactoryBuilder()
+                .setNameFormat("FAWE Regenerator - %d")
+                .build();
         if (generateConcurrent) {
             //Using concurrent chunk generation
-            executor = Executors.newFixedThreadPool(Settings.settings().QUEUE.PARALLEL_THREADS, new ThreadFactoryBuilder()
-                    .setNameFormat("fawe-regen-%d")
-                    .build()
-            );
+            executor = Executors.newFixedThreadPool(Settings.settings().QUEUE.PARALLEL_THREADS, factory);
         } else { // else using sequential chunk generation, concurrent not supported
-            executor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
-                    .setNameFormat("fawe-regen-%d")
-                    .build());
+            executor = Executors.newSingleThreadExecutor(factory);
         }
 
         //TODO: can we get that required radius down without affecting chunk generation (e.g. strucures, features, ...)?

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/Fawe.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/Fawe.java
@@ -144,7 +144,7 @@ public class Fawe {
                 0L,
                 TimeUnit.MILLISECONDS,
                 new LinkedBlockingQueue<>(),
-                new ThreadFactoryBuilder().setNameFormat("fawe-clipboard-%d").build()
+                new ThreadFactoryBuilder().setNameFormat("FAWE Clipboard - %d").build()
         ));
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/FaweCache.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/FaweCache.java
@@ -18,6 +18,7 @@ import com.fastasyncworldedit.core.util.collection.CleanableThreadLocal;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sk89q.jnbt.ByteArrayTag;
 import com.sk89q.jnbt.ByteTag;
 import com.sk89q.jnbt.CompoundTag;
@@ -48,7 +49,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -616,7 +616,7 @@ public enum FaweCache implements Trimable {
         ArrayBlockingQueue<Runnable> queue = new ArrayBlockingQueue<>(nThreads, true);
         return new ThreadPoolExecutor(nThreads, nThreads,
                 0L, TimeUnit.MILLISECONDS, queue,
-                Executors.defaultThreadFactory(),
+                new ThreadFactoryBuilder().setNameFormat("FAWE Blocking Executor - %d").build(),
                 new ThreadPoolExecutor.CallerRunsPolicy()
         ) {
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/task/FaweForkJoinWorkerThreadFactory.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/task/FaweForkJoinWorkerThreadFactory.java
@@ -2,19 +2,22 @@ package com.fastasyncworldedit.core.util.task;
 
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class FaweForkJoinWorkerThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory {
 
     private final String nameFormat;
+    private final AtomicInteger idCounter;
 
     public FaweForkJoinWorkerThreadFactory(String nameFormat) {
         this.nameFormat = nameFormat;
+        this.idCounter = new AtomicInteger(0);
     }
 
     @Override
     public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
         final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
-        worker.setName(String.format(nameFormat, worker.getPoolIndex()));
+        worker.setName(String.format(nameFormat, idCounter.getAndIncrement()));
         return worker;
     }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

I noticed that the ForkJoinPool threads always have 0 as the identifier because the name is set before they are started. We can resolve that by just counting threads ourselves. I decided to generally clean up the various namings of threads created by FAWE.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
