### PR TITLE
Make sure to process all chunks in PQE even if PARALLEL_THREADS = 1

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
@@ -131,9 +131,12 @@ public class ParallelQueueExtent extends PassthroughExtent {
 
         // Get a pool, to operate on the chunks in parallel
         final int size = Math.min(chunks.size(), Settings.settings().QUEUE.PARALLEL_THREADS);
-        if (size <= 1 && chunksIter.hasNext()) {
-            BlockVector2 pos = chunksIter.next();
-            getExtent().apply(null, filter, region, pos.getX(), pos.getZ(), full);
+        if (size <= 1) {
+            // if PQE is ever used with PARALLEL_THREADS = 1, or only one chunk is edited, just run sequentially
+            while (chunksIter.hasNext()) {
+                BlockVector2 pos = chunksIter.next();
+                getExtent().apply(null, filter, region, pos.getX(), pos.getZ(), full);
+            }
         } else {
             final ForkJoinTask[] tasks = IntStream.range(0, size).mapToObj(i -> handler.submit(() -> {
                 try {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

While current use of PQE in FAWE is always covered by a check to ensure PARALLEL_THREADS is > 1, a more defensive strategy might make sense. Alternatively to this change, we could assert that PT > 1, but that seems unnecessary.

Tested by manually setting PARALLEL_THREADS to 1 via debugger directly before the Math.min call.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
