### PR TITLE
Use actual radius for inverse and adjust inside region check

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CylinderRegion.java
@@ -141,7 +141,7 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
      */
     public void setRadius(Vector2 radius) {
         this.radius = radius.add(0.5, 0.5);
-        this.radiusInverse = Vector2.ONE.divide(radius);
+        this.radiusInverse = Vector2.ONE.divide(this.radius);
     }
 
     /**
@@ -413,11 +413,12 @@ public class CylinderRegion extends AbstractRegion implements FlatRegion {
             final IChunk chunk, final Filter filter, final ChunkFilterBlock block,
             final IChunkGet get, final IChunkSet set, boolean full
     ) {
-        int bcx = chunk.getX() >> 4;
-        int bcz = chunk.getZ() >> 4;
+        int bcx = chunk.getX() << 4;
+        int bcz = chunk.getZ() << 4;
         int tcx = bcx + 15;
         int tcz = bcz + 15;
-        if (contains(bcx, bcz) && contains(tcx, tcz)) {
+        // must contain all 4 corners for fast path
+        if (contains(bcx, bcz) && contains(tcx, tcz) && contains(bcx, tcz) && contains(tcx, bcz)) {
             filter(chunk, filter, block, get, set, minY, maxY, full);
             return;
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`CylinderRegion` had two bugs:

1. The inverseRadius used for multiplication was based on the unadjusted radius. For consistency, it should use the adjusted one.
2. There was a check whether the while y-level is inside the region, which was wrong as it shifted the chunk coords wrongly and it also didn't check all 4 corners, resulting in wrong shapes for larger selections (with the fixed shift).

The changes bring `//sel cyl` + `//set` in line with `//cyl`.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
