### PR TITLE
fix: recover from trimmed chunk

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharBlocks.java
@@ -17,13 +17,23 @@ public abstract class CharBlocks implements IBlocks {
     protected static final Section FULL = new Section() {
         @Override
         public char[] get(CharBlocks blocks, int layer) {
-            return blocks.blocks[layer];
+            char[] arr = blocks.blocks[layer];
+            if (arr == null) {
+                // Chunk probably trimmed mid-operations, but do nothing about it to avoid other issues
+                return EMPTY.get(blocks, layer, false);
+            }
+            return arr;
         }
 
         // Ignore aggressive switch here.
         @Override
         public char[] get(CharBlocks blocks, int layer, boolean aggressive) {
-            return blocks.blocks[layer];
+            char[] arr = blocks.blocks[layer];
+            if (arr == null) {
+                // Chunk probably trimmed mid-operations, but do nothing about it to avoid other issues
+                return EMPTY.get(blocks, layer, false);
+            }
+            return arr;
         }
 
         @Override


### PR DESCRIPTION
 - It's theoretically possible for the section FULL to return a null layer due to race condition with a trim operation
 - Locally cache result and if null, recover
 - I just had the error from #1592 again
 - This seems to have stopped the error, but adding logging did not log, so possibly some bigger bytecode changes?
 - Oh well