### PR TITLE
Maintain insertion order for RandomPattern sub-patterns

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/collection/RandomCollection.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/collection/RandomCollection.java
@@ -33,7 +33,7 @@ public abstract class RandomCollection<T> {
     public static <T> RandomCollection<T> of(Map<T, Double> weights, SimpleRandom random) {
         checkNotNull(random);
         return FastRandomCollection.create(weights, random)
-                .orElse(new SimpleRandomCollection<>(weights, random));
+                .orElseGet(() -> new SimpleRandomCollection<>(weights, random));
     }
 
     public void setRandom(SimpleRandom random) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RandomPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/RandomPattern.java
@@ -27,7 +27,7 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +41,7 @@ public class RandomPattern extends AbstractPattern {
 
     //FAWE start - SimpleRandom > Random, LHS<P> > List
     private final SimpleRandom random;
-    private Map<Pattern, Double> weights = new HashMap<>();
+    private Map<Pattern, Double> weights = new LinkedHashMap<>();
     private RandomCollection<Pattern> collection;
     private LinkedHashSet<Pattern> patterns = new LinkedHashSet<>();
     //FAWE end


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->
## Description
<!-- Please describe what this pull request does. -->

Noise patterns like `#simplex` that take a random pattern, but before, the order didn't match the order of how the command was written down. By keeping the insertion order, the order in the command allows controlling how the resulting noise it mapped to patterns.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
