### PR TITLE
Fix queryRel returning data value for block at absolute coordinates

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -83,6 +83,7 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
     }
 
     @SuppressWarnings("deprecation")
+    @Override
     public int getBlockDataRel(double x, double y, double z) {
         return extent.getBlock(toWorldRel(x, y, z).toBlockPoint()).getBlockType().getLegacyCombinedId() & 0xF;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/shape/WorldEditExpressionEnvironment.java
@@ -83,9 +83,8 @@ public class WorldEditExpressionEnvironment implements ExpressionEnvironment {
     }
 
     @SuppressWarnings("deprecation")
-    @Override
     public int getBlockDataRel(double x, double y, double z) {
-        return extent.getBlock(toWorld(x, y, z)).getBlockType().getLegacyCombinedId() & 0xF;
+        return extent.getBlock(toWorldRel(x, y, z).toBlockPoint()).getBlockType().getLegacyCombinedId() & 0xF;
     }
 
     //FAWE start


### PR DESCRIPTION
## Overview
Fixes the incorrect method for relative data checks in expressions (queryRel)

Fixes #2643

## Description
Current version erroneously uses toWorld instead of toWorldRel, so `queryRel(0,0,0,t,d)` would always return the data of the block at `0,0,0` for `d`, where it should return the data value of whatever block is `0,0,0` offset.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
