### PR TITLE
Track paperweight-userdev versions with renovate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -342,7 +342,7 @@ ij_editorconfig_space_before_colon = false
 ij_editorconfig_space_before_comma = false
 ij_editorconfig_spaces_around_assignment_operators = true
 
-[{*.ant, *.fxml, *.jhm, *.jnlp, *.jrxml, *.pom, *.rng, *.tld, *.wsdl, *.xml, *.xsd, *.xsl, *.xslt, *.xul}]
+[{*.ant,*.fxml,*.jhm,*.jnlp,*.jrxml,*.pom,*.rng,*.tld,*.wsdl,*.xml,*.xsd,*.xsl,*.xslt,*.xul}]
 ij_xml_align_attributes = true
 ij_xml_align_text = false
 ij_xml_attribute_wrap = normal
@@ -360,7 +360,7 @@ ij_xml_space_around_equals_in_attribute = false
 ij_xml_space_inside_empty_tag = false
 ij_xml_text_wrap = normal
 
-[{*.ats, *.ts}]
+[{*.ats,*.ts}]
 ij_continuation_indent_size = 4
 ij_typescript_align_imports = false
 ij_typescript_align_multiline_array_initializer_expression = false
@@ -528,7 +528,7 @@ ij_typescript_while_brace_force = never
 ij_typescript_while_on_new_line = false
 ij_typescript_wrap_comments = false
 
-[{*.bash, *.sh, *.zsh}]
+[{*.bash,*.sh,*.zsh}]
 indent_size = 2
 tab_width = 2
 ij_shell_binary_ops_start_line = false
@@ -537,7 +537,7 @@ ij_shell_minify_program = false
 ij_shell_redirect_followed_by_space = false
 ij_shell_switch_cases_indented = false
 
-[{*.cjs, *.js}]
+[{*.cjs,*.js}]
 ij_continuation_indent_size = 4
 ij_javascript_align_imports = false
 ij_javascript_align_multiline_array_initializer_expression = false
@@ -702,10 +702,10 @@ ij_javascript_while_brace_force = never
 ij_javascript_while_on_new_line = false
 ij_javascript_wrap_comments = false
 
-[{*.ft, *.vm, *.vsl}]
+[{*.ft,*.vm,*.vsl}]
 ij_vtl_keep_indents_on_empty_lines = false
 
-[{*.gant, *.gradle, *.groovy, *.gy}]
+[{*.gant,*.gradle,*.groovy,*.gy}]
 ij_groovy_align_group_field_declarations = false
 ij_groovy_align_multiline_array_initializer_expression = false
 ij_groovy_align_multiline_assignment = false
@@ -884,7 +884,7 @@ ij_groovy_while_brace_force = never
 ij_groovy_while_on_new_line = false
 ij_groovy_wrap_long_lines = false
 
-[{*.gradle.kts, *.kt, *.kts, *.main.kts}]
+[{*.gradle.kts,*.kt,*.kts,*.main.kts}]
 ij_kotlin_align_in_columns_case_branch = false
 ij_kotlin_align_multiline_binary_operation = false
 ij_kotlin_align_multiline_extends_list = false
@@ -963,7 +963,7 @@ ij_kotlin_wrap_elvis_expressions = 1
 ij_kotlin_wrap_expression_body_functions = 0
 ij_kotlin_wrap_first_method_in_call_chain = false
 
-[{*.har, *.jsb2, *.jsb3, *.json, .babelrc, .eslintrc, .stylelintrc, bowerrc, jest.config, mcmod.info}]
+[{*.har,*.jsb2,*.jsb3,*.json,.babelrc,.eslintrc,.stylelintrc,bowerrc,jest.config,mcmod.info}]
 indent_size = 2
 ij_json_keep_blank_lines_in_code = 0
 ij_json_keep_indents_on_empty_lines = false
@@ -976,7 +976,7 @@ ij_json_spaces_within_braces = false
 ij_json_spaces_within_brackets = false
 ij_json_wrap_long_lines = false
 
-[{*.htm, *.html, *.sht, *.shtm, *.shtml}]
+[{*.htm,*.html,*.sht,*.shtm,*.shtml}]
 ij_html_add_new_line_before_tags = body, div, p, form, h1, h2, h3
 ij_html_align_attributes = true
 ij_html_align_text = false
@@ -1004,7 +1004,7 @@ ij_html_space_inside_empty_tag = false
 ij_html_text_wrap = normal
 ij_html_uniform_ident = false
 
-[{*.yaml, *.yml}]
+[{*.yaml,*.yml}]
 indent_size = 2
 ij_yaml_keep_indents_on_empty_lines = false
 ij_yaml_keep_line_breaks = true

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,18 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
+  "$schema" : "https://docs.renovatebot.com/renovate-schema.json",
+  "extends" : [
+    "config:recommended",
     ":semanticCommitsDisabled"
   ],
-  "automerge": true,
-  "ignoreDeps": [
-    "guava",  
+  "automerge" : true,
+  "ignoreDeps" : [
+    "guava",
     "com.google.guava:guava",
     "rhino-runtime",
     "org.antlr",
     "antlr4-runtime",
     "fastutil",
-    "it.unimi.dsi:fastutil",  
+    "it.unimi.dsi:fastutil",
     "auto-value-annotations",
     "auto-value",
     "com.google.code.gson:gson",
@@ -29,7 +29,37 @@
     "org.spongepowered:spongeapi",
     "org.yaml:snakeyaml"
   ],
-  "labels": ["Renovate"],
-  "rebaseWhen": "conflicted",
-  "schedule": ["on the first day of the month"]
+  "labels" : [
+    "Renovate"
+  ],
+  "rebaseWhen" : "conflicted",
+  "schedule" : [
+    "on the first day of the month"
+  ],
+  "customManagers" : [
+    {
+      "customType" : "regex",
+      "datasourceTemplate" : "custom.paperweight-userdev",
+      "fileMatch" : "^worldedit-bukkit\\/adapters\\/adapter-\\d+_\\d+(_\\d+)?\\/build\\.gradle\\.kts$",
+      "matchStrings" : [
+        "url=(?<registryUrl>.*)\\s",
+        "paperDevBundle\\(\"(?<currentValue>.*?)\"\\)\\s"
+      ],
+      "matchStringsStrategy": "combination",
+      "depNameTemplate" : "paperweight-userdev",
+      "extractVersionTemplate" : "(?<version>\\d+\\.\\d+\\.?\\d*-R0\\.1-\\d+\\.\\d+-\\d+)"
+    }
+  ],
+  "customDatasources" : {
+    "paperweight-userdev": {
+      "defaultRegistryUrlTemplate": "",
+      "format": "html"
+    }
+  },
+  "packageRules" : [
+    {
+      "matchDatasources" : ["custom.paperweight-userdev"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?-R0\\.1-\\d+\\d+\\.\\d+-(?<build>\\d+)$"
+    }
+  ]
 }

--- a/worldedit-bukkit/adapters/adapter-1_17_1/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_17_1/build.gradle.kts
@@ -21,6 +21,7 @@ configurations.all {
 
 
 dependencies {
+    // url=https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/1.17.1-R0.1-SNAPSHOT
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.17.1-R0.1-20220414.034903-210")
     compileOnly(libs.paperlib)
 }

--- a/worldedit-bukkit/adapters/adapter-1_18_2/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_18_2/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    // https://papermc.io/repo/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/
+    // url=https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/1.18.2-R0.1-SNAPSHOT
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.18.2-R0.1-20220920.010157-167")
     compileOnly(libs.paperlib)
 }

--- a/worldedit-bukkit/adapters/adapter-1_19_4/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/build.gradle.kts
@@ -11,6 +11,7 @@ repositories {
 }
 
 dependencies {
+    // url=https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/1.19.4-R0.1-SNAPSHOT
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.19.4-R0.1-20230608.201059-104")
     compileOnly(libs.paperlib)
 }

--- a/worldedit-bukkit/adapters/adapter-1_20/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_20/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    // https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/
+    // url=https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/1.20.1-R0.1-SNAPSHOT
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.20.1-R0.1-20230921.165944-178")
     compileOnly(libs.paperlib)
 }

--- a/worldedit-bukkit/adapters/adapter-1_20_2/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    // https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/
+    // url=https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/1.20.2-R0.1-SNAPSHOT
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.20.2-R0.1-20231203.034718-121")
     compileOnly(libs.paperlib)
 }

--- a/worldedit-bukkit/adapters/adapter-1_20_4/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    // https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/
+    // url=https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/1.20.4-R0.1-SNAPSHOT
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.20.4-R0.1-20240106.182028-62")
     compileOnly(libs.paperlib)
 }


### PR DESCRIPTION
## Overview
Adds a custom renovate manager to keep paperweight-userdev versions up to date.

Fixes #2498

## Description
Searches for new userdev versions using the provided directory listing. Comment above paperweight include in build.gradle.kts defines registry (folder containing all builds). Comparison ignores Major, Minor and Patch version (as those don't change in their respective registry) but finally compares the build number (last number - incremental).

![image](https://github.com/IntellectualSites/FastAsyncWorldEdit/assets/27054324/b1431b87-d106-47e3-8ea0-0f2ec08ed88b)
![image](https://github.com/IntellectualSites/FastAsyncWorldEdit/assets/27054324/14d2c528-4dd4-49d3-8e55-9dd20eef0865)
 

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
