### PR TITLE
Use correct find class in ExtentTraverser

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/ExtentTraverser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/ExtentTraverser.java
@@ -51,11 +51,10 @@ public class ExtentTraverser<T extends Extent> {
         return last;
     }
 
-    @SuppressWarnings("unchecked")
     @Nullable
-    public <U> U findAndGet(Class<U> clazz) {
-        ExtentTraverser<Extent> traverser = find(clazz);
-        return (traverser != null) ? (U) traverser.get() : null;
+    public <U extends Extent> U findAndGet(Class<U> clazz) {
+        ExtentTraverser<U> traverser = find(clazz);
+        return (traverser != null) ? traverser.get() : null;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2485
Fixes #2546

## Description
<!-- Please describe what this pull request does. -->

We already discovered this in #2356, but it took me some debugging to figure out that the linked issues are also caused by this bug. There are two `find` methods, and previously, the bound type of the parameter wasn't strict enough to use the method that takes a `Class<U extends Extent>`, but instead the `find(Object)` method was used. This can be fixed by using a sharper bound.

This *can* theoretically cause compile time issues with existing code, but that will mean that the method is used wrongly most likely.

As a bit of background, this caused two `MaskingExtent`s to exist. But the code in https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/2a08ad28a43a3e179c2b78178b27918ffd3c96a3/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/MultiBatchProcessor.java#L118-L124 prevents from having multiple different `Filter` processors of the same type. As the order in which the processors are called depends on a HashSet, the result would be 50/50 either of the masks.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
