### PR TITLE
Cleanup rawtypes warnings in relighting code

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightStarlightRelighter.java
@@ -3,7 +3,6 @@ package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_17_R1_2;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.lighting.NMSRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
@@ -70,8 +69,7 @@ public class PaperweightStarlightRelighter implements Relighter {
     private final ReentrantLock areaLock = new ReentrantLock();
     private final NMSRelighter delegate;
 
-    @SuppressWarnings("rawtypes")
-    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<IQueueChunk> queue) {
+    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<?> queue) {
         this.serverLevel = serverLevel;
         this.delegate = new NMSRelighter(queue);
     }

--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightStarlightRelighterFactory.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightStarlightRelighterFactory.java
@@ -4,7 +4,6 @@ import com.fastasyncworldedit.core.extent.processor.lighting.NullRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelightMode;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.sk89q.worldedit.world.World;
 import org.bukkit.Bukkit;
@@ -15,9 +14,7 @@ import javax.annotation.Nonnull;
 public class PaperweightStarlightRelighterFactory implements RelighterFactory {
 
     @Override
-    public @Nonnull
-    @SuppressWarnings("rawtypes")
-    Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<IQueueChunk> queue) {
+    public @Nonnull Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<?> queue) {
         org.bukkit.World w = Bukkit.getWorld(world.getName());
         if (w == null) {
             return NullRelighter.INSTANCE;

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightStarlightRelighter.java
@@ -3,7 +3,6 @@ package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_18_R2;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.lighting.NMSRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
@@ -45,8 +44,7 @@ public class PaperweightStarlightRelighter implements Relighter {
     private final ReentrantLock areaLock = new ReentrantLock();
     private final NMSRelighter delegate;
 
-    @SuppressWarnings("rawtypes")
-    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<IQueueChunk> queue) {
+    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<?> queue) {
         this.serverLevel = serverLevel;
         this.delegate = new NMSRelighter(queue);
     }

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightStarlightRelighterFactory.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightStarlightRelighterFactory.java
@@ -4,7 +4,6 @@ import com.fastasyncworldedit.core.extent.processor.lighting.NullRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelightMode;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.sk89q.worldedit.world.World;
 import org.bukkit.Bukkit;
@@ -15,9 +14,7 @@ import javax.annotation.Nonnull;
 public class PaperweightStarlightRelighterFactory implements RelighterFactory {
 
     @Override
-    public @Nonnull
-    @SuppressWarnings("rawtypes")
-    Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<IQueueChunk> queue) {
+    public @Nonnull Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<?> queue) {
         org.bukkit.World w = Bukkit.getWorld(world.getName());
         if (w == null) {
             return NullRelighter.INSTANCE;

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightStarlightRelighter.java
@@ -3,7 +3,6 @@ package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_19_R3;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.lighting.NMSRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
@@ -45,8 +44,7 @@ public class PaperweightStarlightRelighter implements Relighter {
     private final ReentrantLock areaLock = new ReentrantLock();
     private final NMSRelighter delegate;
 
-    @SuppressWarnings("rawtypes")
-    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<IQueueChunk> queue) {
+    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<?> queue) {
         this.serverLevel = serverLevel;
         this.delegate = new NMSRelighter(queue);
     }

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightStarlightRelighterFactory.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightStarlightRelighterFactory.java
@@ -4,7 +4,6 @@ import com.fastasyncworldedit.core.extent.processor.lighting.NullRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelightMode;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.sk89q.worldedit.world.World;
 import org.bukkit.Bukkit;
@@ -15,9 +14,7 @@ import javax.annotation.Nonnull;
 public class PaperweightStarlightRelighterFactory implements RelighterFactory {
 
     @Override
-    public @Nonnull
-    @SuppressWarnings("rawtypes")
-    Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<IQueueChunk> queue) {
+    public @Nonnull Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<?> queue) {
         org.bukkit.World w = Bukkit.getWorld(world.getName());
         if (w == null) {
             return NullRelighter.INSTANCE;

--- a/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightStarlightRelighter.java
@@ -3,7 +3,6 @@ package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R1;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.lighting.NMSRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
@@ -45,8 +44,7 @@ public class PaperweightStarlightRelighter implements Relighter {
     private final ReentrantLock areaLock = new ReentrantLock();
     private final NMSRelighter delegate;
 
-    @SuppressWarnings("rawtypes")
-    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<IQueueChunk> queue) {
+    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<?> queue) {
         this.serverLevel = serverLevel;
         this.delegate = new NMSRelighter(queue);
     }

--- a/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightStarlightRelighterFactory.java
+++ b/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightStarlightRelighterFactory.java
@@ -4,7 +4,6 @@ import com.fastasyncworldedit.core.extent.processor.lighting.NullRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelightMode;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.sk89q.worldedit.world.World;
 import org.bukkit.Bukkit;
@@ -15,9 +14,7 @@ import javax.annotation.Nonnull;
 public class PaperweightStarlightRelighterFactory implements RelighterFactory {
 
     @Override
-    public @Nonnull
-    @SuppressWarnings("rawtypes")
-    Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<IQueueChunk> queue) {
+    public @Nonnull Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<?> queue) {
         org.bukkit.World w = Bukkit.getWorld(world.getName());
         if (w == null) {
             return NullRelighter.INSTANCE;

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightStarlightRelighter.java
@@ -3,7 +3,6 @@ package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.lighting.NMSRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
@@ -45,8 +44,7 @@ public class PaperweightStarlightRelighter implements Relighter {
     private final ReentrantLock areaLock = new ReentrantLock();
     private final NMSRelighter delegate;
 
-    @SuppressWarnings("rawtypes")
-    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<IQueueChunk> queue) {
+    public PaperweightStarlightRelighter(ServerLevel serverLevel, IQueueExtent<?> queue) {
         this.serverLevel = serverLevel;
         this.delegate = new NMSRelighter(queue);
     }

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightStarlightRelighterFactory.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightStarlightRelighterFactory.java
@@ -4,7 +4,6 @@ import com.fastasyncworldedit.core.extent.processor.lighting.NullRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelightMode;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.sk89q.worldedit.world.World;
 import org.bukkit.Bukkit;
@@ -15,9 +14,7 @@ import javax.annotation.Nonnull;
 public class PaperweightStarlightRelighterFactory implements RelighterFactory {
 
     @Override
-    public @Nonnull
-    @SuppressWarnings("rawtypes")
-    Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<IQueueChunk> queue) {
+    public @Nonnull Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<?> queue) {
         org.bukkit.World w = Bukkit.getWorld(world.getName());
         if (w == null) {
             return NullRelighter.INSTANCE;

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSRelighterFactory.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSRelighterFactory.java
@@ -5,7 +5,6 @@ import com.fastasyncworldedit.core.extent.processor.lighting.NMSRelighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelightMode;
 import com.fastasyncworldedit.core.extent.processor.lighting.Relighter;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.sk89q.worldedit.world.World;
 
@@ -14,8 +13,7 @@ import javax.annotation.Nonnull;
 public class NMSRelighterFactory implements RelighterFactory {
 
     @Override
-    public @Nonnull
-    Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<IQueueChunk> queue) {
+    public @Nonnull Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<?> queue) {
         return new NMSRelighter(
                 queue,
                 relightMode != null ? relightMode : RelightMode.valueOf(Settings.settings().LIGHTING.MODE)

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/lighting/NMSRelighter.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/lighting/NMSRelighter.java
@@ -4,7 +4,6 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.math.BlockVectorSet;
 import com.fastasyncworldedit.core.math.MutableBlockVector3;
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkHolder;
 import com.fastasyncworldedit.core.util.MathMan;
@@ -34,7 +33,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
-@SuppressWarnings("rawtypes")
 public class NMSRelighter implements Relighter {
 
     private static final int DISPATCH_SIZE = 64;
@@ -51,7 +49,7 @@ public class NMSRelighter implements Relighter {
     }
 
     public final MutableBlockVector3 mutableBlockPos = new MutableBlockVector3(0, 0, 0);
-    private final IQueueExtent<IQueueChunk> queue;
+    private final IQueueExtent<?> queue;
     private final Map<Long, RelightSkyEntry> skyToRelight;
     private final Object present = new Object();
     private final Map<Long, Integer> chunksToSend;
@@ -66,11 +64,11 @@ public class NMSRelighter implements Relighter {
     private final AtomicBoolean finished = new AtomicBoolean(false);
     private boolean removeFirst;
 
-    public NMSRelighter(IQueueExtent<IQueueChunk> queue) {
+    public NMSRelighter(IQueueExtent<?> queue) {
         this(queue, null);
     }
 
-    public NMSRelighter(IQueueExtent<IQueueChunk> queue, RelightMode relightMode) {
+    public NMSRelighter(IQueueExtent<?> queue, RelightMode relightMode) {
         this.queue = queue;
         this.skyToRelight = new Long2ObjectOpenHashMap<>(12);
         this.lightQueue = new Long2ObjectOpenHashMap<>(12);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/lighting/RelighterFactory.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/lighting/RelighterFactory.java
@@ -1,6 +1,5 @@
 package com.fastasyncworldedit.core.extent.processor.lighting;
 
-import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.sk89q.worldedit.world.World;
 
@@ -25,6 +24,6 @@ public interface RelighterFactory {
      * @return a new Relighter instance with the specified settings.
      */
     @Nonnull
-    Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<IQueueChunk> queue);
+    Relighter createRelighter(RelightMode relightMode, World world, IQueueExtent<?> queue);
 
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

We previously used the raw type `IQueueChunk` as type parameter. However, none of the code depends on that specific interface, we can just fall back to the upper bound `IChunk`. This allows to get rid of warnings and suppressions.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
