### PR TITLE
Use FastSchematicReader by default

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -313,9 +313,9 @@ public class SchematicCommands {
             Actor actor, LocalSession session,
             @Arg(desc = "File name.")
                     String filename,
-            @Arg(desc = "Format name.", def = "fast")
-                    String formatName,
             //FAWE start - random rotation
+            @Arg(desc = "Format name.", def = "")
+                    String formatName,
             @Switch(name = 'r', desc = "Apply random rotation to the clipboard")
                     boolean randomRotate
             //FAWE end
@@ -325,6 +325,11 @@ public class SchematicCommands {
         //FAWE start
         ClipboardFormat format;
         InputStream in = null;
+        // if format is set explicitly, do not look up by extension!
+        boolean noExplicitFormat = formatName == null;
+        if (noExplicitFormat) {
+            formatName = "fast";
+        }
         try {
             URI uri;
             if (formatName.startsWith("url:")) {
@@ -369,7 +374,7 @@ public class SchematicCommands {
                         actor.print(Caption.of("fawe.error.no-perm", "worldedit.schematic.load.other"));
                         return;
                     }
-                    if (filename.matches(".*\\.[\\w].*")) {
+                    if (noExplicitFormat && filename.matches(".*\\.[\\w].*")) {
                         format = ClipboardFormats
                                 .findByExtension(filename.substring(filename.lastIndexOf('.') + 1));
                     } else {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/ClipboardFormats.java
@@ -26,7 +26,6 @@ import com.fastasyncworldedit.core.extent.clipboard.MultiClipboardHolder;
 import com.fastasyncworldedit.core.extent.clipboard.URIClipboardHolder;
 import com.fastasyncworldedit.core.internal.io.FastByteArrayOutputStream;
 import com.fastasyncworldedit.core.util.MainUtil;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.io.ByteSource;
@@ -51,6 +50,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -64,7 +64,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class ClipboardFormats {
 
     private static final Map<String, ClipboardFormat> aliasMap = new HashMap<>();
-    private static final Multimap<String, ClipboardFormat> fileExtensionMap = HashMultimap.create();
+    // FAWE start - keep order of ClipboardFormat entries -> prefer FAST over SPONGE_SCHEMATIC
+    private static final Multimap<String, ClipboardFormat> fileExtensionMap = Multimaps.newMultimap(new HashMap<>(), LinkedHashSet::new);
+    // FAWE end
     private static final List<ClipboardFormat> registeredFormats = new ArrayList<>();
 
     public static void registerClipboardFormat(ClipboardFormat format) {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`HashMultiMap` has no guarantees about the order of the values for a key. In our case, this leads to SPONGE_SCHEMATIC being first when iterating in `ClipboardFormats.findByExtension(...)`. We want FAST to come before, therefore we should use a `MultiMap` where values are in the order they are registered. This matches the `registeredFormats` list used by `findByFile`.

The change to the command is needed to allow actually enforcing a different schematic format.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
