### PR TITLE
fix: always init ChunkFilterBlock to the chunk

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IQueueExtent.java
@@ -115,7 +115,7 @@ public interface IQueueExtent<T extends IChunk> extends Flushable, Trimable, ICh
      * A filter block is used to iterate over blocks / positions. Essentially combines BlockVector3,
      * Extent and BlockState functions in a way that avoids lookups.
      */
-    ChunkFilterBlock initFilterBlock();
+    ChunkFilterBlock createFilterBlock();
 
     /**
      * Returns the number of chunks in this queue.
@@ -129,7 +129,14 @@ public interface IQueueExtent<T extends IChunk> extends Flushable, Trimable, ICh
      */
     boolean isEmpty();
 
-    default ChunkFilterBlock apply(ChunkFilterBlock block, Filter filter, Region region, int chunkX, int chunkZ, boolean full) {
+    default ChunkFilterBlock apply(
+            @Nullable ChunkFilterBlock block,
+            Filter filter,
+            Region region,
+            int chunkX,
+            int chunkZ,
+            boolean full
+    ) {
         if (!filter.appliesChunk(chunkX, chunkZ)) {
             return block;
         }
@@ -139,8 +146,9 @@ public interface IQueueExtent<T extends IChunk> extends Flushable, Trimable, ICh
         if (newChunk != null) {
             chunk = newChunk;
             if (block == null) {
-                block = this.initFilterBlock();
+                block = this.createFilterBlock();
             }
+            block.initChunk(chunkX, chunkZ);
             chunk.filterBlocks(filter, block, region, full);
         }
         this.submit(chunk);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
@@ -133,9 +133,10 @@ public class ParallelQueueExtent extends PassthroughExtent {
         final int size = Math.min(chunks.size(), Settings.settings().QUEUE.PARALLEL_THREADS);
         if (size <= 1) {
             // if PQE is ever used with PARALLEL_THREADS = 1, or only one chunk is edited, just run sequentially
+            ChunkFilterBlock block = null;
             while (chunksIter.hasNext()) {
                 BlockVector2 pos = chunksIter.next();
-                getExtent().apply(null, filter, region, pos.x(), pos.z(), full);
+                block = getExtent().apply(block, filter, region, pos.x(), pos.z(), full);
             }
         } else {
             final ForkJoinTask[] tasks = IntStream.range(0, size).mapToObj(i -> handler.submit(() -> {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
@@ -28,6 +28,7 @@ import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.Countable;
 import com.sk89q.worldedit.world.World;
@@ -142,6 +143,7 @@ public class ParallelQueueExtent extends PassthroughExtent {
             final ForkJoinTask[] tasks = IntStream.range(0, size).mapToObj(i -> handler.submit(() -> {
                 try {
                     final Filter newFilter = filter.fork();
+                    final Region newRegion = region.clone();
                     // Create a chunk that we will reuse/reset for each operation
                     final SingleThreadQueueExtent queue = (SingleThreadQueueExtent) getNewQueue();
                     queue.setFastMode(fastmode);
@@ -163,7 +165,7 @@ public class ParallelQueueExtent extends PassthroughExtent {
                                     chunkX = pos.x();
                                     chunkZ = pos.z();
                                 }
-                                block = queue.apply(block, newFilter, region, chunkX, chunkZ, full);
+                                block = queue.apply(block, newFilter, newRegion, chunkX, chunkZ, full);
                             }
                             queue.flush();
                         } catch (Throwable t) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
@@ -473,7 +473,7 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
     }
 
     @Override
-    public ChunkFilterBlock initFilterBlock() {
+    public ChunkFilterBlock createFilterBlock() {
         return new CharFilterBlock(this);
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/regions/PolyhedralRegion.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/regions/PolyhedralRegion.java
@@ -71,7 +71,7 @@ public class PolyhedralRegion extends AbstractRegion {
     public PolyhedralRegion(PolyhedralRegion region) {
         this(region.world);
         vertices.addAll(region.vertices);
-        triangles.addAll(region.triangles);
+        region.triangles.forEach(triangle -> triangles.add(triangle.clone()));
         vertexBacklog.addAll(region.vertexBacklog);
 
         minimumPoint = region.minimumPoint;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/regions/Triangle.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/regions/Triangle.java
@@ -7,9 +7,13 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.regions.polyhedron.Edge;
 
-public class Triangle {
+public class Triangle implements Cloneable {
 
     public static double RADIUS = 0.5;
+
+    private final BlockVector3 pos1;
+    private final BlockVector3 pos2;
+    private final BlockVector3 pos3;
 
     private final double[][] verts = new double[3][3];
     private final double[] center = new double[3];
@@ -28,6 +32,9 @@ public class Triangle {
     private final double b;
 
     public Triangle(BlockVector3 pos1, BlockVector3 pos2, BlockVector3 pos3) {
+        this.pos1 = pos1;
+        this.pos2 = pos2;
+        this.pos3 = pos3;
         verts[0] = new double[]{pos1.x(), pos1.y(), pos1.z()};
         verts[1] = new double[]{pos2.x(), pos2.y(), pos2.z()};
         verts[2] = new double[]{pos3.x(), pos3.y(), pos3.z()};
@@ -288,6 +295,11 @@ public class Triangle {
             return false;
         }
         return dot(normal, vmax) >= 0.0f;
+    }
+
+    @Override
+    public Triangle clone() {
+        return new Triangle(pos1, pos2, pos3);
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
@@ -106,7 +106,8 @@ public class MaskingExtent extends AbstractDelegateExtent implements IBatchProce
     @Override
     public IChunkSet processSet(final IChunk chunk, final IChunkGet get, final IChunkSet set) {
         final ChunkFilterBlock filter = getOrCreateFilterBlock.apply(Thread.currentThread().getId());
-        return filter.filter(chunk, get, set, MaskingExtent.this);
+        filter.initChunk(chunk.getX(), chunk.getZ());
+        return filter.filter(chunk, get, set, this);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/CuboidRegion.java
@@ -755,7 +755,6 @@ public class CuboidRegion extends AbstractRegion implements FlatRegion {
     ) {
         int chunkX = chunk.getX();
         int chunkZ = chunk.getZ();
-        block = block.initChunk(chunkX, chunkZ);
 
         //Chunk entry is an "interior chunk" in regards to the entire region, so filter the chunk whole instead of partially
         if ((minX + 15) >> 4 <= chunkX && (maxX - 15) >> 4 >= chunkX && (minZ + 15) >> 4 <= chunkZ && (maxZ - 15) >> 4 >= chunkZ) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/EllipsoidRegion.java
@@ -412,8 +412,6 @@ public class EllipsoidRegion extends AbstractRegion {
                 return;
             }
 
-            block = block.initChunk(chunk.getX(), chunk.getZ());
-
             // Get the solid layers
             int cy = center.y();
             int diffYFull = MathMan.usqrt(diffY2);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -268,7 +268,6 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
     ) {
         int minSection = Math.max(get.getMinSectionPosition(), getMinimumY() >> 4);
         int maxSection = Math.min(get.getMaxSectionPosition(), getMaximumY() >> 4);
-        block = block.initChunk(chunk.getX(), chunk.getZ());
         for (int layer = minSection; layer <= maxSection; layer++) {
             if ((!full && !get.hasSection(layer)) || !filter.appliesLayer(chunk, layer)) {
                 return;


### PR DESCRIPTION
 - rename initFilterBlock from init to create
 - remove where we now needlessly init filter blocks
 - clone regions in PQE to fix Polyhedral
 - fixes #2662
 - fixes #2579