### PR TITLE
Fix Linear pattern index incrementing above array length

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/LinearBlockPattern.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/LinearBlockPattern.java
@@ -1,11 +1,14 @@
 package com.fastasyncworldedit.core.function.pattern;
 
+import com.fastasyncworldedit.core.queue.Filter;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.pattern.AbstractPattern;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BaseBlock;
+
+import java.util.Arrays;
 
 public class LinearBlockPattern extends AbstractPattern implements ResettablePattern {
 
@@ -31,6 +34,12 @@ public class LinearBlockPattern extends AbstractPattern implements ResettablePat
     public boolean apply(Extent extent, BlockVector3 get, BlockVector3 set) throws WorldEditException {
         index = (index + 1) % patternsArray.length;
         return patternsArray[index].apply(extent, get, set);
+    }
+
+    @Override
+    public Filter fork() {
+        final Pattern[] forked = Arrays.stream(this.patternsArray).map(Pattern::fork).toArray(Pattern[]::new);
+        return new LinearBlockPattern(forked);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/LinearBlockPattern.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/LinearBlockPattern.java
@@ -15,7 +15,7 @@ public class LinearBlockPattern extends AbstractPattern implements ResettablePat
     /**
      * Create a new {@link Pattern} instance
      *
-     * @param patterns array of patterns to linearly choose from based on x/z coordinates
+     * @param patterns array of patterns to linearly choose from
      */
     public LinearBlockPattern(Pattern[] patterns) {
         this.patternsArray = patterns;
@@ -23,18 +23,14 @@ public class LinearBlockPattern extends AbstractPattern implements ResettablePat
 
     @Override
     public BaseBlock applyBlock(BlockVector3 position) {
-        if (index == patternsArray.length) {
-            index = 0;
-        }
-        return patternsArray[index++].applyBlock(position);
+        index = (index + 1) % patternsArray.length;
+        return patternsArray[index].applyBlock(position);
     }
 
     @Override
     public boolean apply(Extent extent, BlockVector3 get, BlockVector3 set) throws WorldEditException {
-        if (index == patternsArray.length) {
-            index = 0;
-        }
-        return patternsArray[index++].apply(extent, get, set);
+        index = (index + 1) % patternsArray.length;
+        return patternsArray[index].apply(extent, get, set);
     }
 
     @Override


### PR DESCRIPTION
## Overview
When running async the `#linear` pattern can increment index above the length of the `patternsArray`.
This tends not to happen on small operations.

```
[14:49:33 ERROR]: [com.fastasyncworldedit.core.queue.implementation.ParallelQueueExtent] Catching
java.lang.ArrayIndexOutOfBoundsException: Index 9 out of bounds for length 3
        at com.fastasyncworldedit.core.function.pattern.LinearBlockPattern.apply(LinearBlockPattern.java:37) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.sk89q.worldedit.function.pattern.Pattern.applyBlock(Pattern.java:59) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.fastasyncworldedit.core.extent.filter.LinkedFilter.applyBlock(LinkedFilter.java:28) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.fastasyncworldedit.core.extent.filter.block.CharFilterBlock.filter(CharFilterBlock.java:130) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.sk89q.worldedit.regions.Region.filter(Region.java:367) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.sk89q.worldedit.regions.Region.filter(Region.java:301) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.sk89q.worldedit.regions.CuboidRegion.filter(CuboidRegion.java:762) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.fastasyncworldedit.core.extent.filter.block.ChunkFilterBlock.filter(ChunkFilterBlock.java:88) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.fastasyncworldedit.core.queue.implementation.chunk.ChunkHolder.filterBlocks(ChunkHolder.java:903) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.fastasyncworldedit.core.queue.IQueueExtent.apply(IQueueExtent.java:144) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at com.fastasyncworldedit.core.queue.implementation.ParallelQueueExtent.lambda$apply$0(ParallelQueueExtent.java:162) ~[FastAsyncWorldEdit-Bukkit-2.9.1-SNAPSHOT.jar:?]
        at java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(Unknown Source) ~[?:?]
        at java.util.concurrent.ForkJoinTask.doExec(Unknown Source) ~[?:?]
        at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source) ~[?:?]
        at java.util.concurrent.ForkJoinPool.scan(Unknown Source) ~[?:?]
        at java.util.concurrent.ForkJoinPool.runWorker(Unknown Source) ~[?:?]
        at java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source) ~[?:?]
```

Replication steps for error:

1. Select a decently large selection (64^3 seems enough)
2. Set a linear pattern such as `//set #linear[1,2,3]`
3. Chat ingame may report a success but the operation will either fully or partially fail with OoB errors in console as above

## Description
Changes the index calculation to always modulo with the `patternsArray` length to prevent an Out of Bounds exception.

While this fixes the error, the linear pattern itself is quite messy when running async:

![2024-03-16_15 31 18](https://github.com/IntellectualSites/FastAsyncWorldEdit/assets/1365964/7bd079d7-d5cc-4253-bac3-3f1e20befae5)

I'm not sure if it's worth changing anything, as if you were to make it ordered then it would just look like the `#linear3d` pattern.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
