### PR TITLE
fix: set and clone Expression Environment after Expression cloning

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Expression.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Expression.java
@@ -199,7 +199,9 @@ public class Expression implements Cloneable {
 
     //FAWE start
     public Expression clone() {
-        return new Expression(initialExpression, new HashSet<>(providedSlots));
+        Expression expression = new Expression(initialExpression, new HashSet<>(providedSlots));
+        expression.setEnvironment(getEnvironment());
+        return expression;
     }
     //FAWE end
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Expression.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Expression.java
@@ -24,6 +24,7 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.antlr.ExpressionLexer;
 import com.sk89q.worldedit.antlr.ExpressionParser;
 import com.sk89q.worldedit.internal.expression.invoke.ExpressionCompiler;
+import com.sk89q.worldedit.regions.shape.WorldEditExpressionEnvironment;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -200,7 +201,7 @@ public class Expression implements Cloneable {
     //FAWE start
     public Expression clone() {
         Expression expression = new Expression(initialExpression, new HashSet<>(providedSlots));
-        expression.setEnvironment(getEnvironment());
+        expression.setEnvironment(getEnvironment().clone());
         return expression;
     }
     //FAWE end

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/ExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/ExpressionEnvironment.java
@@ -22,7 +22,7 @@ package com.sk89q.worldedit.internal.expression;
 /**
  * Represents a way to access blocks in a world. Has to accept non-rounded coordinates.
  */
-public interface ExpressionEnvironment {
+public interface ExpressionEnvironment extends Cloneable {
 
     int getBlockType(double x, double y, double z);
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/ExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/ExpressionEnvironment.java
@@ -36,4 +36,5 @@ public interface ExpressionEnvironment {
 
     int getBlockDataRel(double x, double y, double z);
 
+    ExpressionEnvironment clone();
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/ExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/ExpressionEnvironment.java
@@ -36,5 +36,7 @@ public interface ExpressionEnvironment {
 
     int getBlockDataRel(double x, double y, double z);
 
+    // FAWE start
     ExpressionEnvironment clone();
+    // FAWE end
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -94,10 +94,13 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
     public Vector3 toWorldRel(double x, double y, double z) {
         return current.add(x, y, z);
     }
+
+    public WorldEditExpressionEnvironment clone() {
+        return new WorldEditExpressionEnvironment(extent, unit, zero2);
+    }
     //FAWe end
 
     public void setCurrentBlock(Vector3 current) {
         this.current = current;
     }
-
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -28,7 +28,7 @@ import com.sk89q.worldedit.math.Vector3;
 
 public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
-    private final Vector3 UN_OFFSET = Vector3.at(0.5, 0.5, 0.5);
+    private final Vector3 BLOCK_CENTER_OFFSET = Vector3.at(0.5, 0.5, 0.5);
 
     private final Vector3 unit;
     private final Vector3 zero2;
@@ -44,7 +44,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
     public WorldEditExpressionEnvironment(Extent extent, Vector3 unit, Vector3 zero) {
         this.extent = extent;
         this.unit = unit;
-        this.zero2 = zero.add(UN_OFFSET);
+        this.zero2 = zero.add(BLOCK_CENTER_OFFSET);
     }
 
     public BlockVector3 toWorld(double x, double y, double z) {
@@ -98,7 +98,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
     }
 
     public WorldEditExpressionEnvironment clone() {
-        return new WorldEditExpressionEnvironment(extent, unit, zero2.subtract(UN_OFFSET));
+        return new WorldEditExpressionEnvironment(extent, unit, zero2.subtract(BLOCK_CENTER_OFFSET));
     }
     //FAWe end
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -28,6 +28,8 @@ import com.sk89q.worldedit.math.Vector3;
 
 public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
+    private final Vector3 UN_OFFSET = Vector3.at(0.5, 0.5, 0.5);
+
     private final Vector3 unit;
     private final Vector3 zero2;
     //FAWE start - MutableVector3
@@ -42,7 +44,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
     public WorldEditExpressionEnvironment(Extent extent, Vector3 unit, Vector3 zero) {
         this.extent = extent;
         this.unit = unit;
-        this.zero2 = zero.add(0.5, 0.5, 0.5);
+        this.zero2 = zero.add(UN_OFFSET);
     }
 
     public BlockVector3 toWorld(double x, double y, double z) {
@@ -96,7 +98,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
     }
 
     public WorldEditExpressionEnvironment clone() {
-        return new WorldEditExpressionEnvironment(extent, unit, zero2);
+        return new WorldEditExpressionEnvironment(extent, unit, zero2.subtract(UN_OFFSET));
     }
     //FAWe end
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -28,7 +28,7 @@ import com.sk89q.worldedit.math.Vector3;
 
 public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
 
-    private final Vector3 BLOCK_CENTER_OFFSET = Vector3.at(0.5, 0.5, 0.5);
+    private static final Vector3 BLOCK_CENTER_OFFSET = Vector3.at(0.5, 0.5, 0.5);
 
     private final Vector3 unit;
     private final Vector3 zero2;

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/BaseExpressionTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/internal/expression/BaseExpressionTest.java
@@ -114,6 +114,11 @@ class BaseExpressionTest {
             public int getBlockDataRel(double x, double y, double z) {
                 return (int) y * 100;
             }
+
+            @Override
+            public ExpressionEnvironment clone() {
+                return this;
+            }
         });
 
         return expression.evaluate();


### PR DESCRIPTION
## Overview

Fixes #2616

## Description
This Pull Requests sets the WorldEditExpressionEnvironment after an Expression gets cloned to make sure that the Functions class remains its environment after cloning  to not run into a NullPointerException.
When the Expression is cloned, the WorldEditExpressionEnvironment gets cloned as well while making sure that the offset of the environment is not changing during the cloning process.

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
