### PR TITLE
fix: create new biome paletted container when writing

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightGetBlocks.java
@@ -824,7 +824,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                         nmsChunk.mustNotSave = false;
                         nmsChunk.setUnsaved(true);
                         // send to player
-                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING) {
+                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
                             this.send();
                         }
                         if (finalizer != null) {
@@ -1109,31 +1109,21 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (biomes == null || (sectionBiomes = biomes[sectionIndex]) == null) {
             return null;
         }
-        PalettedContainer<Holder<Biome>> biomeData;
-        if (data instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomeData = palettedContainer.copy();
-        } else {
-            LOGGER.warn(
-                    "Cannot correctly set biomes to world, existing biomes may be lost. Expected class " +
-                            "type {} but got {}",
-                    PalettedContainer.class.getSimpleName(),
-                    data.getClass().getSimpleName()
-            );
-            biomeData = data.recreate();
-        }
+        PalettedContainer<Holder<Biome>> biomeData = data.recreate();
         for (int y = 0, index = 0; y < 4; y++) {
             for (int z = 0; z < 4; z++) {
                 for (int x = 0; x < 4; x++, index++) {
                     BiomeType biomeType = sectionBiomes[index];
                     if (biomeType == null) {
-                        continue;
+                        biomeData.set(x, y, z, data.get(x, y, z));
+                    } else {
+                        biomeData.set(
+                                x,
+                                y,
+                                z,
+                                biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
+                        );
                     }
-                    biomeData.set(
-                            x,
-                            y,
-                            z,
-                            biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
-                    );
                 }
             }
         }

--- a/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_19_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_19_R3/PaperweightGetBlocks_Copy.java
@@ -45,7 +45,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     private final int maxHeight;
     final ServerLevel serverLevel;
     final LevelChunk levelChunk;
-    private PalettedContainer<Holder<Biome>>[] biomes = null;
+    private Holder<Biome>[][] biomes = null;
 
     protected PaperweightGetBlocks_Copy(LevelChunk levelChunk) {
         this.levelChunk = levelChunk;
@@ -144,7 +144,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     @Override
     public BiomeType getBiomeType(int x, int y, int z) {
-        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()].get(x >> 2, (y & 15) >> 2, z >> 2);
+        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()][(y & 12) << 2 | (z & 12) | (x & 12) >> 2];
         return PaperweightPlatformAdapter.adapt(biome, serverLevel);
     }
 
@@ -173,10 +173,15 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     protected void storeBiomes(int layer, PalettedContainerRO<Holder<Biome>> biomeData) {
         if (biomes == null) {
-            biomes = new PalettedContainer[getSectionCount()];
+            biomes = new Holder[getSectionCount()][];
+        }
+        if (biomes[layer] == null) {
+            biomes[layer] = new Holder[64];
         }
         if (biomeData instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomes[layer] = palettedContainer.copy();
+            for (int i = 0; i < 64; i++) {
+                biomes[layer][i] = palettedContainer.get(i);
+            }
         } else {
             LOGGER.error(
                     "Cannot correctly save biomes to history. Expected class type {} but got {}",

--- a/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightGetBlocks.java
@@ -822,7 +822,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                         nmsChunk.mustNotSave = false;
                         nmsChunk.setUnsaved(true);
                         // send to player
-                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING) {
+                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
                             this.send();
                         }
                         if (finalizer != null) {
@@ -1106,31 +1106,21 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (biomes == null || (sectionBiomes = biomes[sectionIndex]) == null) {
             return null;
         }
-        PalettedContainer<Holder<Biome>> biomeData;
-        if (data instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomeData = palettedContainer.copy();
-        } else {
-            LOGGER.warn(
-                    "Cannot correctly set biomes to world, existing biomes may be lost. Expected class " +
-                            "type {} but got {}",
-                    PalettedContainer.class.getSimpleName(),
-                    data.getClass().getSimpleName()
-            );
-            biomeData = data.recreate();
-        }
+        PalettedContainer<Holder<Biome>> biomeData = data.recreate();
         for (int y = 0, index = 0; y < 4; y++) {
             for (int z = 0; z < 4; z++) {
                 for (int x = 0; x < 4; x++, index++) {
                     BiomeType biomeType = sectionBiomes[index];
                     if (biomeType == null) {
-                        continue;
+                        biomeData.set(x, y, z, data.get(x, y, z));
+                    } else {
+                        biomeData.set(
+                                x,
+                                y,
+                                z,
+                                biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
+                        );
                     }
-                    biomeData.set(
-                            x,
-                            y,
-                            z,
-                            biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
-                    );
                 }
             }
         }

--- a/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R1/PaperweightGetBlocks_Copy.java
@@ -45,7 +45,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     private final int maxHeight;
     final ServerLevel serverLevel;
     final LevelChunk levelChunk;
-    private PalettedContainer<Holder<Biome>>[] biomes = null;
+    private Holder<Biome>[][] biomes = null;
 
     protected PaperweightGetBlocks_Copy(LevelChunk levelChunk) {
         this.levelChunk = levelChunk;
@@ -144,7 +144,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     @Override
     public BiomeType getBiomeType(int x, int y, int z) {
-        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()].get(x >> 2, (y & 15) >> 2, z >> 2);
+        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()][(y & 12) << 2 | (z & 12) | (x & 12) >> 2];
         return PaperweightPlatformAdapter.adapt(biome, serverLevel);
     }
 
@@ -173,10 +173,15 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     protected void storeBiomes(int layer, PalettedContainerRO<Holder<Biome>> biomeData) {
         if (biomes == null) {
-            biomes = new PalettedContainer[getSectionCount()];
+            biomes = new Holder[getSectionCount()][];
+        }
+        if (biomes[layer] == null) {
+            biomes[layer] = new Holder[64];
         }
         if (biomeData instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomes[layer] = palettedContainer.copy();
+            for (int i = 0; i < 64; i++) {
+                biomes[layer][i] = palettedContainer.get(i);
+            }
         } else {
             LOGGER.error(
                     "Cannot correctly save biomes to history. Expected class type {} but got {}",

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -830,7 +830,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                         nmsChunk.mustNotSave = false;
                         nmsChunk.setUnsaved(true);
                         // send to player
-                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING) {
+                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
                             this.send();
                         }
                         if (finalizer != null) {
@@ -1114,31 +1114,21 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (biomes == null || (sectionBiomes = biomes[sectionIndex]) == null) {
             return null;
         }
-        PalettedContainer<Holder<Biome>> biomeData;
-        if (data instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomeData = palettedContainer.copy();
-        } else {
-            LOGGER.warn(
-                    "Cannot correctly set biomes to world, existing biomes may be lost. Expected class " +
-                            "type {} but got {}",
-                    PalettedContainer.class.getSimpleName(),
-                    data.getClass().getSimpleName()
-            );
-            biomeData = data.recreate();
-        }
+        PalettedContainer<Holder<Biome>> biomeData = data.recreate();
         for (int y = 0, index = 0; y < 4; y++) {
             for (int z = 0; z < 4; z++) {
                 for (int x = 0; x < 4; x++, index++) {
                     BiomeType biomeType = sectionBiomes[index];
                     if (biomeType == null) {
-                        continue;
+                        biomeData.set(x, y, z, data.get(x, y, z));
+                    } else {
+                        biomeData.set(
+                                x,
+                                y,
+                                z,
+                                biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
+                        );
                     }
-                    biomeData.set(
-                            x,
-                            y,
-                            z,
-                            biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
-                    );
                 }
             }
         }

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks_Copy.java
@@ -45,7 +45,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     private final int maxHeight;
     final ServerLevel serverLevel;
     final LevelChunk levelChunk;
-    private PalettedContainer<Holder<Biome>>[] biomes = null;
+    private Holder<Biome>[][] biomes = null;
 
     protected PaperweightGetBlocks_Copy(LevelChunk levelChunk) {
         this.levelChunk = levelChunk;
@@ -144,7 +144,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     @Override
     public BiomeType getBiomeType(int x, int y, int z) {
-        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()].get(x >> 2, (y & 15) >> 2, z >> 2);
+        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()][(y & 12) << 2 | (z & 12) | (x & 12) >> 2];
         return PaperweightPlatformAdapter.adapt(biome, serverLevel);
     }
 
@@ -173,10 +173,15 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     protected void storeBiomes(int layer, PalettedContainerRO<Holder<Biome>> biomeData) {
         if (biomes == null) {
-            biomes = new PalettedContainer[getSectionCount()];
+            biomes = new Holder[getSectionCount()][];
+        }
+        if (biomes[layer] == null) {
+            biomes[layer] = new Holder[64];
         }
         if (biomeData instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomes[layer] = palettedContainer.copy();
+            for (int i = 0; i < 64; i++) {
+                biomes[layer][i] = palettedContainer.get(i);
+            }
         } else {
             LOGGER.error(
                     "Cannot correctly save biomes to history. Expected class type {} but got {}",

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
@@ -829,7 +829,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                         nmsChunk.mustNotSave = false;
                         nmsChunk.setUnsaved(true);
                         // send to player
-                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING) {
+                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
                             this.send();
                         }
                         if (finalizer != null) {
@@ -1111,31 +1111,21 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (biomes == null || (sectionBiomes = biomes[sectionIndex]) == null) {
             return null;
         }
-        PalettedContainer<Holder<Biome>> biomeData;
-        if (data instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomeData = palettedContainer.copy();
-        } else {
-            LOGGER.warn(
-                    "Cannot correctly set biomes to world, existing biomes may be lost. Expected class " +
-                            "type {} but got {}",
-                    PalettedContainer.class.getSimpleName(),
-                    data.getClass().getSimpleName()
-            );
-            biomeData = data.recreate();
-        }
+        PalettedContainer<Holder<Biome>> biomeData = data.recreate();
         for (int y = 0, index = 0; y < 4; y++) {
             for (int z = 0; z < 4; z++) {
                 for (int x = 0; x < 4; x++, index++) {
                     BiomeType biomeType = sectionBiomes[index];
                     if (biomeType == null) {
-                        continue;
+                        biomeData.set(x, y, z, data.get(x, y, z));
+                    } else {
+                        biomeData.set(
+                                x,
+                                y,
+                                z,
+                                biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
+                        );
                     }
-                    biomeData.set(
-                            x,
-                            y,
-                            z,
-                            biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
-                    );
                 }
             }
         }

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks_Copy.java
@@ -45,7 +45,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     private final int maxHeight;
     final ServerLevel serverLevel;
     final LevelChunk levelChunk;
-    private PalettedContainer<Holder<Biome>>[] biomes = null;
+    private Holder<Biome>[][] biomes = null;
 
     protected PaperweightGetBlocks_Copy(LevelChunk levelChunk) {
         this.levelChunk = levelChunk;
@@ -144,7 +144,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     @Override
     public BiomeType getBiomeType(int x, int y, int z) {
-        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()].get(x >> 2, (y & 15) >> 2, z >> 2);
+        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()][(y & 12) << 2 | (z & 12) | (x & 12) >> 2];
         return PaperweightPlatformAdapter.adapt(biome, serverLevel);
     }
 
@@ -173,10 +173,15 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     protected void storeBiomes(int layer, PalettedContainerRO<Holder<Biome>> biomeData) {
         if (biomes == null) {
-            biomes = new PalettedContainer[getSectionCount()];
+            biomes = new Holder[getSectionCount()][];
+        }
+        if (biomes[layer] == null) {
+            biomes[layer] = new Holder[64];
         }
         if (biomeData instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomes[layer] = palettedContainer.copy();
+            for (int i = 0; i < 64; i++) {
+                biomes[layer][i] = palettedContainer.get(i);
+            }
         } else {
             LOGGER.error(
                     "Cannot correctly save biomes to history. Expected class type {} but got {}",

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
@@ -830,7 +830,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                         nmsChunk.mustNotSave = false;
                         nmsChunk.setUnsaved(true);
                         // send to player
-                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING) {
+                        if (Settings.settings().LIGHTING.MODE == 0 || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
                             this.send();
                         }
                         if (finalizer != null) {
@@ -1114,31 +1114,21 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         if (biomes == null || (sectionBiomes = biomes[sectionIndex]) == null) {
             return null;
         }
-        PalettedContainer<Holder<Biome>> biomeData;
-        if (data instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomeData = palettedContainer.copy();
-        } else {
-            LOGGER.warn(
-                    "Cannot correctly set biomes to world, existing biomes may be lost. Expected class " +
-                            "type {} but got {}",
-                    PalettedContainer.class.getSimpleName(),
-                    data.getClass().getSimpleName()
-            );
-            biomeData = data.recreate();
-        }
+        PalettedContainer<Holder<Biome>> biomeData = data.recreate();
         for (int y = 0, index = 0; y < 4; y++) {
             for (int z = 0; z < 4; z++) {
                 for (int x = 0; x < 4; x++, index++) {
                     BiomeType biomeType = sectionBiomes[index];
                     if (biomeType == null) {
-                        continue;
+                        biomeData.set(x, y, z, data.get(x, y, z));
+                    } else {
+                        biomeData.set(
+                                x,
+                                y,
+                                z,
+                                biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
+                        );
                     }
-                    biomeData.set(
-                            x,
-                            y,
-                            z,
-                            biomeHolderIdMap.byIdOrThrow(adapter.getInternalBiomeId(biomeType))
-                    );
                 }
             }
         }

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks_Copy.java
@@ -46,7 +46,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     private final int maxHeight;
     final ServerLevel serverLevel;
     final LevelChunk levelChunk;
-    private PalettedContainer<Holder<Biome>>[] biomes = null;
+    private Holder<Biome>[][] biomes = null;
 
     protected PaperweightGetBlocks_Copy(LevelChunk levelChunk) {
         this.levelChunk = levelChunk;
@@ -145,7 +145,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     @Override
     public BiomeType getBiomeType(int x, int y, int z) {
-        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()].get(x >> 2, (y & 15) >> 2, z >> 2);
+        Holder<Biome> biome = biomes[(y >> 4) - getMinSectionPosition()][(y & 12) << 2 | (z & 12) | (x & 12) >> 2];
         return PaperweightPlatformAdapter.adapt(biome, serverLevel);
     }
 
@@ -174,10 +174,15 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     protected void storeBiomes(int layer, PalettedContainerRO<Holder<Biome>> biomeData) {
         if (biomes == null) {
-            biomes = new PalettedContainer[getSectionCount()];
+            biomes = new Holder[getSectionCount()][];
+        }
+        if (biomes[layer] == null) {
+            biomes[layer] = new Holder[64];
         }
         if (biomeData instanceof PalettedContainer<Holder<Biome>> palettedContainer) {
-            biomes[layer] = palettedContainer.copy();
+            for (int i = 0; i < 64; i++) {
+                biomes[layer][i] = palettedContainer.get(i);
+            }
         } else {
             LOGGER.error(
                     "Cannot correctly save biomes to history. Expected class type {} but got {}",


### PR DESCRIPTION
 - resizing a paletted container copy alters the original paletted container
 - copy is not clone
 - fixes #2790