### PR TITLE
Allow factory suggestions to have parser context

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
@@ -127,6 +127,14 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
         return Stream.empty();
     }
 
+    /**
+     * Returns a stream of suggestions for the argument at the given index.
+     *
+     * @param argumentInput the already provided input for the argument at the given index.
+     * @param index         the index of the argument to get suggestions for.
+     * @param context       the context which may optionally be provided by a parser.
+     * @return a stream of suggestions matching the given input for the argument at the given index.
+     */
     protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         return getSuggestions(argumentInput, index);
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
@@ -124,7 +124,7 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
      * @return a stream of suggestions matching the given input for the argument at the given index.
      */
     protected Stream<String> getSuggestions(String argumentInput, int index) {
-        return Stream.empty();
+        return getSuggestions(argumentInput, index, new ParserContext());
     }
 
     /**
@@ -136,7 +136,7 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
      * @return a stream of suggestions matching the given input for the argument at the given index.
      */
     protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
-        return getSuggestions(argumentInput, index);
+        return Stream.empty();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
@@ -122,7 +122,10 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
      * @param argumentInput the already provided input for the argument at the given index.
      * @param index         the index of the argument to get suggestions for.
      * @return a stream of suggestions matching the given input for the argument at the given index.
+     *
+     * @deprecated Use the version that takes a {@link ParserContext}, {@link #getSuggestions(String, int, ParserContext)}
      */
+    @Deprecated
     protected Stream<String> getSuggestions(String argumentInput, int index) {
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
@@ -124,7 +124,7 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
      * @return a stream of suggestions matching the given input for the argument at the given index.
      */
     protected Stream<String> getSuggestions(String argumentInput, int index) {
-        return getSuggestions(argumentInput, index, new ParserContext());
+        return Stream.empty();
     }
 
     /**
@@ -136,7 +136,7 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
      * @return a stream of suggestions matching the given input for the argument at the given index.
      */
     protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
-        return Stream.empty();
+        return getSuggestions(argumentInput, index);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/RichParser.java
@@ -53,7 +53,7 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
     }
 
     @Nonnull
-    private Function<String, Stream<? extends String>> extractArguments(String input) {
+    private Function<String, Stream<? extends String>> extractArguments(String input, ParserContext context) {
         return prefix -> {
             if (input.length() > prefix.length() && input.startsWith(prefix + "[")) {
                 // input already contains argument(s) -> extract them
@@ -65,7 +65,7 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
                 }
                 String previous = prefix + builder;
                 // read the suggestions for the last argument
-                return getSuggestions(strings[strings.length - 1], strings.length - 1)
+                return getSuggestions(strings[strings.length - 1], strings.length - 1, context)
                         .map(suggestion -> previous + "[" + suggestion);
             } else {
                 return Stream.of(prefix);
@@ -95,7 +95,7 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
     public Stream<String> getSuggestions(String input) {
         return Arrays.stream(this.prefixes)
                 .filter(validPrefix(input))
-                .flatMap(extractArguments(input));
+                .flatMap(extractArguments(input, new ParserContext()));
     }
 
     @Override
@@ -123,7 +123,13 @@ public abstract class RichParser<E> extends InputParser<E> implements AliasedPar
      * @param index         the index of the argument to get suggestions for.
      * @return a stream of suggestions matching the given input for the argument at the given index.
      */
-    protected abstract Stream<String> getSuggestions(String argumentInput, int index);
+    protected Stream<String> getSuggestions(String argumentInput, int index) {
+        return Stream.empty();
+    }
+
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
+        return getSuggestions(argumentInput, index);
+    }
 
     /**
      * Parses the already split arguments.

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/RichMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/RichMaskParser.java
@@ -97,11 +97,11 @@ public class RichMaskParser extends FaweParser<Mask> {
                                 )),
                                 () -> {
                                     if (full.length() == 1) {
-                                        return new ArrayList<>(worldEdit.getMaskFactory().getSuggestions(""));
+                                        return new ArrayList<>(worldEdit.getMaskFactory().getSuggestions("", context));
                                     }
                                     return new ArrayList<>(worldEdit
                                             .getMaskFactory()
-                                            .getSuggestions(command.toLowerCase(Locale.ROOT)));
+                                            .getSuggestions(command.toLowerCase(Locale.ROOT), context));
                                 }
                         );
                     }
@@ -164,11 +164,11 @@ public class RichMaskParser extends FaweParser<Mask> {
                                         )),
                                         () -> {
                                             if (full.length() == 1) {
-                                                return new ArrayList<>(worldEdit.getMaskFactory().getSuggestions(""));
+                                                return new ArrayList<>(worldEdit.getMaskFactory().getSuggestions("", context));
                                             }
                                             return new ArrayList<>(worldEdit
                                                     .getMaskFactory()
-                                                    .getSuggestions(command.toLowerCase(Locale.ROOT)));
+                                                    .getSuggestions(command.toLowerCase(Locale.ROOT), context));
                                         }
                                 );
                             }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
@@ -37,6 +37,7 @@ import com.sk89q.worldedit.internal.annotation.ClipboardMask;
 import com.sk89q.worldedit.internal.registry.AbstractFactory;
 import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.session.ClipboardHolder;
+import com.sk89q.worldedit.session.request.RequestExtent;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.world.World;
@@ -113,8 +114,7 @@ public class FactoryConverter<T> implements ArgumentConverter<T> {
         );
     }
 
-    @Override
-    public ConversionResult<T> convert(String argument, InjectedValueAccess context) {
+    private ParserContext createContext(InjectedValueAccess context) {
         Actor actor = context.injectedValue(Key.of(Actor.class))
                 .orElseThrow(() -> new IllegalStateException("No actor"));
         LocalSession session = WorldEdit.getInstance().getSessionManager().get(actor);
@@ -139,6 +139,13 @@ public class FactoryConverter<T> implements ArgumentConverter<T> {
             contextTweaker.accept(parserContext);
         }
 
+        return parserContext;
+    }
+
+    @Override
+    public ConversionResult<T> convert(String argument, InjectedValueAccess context) {
+        ParserContext parserContext = createContext(context);
+
         try {
             return SuccessfulConversion.fromSingle(
                     factoryExtractor.apply(worldEdit).parseFromInput(argument, parserContext)
@@ -150,7 +157,9 @@ public class FactoryConverter<T> implements ArgumentConverter<T> {
 
     @Override
     public List<String> getSuggestions(String input, InjectedValueAccess context) {
-        return factoryExtractor.apply(worldEdit).getSuggestions(input);
+        ParserContext parserContext = createContext(context);
+
+        return factoryExtractor.apply(worldEdit).getSuggestions(input, parserContext);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/FactoryConverter.java
@@ -37,7 +37,6 @@ import com.sk89q.worldedit.internal.annotation.ClipboardMask;
 import com.sk89q.worldedit.internal.registry.AbstractFactory;
 import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.session.ClipboardHolder;
-import com.sk89q.worldedit.session.request.RequestExtent;
 import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.world.World;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -127,13 +127,13 @@ public final class MaskFactory extends AbstractFactory<Mask> {
     }
 
     @Override
-    public List<String> getSuggestions(String input) {
+    public List<String> getSuggestions(String input, final ParserContext parserContext) {
         final String[] split = input.split(" ");
         if (split.length > 1) {
             String prev = input.substring(0, input.lastIndexOf(" ")) + " ";
-            return super.getSuggestions(split[split.length - 1]).stream().map(s -> prev + s).collect(Collectors.toList());
+            return super.getSuggestions(split[split.length - 1], parserContext).stream().map(s -> prev + s).collect(Collectors.toList());
         }
-        return super.getSuggestions(input);
+        return super.getSuggestions(input, parserContext);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java
@@ -96,9 +96,14 @@ public abstract class AbstractFactory<E> {
         throw new NoMatchException(Caption.of("worldedit.error.no-match", TextComponent.of(input)));
     }
 
+    @Deprecated
     public List<String> getSuggestions(String input) {
+        return getSuggestions(input, new ParserContext());
+    }
+
+    public List<String> getSuggestions(String input, ParserContext context) {
         return parsers.stream().flatMap(
-                p -> p.getSuggestions(input)
+                p -> p.getSuggestions(input, context)
         ).collect(Collectors.toList());
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/InputParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/InputParser.java
@@ -45,9 +45,22 @@ public abstract class InputParser<E> {
      * Gets a stream of suggestions of input to this parser.
      *
      * @return a stream of suggestions
+     * @deprecated Use the version that takes a {@link ParserContext}, {@link #getSuggestions(String, ParserContext)}
      */
+    @Deprecated
     public Stream<String> getSuggestions(String input) {
         return Stream.empty();
     }
 
+    /**
+     * Gets a stream of suggestions of input to this parser.
+     *
+     * @param input The string input
+     * @param context The parser context
+     *
+     * @return a stream of suggestions
+     */
+    public Stream<String> getSuggestions(String input, ParserContext context) {
+        return getSuggestions(input);
+    }
 }


### PR DESCRIPTION
## Overview
Closely mirrors upstream changes in https://github.com/EngineHub/WorldEdit/pull/2236

"This is a refactor to allow access to a ParserContext within the suggestion methods. This is required for any suggestions within the factory parser that are player-specific"

## Description
This PR adds context as an option to the getSuggestions() method of parsers.
While no changes to existing Masks or Patterns are present, this change would allow for that to be done in future.

Originally I had gone through and added context to every parser in FAWE, allowing for the new `getSuggestions(String argumentInput, int index, ParserContext context)` method in RichParser to be abstract, replacing the existing method without context. 
However, that would be a breaking change for any addon plugin using rich parsing such as Arceon.

While it does work & prevents breaking existing parsers, I don't think my approach of 2x methods looks the best so I would appreciate any thoughts on that.
I have tested against existing FAWE, Arceon, and my own custom masks/patterns to double check this is backwards compatible.


It's worth mentioning that my reason for pursuing this change is a custom mask I implemented which would benefit from player-specific tab completion.

Additionally as a basic example, this is a mask that wants a Y value, which can suggest the user's Y level:

![image](https://github.com/IntellectualSites/FastAsyncWorldEdit/assets/1365964/eebe91c0-3a3c-4445-8311-9fc12237f04a)

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
