### PR TITLE
Fix build configuration cyclic error (WE port)

### DIFF
--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -141,20 +141,15 @@ tasks.named<Jar>("jar") {
 addJarManifest(WorldEditKind.Plugin, includeClasspath = true)
 
 tasks.named<ShadowJar>("shadowJar") {
-    dependsOn(project.project(":worldedit-bukkit:adapters").subprojects.map { it.tasks.named("assemble") })
-    from(Callable {
-        adapters.resolve()
-                .map { f ->
-                    zipTree(f).matching {
-                        exclude("META-INF/")
-                    }
-                }
-    })
+    configurations.add(adapters)
     archiveFileName.set("${rootProject.name}-Bukkit-${project.version}.${archiveExtension.getOrElse("jar")}")
     dependencies {
         // In tandem with not bundling log4j, we shouldn't relocate base package here.
         // relocate("org.apache.logging", "com.sk89q.worldedit.log4j")
         relocate("org.antlr.v4", "com.sk89q.worldedit.antlr4")
+
+        exclude(dependency("$group:$name"))
+
         include(dependency(":worldedit-core"))
         include(dependency(":worldedit-libs:bukkit"))
         // Purposefully not included, we assume (even though no API exposes it) that Log4J will be present at runtime
@@ -190,6 +185,15 @@ tasks.named<ShadowJar>("shadowJar") {
         }
         relocate("org.anarres", "com.fastasyncworldedit.core.internal.io") {
             include(dependency("org.anarres:parallelgzip:1.0.5"))
+        }
+    }
+
+    project.project(":worldedit-bukkit:adapters").subprojects.forEach {
+        dependencies {
+            include(dependency("${it.group}:${it.name}"))
+        }
+        minimize {
+            exclude(dependency("${it.group}:${it.name}"))
         }
     }
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->
Fixes #2518 

## Description
<!-- Please describe what this pull request does. -->
Change build configuration for Bukkit platform to avoid a cyclic exception. Direct port of https://github.com/EngineHub/WorldEdit/issues/2426 (and its respective fix)

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
