### PR TITLE
fix: improve how we determine if using FAWE from jenkins

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/UpdateNotification.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/UpdateNotification.java
@@ -59,12 +59,12 @@ public class UpdateNotification {
             Document doc = db.parse(body);
             faweVersion = doc.getElementsByTagName("lastSuccessfulBuild").item(0).getFirstChild().getTextContent();
             FaweVersion faweVersion = Fawe.instance().getVersion();
-            if (faweVersion.build == 0 && !faweVersion.snapshot) {
+            if (faweVersion.build == 0 && faweVersion.snapshot) {
                 LOGGER.warn("You are using a snapshot or a custom version of FAWE. This is not an official build distributed " +
                         "via https://www.spigotmc.org/resources/13932/");
                 return;
             }
-            if (faweVersion.build < Integer.parseInt(UpdateNotification.faweVersion)) {
+            if (faweVersion.snapshot && faweVersion.build < Integer.parseInt(UpdateNotification.faweVersion)) {
                 hasUpdate = true;
                 int versionDifference = Integer.parseInt(UpdateNotification.faweVersion) - faweVersion.build;
                 LOGGER.warn(


### PR DESCRIPTION
 - SNAPSHOT will usually only be removed if it's a release version
 - If others remove SNAPSHOT, then they're probably doing their own stuff, just use this as the "release" check
 - fixes #2744