### PR TITLE
List FAWE class additions in Javadocs

### DIFF
--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/package-info.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/package-info.java
@@ -1,6 +1,6 @@
 /**
  * The following classes are FAWE additions:
  *
- * @see com.sk89q.worldedit.cli.AccessPoint
+ * {@link com.sk89q.worldedit.cli.AccessPoint}
  */
 package com.sk89q.worldedit.cli;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/package-info.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/package-info.java
@@ -20,8 +20,8 @@
 /**
  * The following classes are FAWE additions:
  *
- * @see com.sk89q.worldedit.command.argument.ExpressionConverter
- * @see com.sk89q.worldedit.command.argument.LocationConverter
+ * {@link com.sk89q.worldedit.command.argument.ExpressionConverter},
+ * {@link com.sk89q.worldedit.command.argument.LocationConverter}
  */
 @org.enginehub.piston.util.NonnullByDefault
 package com.sk89q.worldedit.command.argument;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/package-info.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/package-info.java
@@ -1,6 +1,6 @@
 /**
  * The following classes are FAWE additions:
  *
- * @see com.sk89q.worldedit.command.HistorySubCommands
+ * {@link com.sk89q.worldedit.command.HistorySubCommands}
  */
 package com.sk89q.worldedit.command;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/annotation/package-info.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/util/annotation/package-info.java
@@ -1,14 +1,14 @@
 /**
  * The following classes are FAWE additions:
  *
- * @see com.sk89q.worldedit.command.util.annotation.AllowedRegion
- * @see com.sk89q.worldedit.command.util.annotation.Confirm
- * @see com.sk89q.worldedit.command.util.annotation.ConfirmHandler
- * @see com.sk89q.worldedit.command.util.annotation.Link
- * @see com.sk89q.worldedit.command.util.annotation.PatternList
- * @see com.sk89q.worldedit.command.util.annotation.Preload
- * @see com.sk89q.worldedit.command.util.annotation.PreloadHandler
- * @see com.sk89q.worldedit.command.util.annotation.Step
- * @see com.sk89q.worldedit.command.util.annotation.Time
+ * {@link com.sk89q.worldedit.command.util.annotation.AllowedRegion},
+ * {@link com.sk89q.worldedit.command.util.annotation.Confirm},
+ * {@link com.sk89q.worldedit.command.util.annotation.ConfirmHandler},
+ * {@link com.sk89q.worldedit.command.util.annotation.Link},
+ * {@link com.sk89q.worldedit.command.util.annotation.PatternList},
+ * {@link com.sk89q.worldedit.command.util.annotation.Preload},
+ * {@link com.sk89q.worldedit.command.util.annotation.PreloadHandler},
+ * {@link com.sk89q.worldedit.command.util.annotation.Step},
+ * {@link com.sk89q.worldedit.command.util.annotation.Time}
  */
 package com.sk89q.worldedit.command.util.annotation;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/package-info.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/package-info.java
@@ -1,6 +1,6 @@
 /**
  * The following classes are FAWE additions:
  *
- * @see com.sk89q.worldedit.function.operation.BackwardsExtentBlockCopy
+ * {@link com.sk89q.worldedit.function.operation.BackwardsExtentBlockCopy}
  */
 package com.sk89q.worldedit.function.operation;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/package-info.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/package-info.java
@@ -1,6 +1,6 @@
 /**
  * The following classes are FAWE additions:
  *
- * @see com.sk89q.worldedit.world.block.BlockTypesCache
+ * {@link com.sk89q.worldedit.world.block.BlockTypesCache}
  */
 package com.sk89q.worldedit.world.block;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/package-info.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/package-info.java
@@ -1,7 +1,7 @@
 /**
- * The following classes are FAWE additions:
+ * The following classes are FAWE additions
  *
- * @see com.sk89q.worldedit.world.chunk.AnvilChunk15
- * @see com.sk89q.worldedit.world.chunk.AnvilChunk17
+ * {@link com.sk89q.worldedit.world.chunk.AnvilChunk15},
+ * {@link com.sk89q.worldedit.world.chunk.AnvilChunk17}
  */
 package com.sk89q.worldedit.world.chunk;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/package-info.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/chunk/package-info.java
@@ -1,5 +1,5 @@
 /**
- * The following classes are FAWE additions
+ * The following classes are FAWE additions:
  *
  * {@link com.sk89q.worldedit.world.chunk.AnvilChunk15},
  * {@link com.sk89q.worldedit.world.chunk.AnvilChunk17}


### PR DESCRIPTION
Otherwise, the class additions are omitted from the overview.

![Screenshot 2024-03-31 at 22 47 29](https://github.com/IntellectualSites/FastAsyncWorldEdit/assets/13383509/86511ecb-1723-4140-b9f6-8b611750ff47)
