### PR TITLE
Avoid premature trimming in RegionIntersection

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionIntersection.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/RegionIntersection.java
@@ -164,14 +164,23 @@ public class RegionIntersection extends AbstractRegion {
         int bz = chunk.getZ() << 4;
         int tx = bx + 15;
         int tz = bz + 15;
+        List<Region> intersecting = new ArrayList<>(2);
         for (Region region : regions) {
             BlockVector3 regMin = region.getMinimumPoint();
             BlockVector3 regMax = region.getMaximumPoint();
             if (tx >= regMin.getX() && bx <= regMax.getX() && tz >= regMin.getZ() && bz <= regMax.getZ()) {
-                return region.processSet(chunk, get, set);
+                intersecting.add(region);
             }
         }
-        return null;
+        if (intersecting.isEmpty()) {
+            return null;
+        }
+        if (intersecting.size() == 1) {
+            return intersecting.get(0).processSet(chunk, get, set);
+        }
+        // if multiple regions intersect with this chunk, we must be more careful, otherwise one region might trim content of
+        // another region
+        return super.processSet(chunk, get, set);
     }
 
     @Override


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2470

## Description
<!-- Please describe what this pull request does. -->

RegionIntersection can *delegate* to `Region#processSet` of one of the regions only if only this region overlaps with the chunk to process.
Otherwise, we need to check if any region contains a block before we can trim it, i.e. delegate to the default implementation of processSet.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
