### PR TITLE
Fix out of bounds error for erode and pull brushes

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ErodeBrush.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ErodeBrush.java
@@ -67,11 +67,11 @@ public class ErodeBrush implements Brush {
         final int by = target.getBlockY();
         final int bz = target.getBlockZ();
 
-        for (int x = -brushSize, relx = 0; x <= brushSize; x++, relx++) {
+        for (int x = -brushSize, relx = 0; x <= brushSize && relx < buffer1.getWidth(); x++, relx++) {
             int x0 = x + bx;
-            for (int y = -brushSize, rely = 0; y <= brushSize; y++, rely++) {
+            for (int y = -brushSize, rely = 0; y <= brushSize && rely < buffer1.getHeight(); y++, rely++) {
                 int y0 = y + by;
-                for (int z = -brushSize, relz = 0; z <= brushSize; z++, relz++) {
+                for (int z = -brushSize, relz = 0; z <= brushSize && relz < buffer1.getLength(); z++, relz++) {
                     int z0 = z + bz;
                     BlockState state = es.getBlock(x0, y0, z0);
                     buffer1.setBlock(relx, rely, relz, state);
@@ -115,11 +115,11 @@ public class ErodeBrush implements Brush {
             Clipboard current, Clipboard target
     ) {
         int[] frequency = null;
-        for (int x = -brushSize, relx = 0; x <= brushSize; x++, relx++) {
+        for (int x = -brushSize, relx = 0; x <= brushSize && relx < target.getWidth(); x++, relx++) {
             int x2 = x * x;
-            for (int z = -brushSize, relz = 0; z <= brushSize; z++, relz++) {
+            for (int z = -brushSize, relz = 0; z <= brushSize && relz < target.getLength(); z++, relz++) {
                 int x2y2 = x2 + z * z;
-                for (int y = -brushSize, rely = 0; y <= brushSize; y++, rely++) {
+                for (int y = -brushSize, rely = 0; y <= brushSize && rely < target.getHeight(); y++, rely++) {
                     int cube = x2y2 + y * y;
                     target.setBlock(relx, rely, relz, current.getBlock(relx, rely, relz));
                     if (cube >= brushSizeSquared) {
@@ -166,11 +166,11 @@ public class ErodeBrush implements Brush {
             Clipboard current, Clipboard target
     ) {
         int[] frequency = null;
-        for (int x = -brushSize, relx = 0; x <= brushSize; x++, relx++) {
+        for (int x = -brushSize, relx = 0; x <= brushSize && relx < target.getWidth(); x++, relx++) {
             int x2 = x * x;
-            for (int z = -brushSize, relz = 0; z <= brushSize; z++, relz++) {
+            for (int z = -brushSize, relz = 0; z <= brushSize && relz < target.getLength(); z++, relz++) {
                 int x2y2 = x2 + z * z;
-                for (int y = -brushSize, rely = 0; y <= brushSize; y++, rely++) {
+                for (int y = -brushSize, rely = 0; y <= brushSize && rely < target.getHeight(); y++, rely++) {
                     int cube = x2y2 + y * y;
                     target.setBlock(relx, rely, relz, current.getBlock(relx, rely, relz));
                     if (cube >= brushSizeSquared) {


### PR DESCRIPTION
## Overview
There is no existing check to ensure that a setBlock() is within bounds, i.e that it won't try to set an index above the max. 
So currently using the erode/pull brush where the radius extends it above world height causes an error.

Fixes #2380

## Description
Adds a simple check to ensure that the relative coords are within the max dimensions for the given clipboard.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
