### PR TITLE
Reuse generateTree code across versions

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_17_R1_2/PaperweightFaweAdapter.java
@@ -1,7 +1,6 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_17_R1_2;
 
-import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
-import com.fastasyncworldedit.bukkit.adapter.IDelegateBukkitImplAdapter;
+import com.fastasyncworldedit.bukkit.adapter.FaweAdapter;
 import com.fastasyncworldedit.bukkit.adapter.NMSRelighterFactory;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.entity.LazyBaseEntity;
@@ -10,16 +9,13 @@ import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
 import com.fastasyncworldedit.core.util.NbtUtils;
-import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.sk89q.jnbt.Tag;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.ext.fawe.PaperweightAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_17_R1_2.nbt.PaperweightLazyCompoundTag;
@@ -39,7 +35,6 @@ import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.SideEffectSet;
-import com.sk89q.worldedit.util.TreeGenerator;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.nbt.BinaryTag;
 import com.sk89q.worldedit.util.nbt.CompoundBinaryTag;
@@ -79,14 +74,12 @@ import net.minecraft.world.level.chunk.LevelChunkSection;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.TreeType;
+import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_17_R1.CraftChunk;
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_17_R1.block.CraftBlockState;
 import org.bukkit.craftbukkit.v1_17_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
@@ -110,8 +103,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
-        IDelegateBukkitImplAdapter<net.minecraft.nbt.Tag> {
+public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.Tag, ServerLevel> {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -235,11 +227,10 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     public BlockState getBlock(Location location) {
         Preconditions.checkNotNull(location);
 
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         int x = location.getBlockX();
         int y = location.getBlockY();
         int z = location.getBlockZ();
-        final ServerLevel handle = craftWorld.getHandle();
+        final ServerLevel handle = getServerLevel(location.getWorld());
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
         final BlockPos blockPos = new BlockPos(x, y, z);
         final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(blockPos);
@@ -255,12 +246,11 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     public BaseBlock getFullBlock(final Location location) {
         Preconditions.checkNotNull(location);
 
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         int x = location.getBlockX();
         int y = location.getBlockY();
         int z = location.getBlockZ();
 
-        final ServerLevel handle = craftWorld.getHandle();
+        final ServerLevel handle = getServerLevel(location.getWorld());
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
         final BlockPos blockPos = new BlockPos(x, y, z);
         final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(blockPos);
@@ -344,10 +334,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(org.bukkit.World world) {
-        return new PaperweightFaweWorldNativeAccess(
-                this,
-                new WeakReference<>(((CraftWorld) world).getHandle())
-        );
+        return new PaperweightFaweWorldNativeAccess(this, new WeakReference<>(getServerLevel(world)));
     }
 
     @Override
@@ -492,7 +479,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public void sendFakeChunk(org.bukkit.World world, Player player, ChunkPacket chunkPacket) {
-        ServerLevel nmsWorld = ((CraftWorld) world).getHandle();
+        ServerLevel nmsWorld = getServerLevel(world);
         ChunkHolder map = PaperweightPlatformAdapter.getPlayerChunk(nmsWorld, chunkPacket.getChunkX(), chunkPacket.getChunkZ());
         if (map != null && map.wasAccessibleSinceLastSave()) {
             boolean flag = false;
@@ -530,7 +517,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockState1 = Block.stateById(internalId);
         return blockState1.hasPostProcess(
-                ((CraftWorld) world).getHandle(),
+                getServerLevel(world),
                 new BlockPos(blockVector3.getX(), blockVector3.getY(), blockVector3.getZ())
         );
     }
@@ -546,54 +533,33 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     }
 
     @Override
-    public boolean generateTree(
-            TreeGenerator.TreeType treeType, EditSession editSession, BlockVector3 blockVector3,
-            org.bukkit.World bukkitWorld
-    ) {
-        TreeType bukkitType = BukkitWorld.toBukkitTreeType(treeType);
-        if (bukkitType == TreeType.CHORUS_PLANT) {
-            blockVector3 = blockVector3.add(
-                    0,
-                    1,
-                    0
-            ); // bukkit skips the feature gen which does this offset normally, so we have to add it back
-        }
-        ServerLevel serverLevel = ((CraftWorld) bukkitWorld).getHandle();
-        final BlockVector3 finalBlockVector = blockVector3;
-        // Sync to main thread to ensure no clashes occur
-        Map<BlockPos, CraftBlockState> placed = TaskManager.taskManager().sync(() -> {
-            serverLevel.captureTreeGeneration = true;
-            serverLevel.captureBlockStates = true;
-            try {
-                if (!bukkitWorld.generateTree(BukkitAdapter.adapt(bukkitWorld, finalBlockVector), bukkitType)) {
-                    return null;
-                }
-                return ImmutableMap.copyOf(serverLevel.capturedBlockStates);
-            } finally {
-                serverLevel.captureBlockStates = false;
-                serverLevel.captureTreeGeneration = false;
-                serverLevel.capturedBlockStates.clear();
-            }
-        });
-        if (placed == null || placed.isEmpty()) {
-            return false;
-        }
-        for (CraftBlockState craftBlockState : placed.values()) {
-            if (craftBlockState == null || craftBlockState.getType() == Material.AIR) {
-                continue;
-            }
-            editSession.setBlock(craftBlockState.getX(), craftBlockState.getY(), craftBlockState.getZ(),
-                    BukkitAdapter.adapt(((org.bukkit.block.BlockState) craftBlockState).getBlockData())
-            );
-        }
-        return true;
+    protected void preCaptureStates(final ServerLevel serverLevel) {
+        serverLevel.captureTreeGeneration = true;
+        serverLevel.captureBlockStates = true;
+    }
+
+    @Override
+    protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
+        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+    }
+
+    @Override
+    protected void postCaptureBlockStates(final ServerLevel serverLevel) {
+        serverLevel.captureBlockStates = false;
+        serverLevel.captureTreeGeneration = false;
+        serverLevel.capturedBlockStates.clear();
+    }
+
+    @Override
+    protected ServerLevel getServerLevel(final World world) {
+        return ((CraftWorld) world).getHandle();
     }
 
     @Override
     public List<org.bukkit.entity.Entity> getEntities(org.bukkit.World world) {
         // Quickly add each entity to a list copy.
         List<Entity> mcEntities = new ArrayList<>();
-        ((CraftWorld) world).getHandle().entityManager.getEntityGetter().getAll().forEach(mcEntities::add);
+        getServerLevel(world).entityManager.getEntityGetter().getAll().forEach(mcEntities::add);
 
         List<org.bukkit.entity.Entity> list = new ArrayList<>();
         mcEntities.forEach((mcEnt) -> {

--- a/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_18_R2/PaperweightFaweAdapter.java
@@ -1,7 +1,6 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_18_R2;
 
-import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
-import com.fastasyncworldedit.bukkit.adapter.IDelegateBukkitImplAdapter;
+import com.fastasyncworldedit.bukkit.adapter.FaweAdapter;
 import com.fastasyncworldedit.bukkit.adapter.NMSRelighterFactory;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.entity.LazyBaseEntity;
@@ -10,16 +9,13 @@ import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
 import com.fastasyncworldedit.core.util.NbtUtils;
-import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.sk89q.jnbt.Tag;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.blocks.TileEntityBlock;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_18_R2.PaperweightAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_18_R2.nbt.PaperweightLazyCompoundTag;
@@ -39,7 +35,6 @@ import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.SideEffectSet;
-import com.sk89q.worldedit.util.TreeGenerator;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.nbt.BinaryTag;
 import com.sk89q.worldedit.util.nbt.CompoundBinaryTag;
@@ -80,14 +75,12 @@ import net.minecraft.world.level.chunk.LevelChunkSection;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.TreeType;
+import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_18_R2.CraftChunk;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_18_R2.block.CraftBlockState;
 import org.bukkit.craftbukkit.v1_18_R2.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
@@ -111,8 +104,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
-        IDelegateBukkitImplAdapter<net.minecraft.nbt.Tag> {
+public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.Tag, ServerLevel> {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -235,11 +227,10 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     public BlockState getBlock(Location location) {
         Preconditions.checkNotNull(location);
 
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         int x = location.getBlockX();
         int y = location.getBlockY();
         int z = location.getBlockZ();
-        final ServerLevel handle = craftWorld.getHandle();
+        final ServerLevel handle = getServerLevel(location.getWorld());
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
         final BlockPos blockPos = new BlockPos(x, y, z);
         final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(blockPos);
@@ -255,12 +246,11 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     public BaseBlock getFullBlock(final Location location) {
         Preconditions.checkNotNull(location);
 
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         int x = location.getBlockX();
         int y = location.getBlockY();
         int z = location.getBlockZ();
 
-        final ServerLevel handle = craftWorld.getHandle();
+        final ServerLevel handle = getServerLevel(location.getWorld());
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
         final BlockPos blockPos = new BlockPos(x, y, z);
         final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(blockPos);
@@ -337,10 +327,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(org.bukkit.World world) {
-        return new PaperweightFaweWorldNativeAccess(
-                this,
-                new WeakReference<>(((CraftWorld) world).getHandle())
-        );
+        return new PaperweightFaweWorldNativeAccess(this, new WeakReference<>(getServerLevel(world)));
     }
 
     @Override
@@ -485,7 +472,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public void sendFakeChunk(org.bukkit.World world, Player player, ChunkPacket chunkPacket) {
-        ServerLevel nmsWorld = ((CraftWorld) world).getHandle();
+        ServerLevel nmsWorld = getServerLevel(world);
         ChunkHolder map = PaperweightPlatformAdapter.getPlayerChunk(nmsWorld, chunkPacket.getChunkX(), chunkPacket.getChunkZ());
         if (map != null && map.wasAccessibleSinceLastSave()) {
             // PlayerChunk.d players = map.players;
@@ -522,7 +509,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockState1 = Block.stateById(internalId);
         return blockState1.hasPostProcess(
-                ((CraftWorld) world).getHandle(),
+                getServerLevel(world),
                 new BlockPos(blockVector3.getX(), blockVector3.getY(), blockVector3.getZ())
         );
     }
@@ -538,54 +525,33 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     }
 
     @Override
-    public boolean generateTree(
-            TreeGenerator.TreeType treeType, EditSession editSession, BlockVector3 blockVector3,
-            org.bukkit.World bukkitWorld
-    ) {
-        TreeType bukkitType = BukkitWorld.toBukkitTreeType(treeType);
-        if (bukkitType == TreeType.CHORUS_PLANT) {
-            blockVector3 = blockVector3.add(
-                    0,
-                    1,
-                    0
-            ); // bukkit skips the feature gen which does this offset normally, so we have to add it back
-        }
-        ServerLevel serverLevel = ((CraftWorld) bukkitWorld).getHandle();
-        final BlockVector3 finalBlockVector = blockVector3;
-        // Sync to main thread to ensure no clashes occur
-        Map<BlockPos, CraftBlockState> placed = TaskManager.taskManager().sync(() -> {
-            serverLevel.captureTreeGeneration = true;
-            serverLevel.captureBlockStates = true;
-            try {
-                if (!bukkitWorld.generateTree(BukkitAdapter.adapt(bukkitWorld, finalBlockVector), bukkitType)) {
-                    return null;
-                }
-                return ImmutableMap.copyOf(serverLevel.capturedBlockStates);
-            } finally {
-                serverLevel.captureBlockStates = false;
-                serverLevel.captureTreeGeneration = false;
-                serverLevel.capturedBlockStates.clear();
-            }
-        });
-        if (placed == null || placed.isEmpty()) {
-            return false;
-        }
-        for (CraftBlockState craftBlockState : placed.values()) {
-            if (craftBlockState == null || craftBlockState.getType() == Material.AIR) {
-                continue;
-            }
-            editSession.setBlock(craftBlockState.getX(), craftBlockState.getY(), craftBlockState.getZ(),
-                    BukkitAdapter.adapt(((org.bukkit.block.BlockState) craftBlockState).getBlockData())
-            );
-        }
-        return true;
+    protected void preCaptureStates(final ServerLevel serverLevel) {
+        serverLevel.captureTreeGeneration = true;
+        serverLevel.captureBlockStates = true;
+    }
+
+    @Override
+    protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
+        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+    }
+
+    @Override
+    protected void postCaptureBlockStates(final ServerLevel serverLevel) {
+        serverLevel.captureBlockStates = false;
+        serverLevel.captureTreeGeneration = false;
+        serverLevel.capturedBlockStates.clear();
+    }
+
+    @Override
+    protected ServerLevel getServerLevel(final World world) {
+        return ((CraftWorld) world).getHandle();
     }
 
     @Override
     public List<org.bukkit.entity.Entity> getEntities(org.bukkit.World world) {
         // Quickly add each entity to a list copy.
         List<Entity> mcEntities = new ArrayList<>();
-        ((CraftWorld) world).getHandle().entityManager.getEntityGetter().getAll().forEach(mcEntities::add);
+        getServerLevel(world).entityManager.getEntityGetter().getAll().forEach(mcEntities::add);
 
         List<org.bukkit.entity.Entity> list = new ArrayList<>();
         mcEntities.forEach((mcEnt) -> {

--- a/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightFaweAdapter.java
@@ -1,7 +1,6 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R1;
 
-import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
-import com.fastasyncworldedit.bukkit.adapter.IDelegateBukkitImplAdapter;
+import com.fastasyncworldedit.bukkit.adapter.FaweAdapter;
 import com.fastasyncworldedit.bukkit.adapter.NMSRelighterFactory;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.entity.LazyBaseEntity;
@@ -10,15 +9,12 @@ import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
 import com.fastasyncworldedit.core.util.NbtUtils;
-import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.sk89q.jnbt.Tag;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R1.PaperweightAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R1.nbt.PaperweightLazyCompoundTag;
@@ -38,7 +34,6 @@ import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.SideEffectSet;
-import com.sk89q.worldedit.util.TreeGenerator;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.nbt.BinaryTag;
 import com.sk89q.worldedit.util.nbt.CompoundBinaryTag;
@@ -77,13 +72,11 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.TreeType;
+import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_20_R1.block.CraftBlockState;
 import org.bukkit.craftbukkit.v1_20_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftPlayer;
@@ -111,8 +104,7 @@ import java.util.stream.Stream;
 
 import static net.minecraft.core.registries.Registries.BIOME;
 
-public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
-        IDelegateBukkitImplAdapter<net.minecraft.nbt.Tag> {
+public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.Tag, ServerLevel> {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static Method CHUNK_HOLDER_WAS_ACCESSIBLE_SINCE_LAST_SAVE;
@@ -244,11 +236,10 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     public BlockState getBlock(Location location) {
         Preconditions.checkNotNull(location);
 
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         int x = location.getBlockX();
         int y = location.getBlockY();
         int z = location.getBlockZ();
-        final ServerLevel handle = craftWorld.getHandle();
+        final ServerLevel handle = getServerLevel(location.getWorld());
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
         final BlockPos blockPos = new BlockPos(x, y, z);
         final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(blockPos);
@@ -264,12 +255,11 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     public BaseBlock getFullBlock(final Location location) {
         Preconditions.checkNotNull(location);
 
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         int x = location.getBlockX();
         int y = location.getBlockY();
         int z = location.getBlockZ();
 
-        final ServerLevel handle = craftWorld.getHandle();
+        final ServerLevel handle = getServerLevel(location.getWorld());
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
         final BlockPos blockPos = new BlockPos(x, y, z);
         final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(blockPos);
@@ -298,10 +288,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(org.bukkit.World world) {
-        return new PaperweightFaweWorldNativeAccess(
-                this,
-                new WeakReference<>(((CraftWorld) world).getHandle())
-        );
+        return new PaperweightFaweWorldNativeAccess(this, new WeakReference<>(getServerLevel(world)));
     }
 
     @Override
@@ -446,7 +433,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public void sendFakeChunk(org.bukkit.World world, Player player, ChunkPacket chunkPacket) {
-        ServerLevel nmsWorld = ((CraftWorld) world).getHandle();
+        ServerLevel nmsWorld = getServerLevel(world);
         ChunkHolder map = PaperweightPlatformAdapter.getPlayerChunk(nmsWorld, chunkPacket.getChunkX(), chunkPacket.getChunkZ());
         if (map != null && wasAccessibleSinceLastSave(map)) {
             boolean flag = false;
@@ -484,7 +471,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockState1 = Block.stateById(internalId);
         return blockState1.hasPostProcess(
-                ((CraftWorld) world).getHandle(),
+                getServerLevel(world),
                 new BlockPos(blockVector3.getX(), blockVector3.getY(), blockVector3.getZ())
         );
     }
@@ -501,47 +488,26 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     }
 
     @Override
-    public boolean generateTree(
-            TreeGenerator.TreeType treeType, EditSession editSession, BlockVector3 blockVector3,
-            org.bukkit.World bukkitWorld
-    ) {
-        TreeType bukkitType = BukkitWorld.toBukkitTreeType(treeType);
-        if (bukkitType == TreeType.CHORUS_PLANT) {
-            blockVector3 = blockVector3.add(
-                    0,
-                    1,
-                    0
-            ); // bukkit skips the feature gen which does this offset normally, so we have to add it back
-        }
-        ServerLevel serverLevel = ((CraftWorld) bukkitWorld).getHandle();
-        final BlockVector3 finalBlockVector = blockVector3;
-        // Sync to main thread to ensure no clashes occur
-        Map<BlockPos, CraftBlockState> placed = TaskManager.taskManager().sync(() -> {
-            serverLevel.captureTreeGeneration = true;
-            serverLevel.captureBlockStates = true;
-            try {
-                if (!bukkitWorld.generateTree(BukkitAdapter.adapt(bukkitWorld, finalBlockVector), bukkitType)) {
-                    return null;
-                }
-                return ImmutableMap.copyOf(serverLevel.capturedBlockStates);
-            } finally {
-                serverLevel.captureBlockStates = false;
-                serverLevel.captureTreeGeneration = false;
-                serverLevel.capturedBlockStates.clear();
-            }
-        });
-        if (placed == null || placed.isEmpty()) {
-            return false;
-        }
-        for (CraftBlockState craftBlockState : placed.values()) {
-            if (craftBlockState == null || craftBlockState.getType() == Material.AIR) {
-                continue;
-            }
-            editSession.setBlock(craftBlockState.getX(), craftBlockState.getY(), craftBlockState.getZ(),
-                    BukkitAdapter.adapt(((org.bukkit.block.BlockState) craftBlockState).getBlockData())
-            );
-        }
-        return true;
+    protected void preCaptureStates(final ServerLevel serverLevel) {
+        serverLevel.captureTreeGeneration = true;
+        serverLevel.captureBlockStates = true;
+    }
+
+    @Override
+    protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
+        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+    }
+
+    @Override
+    protected void postCaptureBlockStates(final ServerLevel serverLevel) {
+        serverLevel.captureBlockStates = false;
+        serverLevel.captureTreeGeneration = false;
+        serverLevel.capturedBlockStates.clear();
+    }
+
+    @Override
+    protected ServerLevel getServerLevel(final World world) {
+        return ((CraftWorld) world).getHandle();
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -1,7 +1,6 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2;
 
-import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
-import com.fastasyncworldedit.bukkit.adapter.IDelegateBukkitImplAdapter;
+import com.fastasyncworldedit.bukkit.adapter.FaweAdapter;
 import com.fastasyncworldedit.bukkit.adapter.NMSRelighterFactory;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.entity.LazyBaseEntity;
@@ -10,15 +9,12 @@ import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
 import com.fastasyncworldedit.core.util.NbtUtils;
-import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.sk89q.jnbt.Tag;
-import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2.regen.PaperweightRegen;
@@ -37,7 +33,6 @@ import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.SideEffectSet;
-import com.sk89q.worldedit.util.TreeGenerator;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.nbt.BinaryTag;
 import com.sk89q.worldedit.util.nbt.CompoundBinaryTag;
@@ -76,13 +71,11 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.TreeType;
+import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_20_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_20_R2.block.CraftBlockState;
 import org.bukkit.craftbukkit.v1_20_R2.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_20_R2.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_20_R2.entity.CraftPlayer;
@@ -110,8 +103,7 @@ import java.util.stream.Stream;
 
 import static net.minecraft.core.registries.Registries.BIOME;
 
-public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
-        IDelegateBukkitImplAdapter<net.minecraft.nbt.Tag> {
+public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.Tag, ServerLevel> {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static Method CHUNK_HOLDER_WAS_ACCESSIBLE_SINCE_LAST_SAVE;
@@ -247,11 +239,10 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     public BlockState getBlock(Location location) {
         Preconditions.checkNotNull(location);
 
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         int x = location.getBlockX();
         int y = location.getBlockY();
         int z = location.getBlockZ();
-        final ServerLevel handle = craftWorld.getHandle();
+        final ServerLevel handle = getServerLevel(location.getWorld());
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
         final BlockPos blockPos = new BlockPos(x, y, z);
         final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(blockPos);
@@ -267,12 +258,11 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     public BaseBlock getFullBlock(final Location location) {
         Preconditions.checkNotNull(location);
 
-        CraftWorld craftWorld = ((CraftWorld) location.getWorld());
         int x = location.getBlockX();
         int y = location.getBlockY();
         int z = location.getBlockZ();
 
-        final ServerLevel handle = craftWorld.getHandle();
+        final ServerLevel handle = getServerLevel(location.getWorld());
         LevelChunk chunk = handle.getChunk(x >> 4, z >> 4);
         final BlockPos blockPos = new BlockPos(x, y, z);
         final net.minecraft.world.level.block.state.BlockState blockData = chunk.getBlockState(blockPos);
@@ -301,10 +291,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(org.bukkit.World world) {
-        return new PaperweightFaweWorldNativeAccess(
-                this,
-                new WeakReference<>(((CraftWorld) world).getHandle())
-        );
+        return new PaperweightFaweWorldNativeAccess(this, new WeakReference<>(getServerLevel(world)));
     }
 
     @Override
@@ -449,7 +436,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
 
     @Override
     public void sendFakeChunk(org.bukkit.World world, Player player, ChunkPacket chunkPacket) {
-        ServerLevel nmsWorld = ((CraftWorld) world).getHandle();
+        ServerLevel nmsWorld = getServerLevel(world);
         ChunkHolder map = PaperweightPlatformAdapter.getPlayerChunk(nmsWorld, chunkPacket.getChunkX(), chunkPacket.getChunkZ());
         if (map != null && wasAccessibleSinceLastSave(map)) {
             boolean flag = false;
@@ -487,7 +474,7 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
         int internalId = BlockStateIdAccess.getBlockStateId(blockState);
         net.minecraft.world.level.block.state.BlockState blockState1 = Block.stateById(internalId);
         return blockState1.hasPostProcess(
-                ((CraftWorld) world).getHandle(),
+                getServerLevel(world),
                 new BlockPos(blockVector3.getX(), blockVector3.getY(), blockVector3.getZ())
         );
     }
@@ -504,47 +491,26 @@ public final class PaperweightFaweAdapter extends CachedBukkitAdapter implements
     }
 
     @Override
-    public boolean generateTree(
-            TreeGenerator.TreeType treeType, EditSession editSession, BlockVector3 blockVector3,
-            org.bukkit.World bukkitWorld
-    ) {
-        TreeType bukkitType = BukkitWorld.toBukkitTreeType(treeType);
-        if (bukkitType == TreeType.CHORUS_PLANT) {
-            blockVector3 = blockVector3.add(
-                    0,
-                    1,
-                    0
-            ); // bukkit skips the feature gen which does this offset normally, so we have to add it back
-        }
-        ServerLevel serverLevel = ((CraftWorld) bukkitWorld).getHandle();
-        final BlockVector3 finalBlockVector = blockVector3;
-        // Sync to main thread to ensure no clashes occur
-        Map<BlockPos, CraftBlockState> placed = TaskManager.taskManager().sync(() -> {
-            serverLevel.captureTreeGeneration = true;
-            serverLevel.captureBlockStates = true;
-            try {
-                if (!bukkitWorld.generateTree(BukkitAdapter.adapt(bukkitWorld, finalBlockVector), bukkitType)) {
-                    return null;
-                }
-                return ImmutableMap.copyOf(serverLevel.capturedBlockStates);
-            } finally {
-                serverLevel.captureBlockStates = false;
-                serverLevel.captureTreeGeneration = false;
-                serverLevel.capturedBlockStates.clear();
-            }
-        });
-        if (placed == null || placed.isEmpty()) {
-            return false;
-        }
-        for (CraftBlockState craftBlockState : placed.values()) {
-            if (craftBlockState == null || craftBlockState.getType() == Material.AIR) {
-                continue;
-            }
-            editSession.setBlock(craftBlockState.getX(), craftBlockState.getY(), craftBlockState.getZ(),
-                    BukkitAdapter.adapt(((org.bukkit.block.BlockState) craftBlockState).getBlockData())
-            );
-        }
-        return true;
+    protected void preCaptureStates(final ServerLevel serverLevel) {
+        serverLevel.captureTreeGeneration = true;
+        serverLevel.captureBlockStates = true;
+    }
+
+    @Override
+    protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
+        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+    }
+
+    @Override
+    protected void postCaptureBlockStates(final ServerLevel serverLevel) {
+        serverLevel.captureBlockStates = false;
+        serverLevel.captureTreeGeneration = false;
+        serverLevel.capturedBlockStates.clear();
+    }
+
+    @Override
+    protected ServerLevel getServerLevel(final World world) {
+        return ((CraftWorld) world).getHandle();
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
@@ -1,0 +1,72 @@
+package com.fastasyncworldedit.bukkit.adapter;
+
+import com.fastasyncworldedit.core.util.TaskManager;
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.BukkitWorld;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.util.TreeGenerator;
+import org.bukkit.Material;
+import org.bukkit.TreeType;
+import org.bukkit.World;
+import org.bukkit.block.BlockState;
+
+import java.util.List;
+
+/**
+ * A base class for version-specific implementations of the BukkitImplAdapter
+ *
+ * @param <TAG>          the version-specific NBT tag type
+ * @param <SERVER_LEVEL> the version-specific ServerLevel type
+ */
+public abstract class FaweAdapter<TAG, SERVER_LEVEL> extends CachedBukkitAdapter implements IDelegateBukkitImplAdapter<TAG> {
+
+    @Override
+    public boolean generateTree(
+            final TreeGenerator.TreeType treeType,
+            final EditSession editSession,
+            BlockVector3 blockVector3,
+            final World world
+    ) {
+        TreeType bukkitType = BukkitWorld.toBukkitTreeType(treeType);
+        if (bukkitType == TreeType.CHORUS_PLANT) {
+            // bukkit skips the feature gen which does this offset normally, so we have to add it back
+            blockVector3 = blockVector3.add(BlockVector3.UNIT_Y);
+        }
+        BlockVector3 target = blockVector3;
+        SERVER_LEVEL serverLevel = getServerLevel(world);
+        List<BlockState> placed = TaskManager.taskManager().sync(() -> {
+            preCaptureStates(serverLevel);
+            try {
+                if (!world.generateTree(BukkitAdapter.adapt(world, target), bukkitType)) {
+                    return null;
+                }
+                return getCapturedBlockStatesCopy(serverLevel);
+            } finally {
+                postCaptureBlockStates(serverLevel);
+            }
+        });
+
+        if (placed == null || placed.isEmpty()) {
+            return false;
+        }
+        for (BlockState blockState : placed) {
+            if (blockState == null || blockState.getType() == Material.AIR) {
+                continue;
+            }
+            editSession.setBlock(blockState.getX(), blockState.getY(), blockState.getZ(),
+                    BukkitAdapter.adapt(blockState.getBlockData())
+            );
+        }
+        return true;
+    }
+
+    protected abstract void preCaptureStates(SERVER_LEVEL serverLevel);
+
+    protected abstract List<BlockState> getCapturedBlockStatesCopy(SERVER_LEVEL serverLevel);
+
+    protected abstract void postCaptureBlockStates(SERVER_LEVEL serverLevel);
+
+    protected abstract SERVER_LEVEL getServerLevel(World world);
+
+}


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

The `generateTree` code is pretty stable, and we currently just copy it from one version to another. We can introduce a common superclass to deal with the version independent parts of the code and only implement the relevant parts in the versioned adapters.

It would be possible to replace more code using MethodHandles, but I don't think this makes things clearer.

There are also more things in those classes that could potentially deduplicated in a similar manner, but I think this is already hard enough to review properly, and the benefit in other methods seems smaller.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
