### PR TITLE
Change -h Tool Command Flag to Always Impact Secondary Brush

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ToolUtilCommands.java
@@ -85,9 +85,8 @@ public class ToolUtilCommands {
             player.print(Caption.of("worldedit.tool.mask.disabled"));
             tool.setMask(null);
         } else {
-            BrushSettings settings = secondary ? tool.getSecondary() : tool.getContext();
-            String lastArg = Iterables.getLast(CommandArgParser.spaceSplit(arguments.get()))
-                    .getSubstring();
+            BrushSettings settings = secondary ? tool.getSecondary() : tool.getPrimary();
+            String lastArg = Iterables.getLast(CommandArgParser.spaceSplit(arguments.get())).getSubstring();
             settings.addSetting(BrushSettings.SettingType.MASK, lastArg);
             settings.setMask(maskOpt);
             tool.update();
@@ -118,7 +117,7 @@ public class ToolUtilCommands {
         if (pattern == null) {
             tool.setFill(null);
         } else {
-            BrushSettings settings = secondary ? tool.getSecondary() : tool.getContext();
+            BrushSettings settings = secondary ? tool.getSecondary() : tool.getPrimary();
             settings.setFill(pattern);
             String lastArg = Iterables.getLast(CommandArgParser.spaceSplit(arguments.get())).getSubstring();
             settings.addSetting(BrushSettings.SettingType.FILL, lastArg);
@@ -158,7 +157,7 @@ public class ToolUtilCommands {
         we.checkMaxBrushRadius(size);
         BrushTool tool = session.getBrushTool(player, false);
 
-        BrushSettings settings = secondary ? tool.getSecondary() : tool.getContext();
+        BrushSettings settings = secondary ? tool.getSecondary() : tool.getPrimary();
         settings.setSize(size);
         String lastArg = Iterables.getLast(CommandArgParser.spaceSplit(arguments.get())).getSubstring();
         settings.addSetting(BrushSettings.SettingType.FILL, lastArg);
@@ -326,7 +325,7 @@ public class ToolUtilCommands {
             return;
         }
 
-        BrushSettings settings = secondary ? tool.getSecondary() : tool.getContext();
+        BrushSettings settings = secondary ? tool.getSecondary() : tool.getPrimary();
         Scroll action = Scroll.fromArguments(tool, player, session, mode, commandStr, true);
         settings.setScrollAction(action);
         if (mode == Scroll.Action.NONE) {
@@ -364,7 +363,7 @@ public class ToolUtilCommands {
             tool.setSourceMask(null);
             return;
         }
-        BrushSettings settings = secondary ? tool.getSecondary() : tool.getContext();
+        BrushSettings settings = secondary ? tool.getSecondary() : tool.getPrimary();
         String lastArg = Iterables.getLast(CommandArgParser.spaceSplit(arguments.get())).getSubstring();
         settings.addSetting(BrushSettings.SettingType.SOURCE_MASK, lastArg);
         settings.setSourceMask(maskArg);
@@ -395,7 +394,7 @@ public class ToolUtilCommands {
             tool.setTransform(null);
             return;
         }
-        BrushSettings settings = secondary ? tool.getSecondary() : tool.getContext();
+        BrushSettings settings = secondary ? tool.getSecondary() : tool.getPrimary();
         String lastArg = Iterables.getLast(CommandArgParser.spaceSplit(arguments.get())).getSubstring();
         settings.addSetting(BrushSettings.SettingType.TRANSFORM, lastArg);
         settings.setTransform(transform);


### PR DESCRIPTION
## Overview
I was asked recently what the `-h` flag did in various tool util commands as the existing description of "Whether the offhand should be considered or not" is unclear to others and myself.
Upon using it, and from the feedback of others trying to use it too, it felt inconsistent in when it would change the primary or secondary brush.

From reading the code it appears the intent is for tool util commands to change the last used brush when a primary & secondary are set, with the flag inverting which one it impacts.

I think this isn't very intuitive and believe it would make more sense to just have the flag set to change the secondary brush, otherwise the primary.

## Description
This changes the `-h` flag to always change the value for the secondary brush, if one is set. If no flag is used, or no secondary brush is set, then it will just change the primary brush.

I have changed the help page info to make this clear.

Additionally I have added the same flag functionality to the `/size` / `/br size` command.

Lastly, some minor tidying of the unused editSession import, and the inconsistent tool/brushTool/bt naming.



Hopefully this change makes sense, I'd be curious to hear if myself and those I spoke to are in the minority when it comes to thinking the existing method is unclear and hard to use.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
