### PR TITLE
Reduce duplicated singleton objects

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/FaweCache.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/FaweCache.java
@@ -61,14 +61,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public enum FaweCache implements Trimable {
     /**
-     * @deprecated Use {@link #INSTANCE} to get an instance.
-     */
-    @Deprecated(forRemoval = true, since = "2.0.0")
-    IMP,
-    /**
      * @since 2.0.0
      */
     INSTANCE;
+
+    /**
+     * @deprecated Use {@link #INSTANCE} to get an instance.
+     */
+    @Deprecated(forRemoval = true, since = "2.0.0")
+    public static final FaweCache IMP = INSTANCE;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -19,14 +19,14 @@ import java.util.stream.Stream;
 
 public class Settings extends Config {
 
+    @Ignore
+    static Settings INSTANCE = new Settings();
     /**
      * @deprecated Use {@link #settings()} instead to get an instance.
      */
     @Ignore
     @Deprecated(forRemoval = true, since = "2.0.0")
-    public static final Settings IMP = new Settings();
-    @Ignore
-    static Settings INSTANCE = new Settings();
+    public static final Settings IMP = INSTANCE;
     @Ignore
     public boolean PROTOCOL_SUPPORT_FIX = false;
     @Comment("These first 6 aren't configurable") // This is a comment

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/database/DBHandler.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/database/DBHandler.java
@@ -13,7 +13,7 @@ public class DBHandler {
      * @deprecated Use {@link #dbHandler()} instead.
      */
     @Deprecated(forRemoval = true, since = "2.0.0")
-    public static final DBHandler IMP = new DBHandler();
+    public static final DBHandler IMP = dbHandler();
     private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static DBHandler INSTANCE;
     private final Map<World, RollbackDatabase> databases = new ConcurrentHashMap<>(8, 0.9f, 1);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/WEManager.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/WEManager.java
@@ -32,7 +32,7 @@ public class WEManager {
      * @deprecated Use {@link #weManager()} instead.
      */
     @Deprecated(forRemoval = true, since = "2.0.0")
-    public static WEManager IMP = new WEManager();
+    public static WEManager IMP = weManager();
     private final ArrayDeque<FaweMaskManager> managers = new ArrayDeque<>();
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistorySubCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistorySubCommands.java
@@ -201,7 +201,7 @@ public class HistorySubCommands {
                                                         .at(summary.maxX, world.getMaxY(), summary.maxZ)
                                         );
                                         rollback.setTime(historyFile.lastModified());
-                                        RollbackDatabase db = DBHandler.IMP
+                                        RollbackDatabase db = DBHandler.dbHandler()
                                                 .getDatabase(world);
                                         db.logEdit(rollback);
                                         actor.print(TextComponent.of("Logging: " + historyFile));


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

I noticed that we initialize a few objects that are meant to be singletons twice and keep them in memory.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
