### PR TITLE
Use isMovementBlocker() instead of isSolid() in heightmap calculation

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/heightmap/HeightMapType.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/heightmap/HeightMapType.java
@@ -17,19 +17,19 @@ public enum HeightMapType {
     MOTION_BLOCKING {
         @Override
         public boolean includes(BlockState state) {
-            return state.getMaterial().isSolid() || HeightMapType.hasFluid(state);
+            return state.getMaterial().isMovementBlocker() || HeightMapType.hasFluid(state);
         }
     },
     MOTION_BLOCKING_NO_LEAVES {
         @Override
         public boolean includes(BlockState state) {
-            return (state.getMaterial().isSolid() || HeightMapType.hasFluid(state)) && !HeightMapType.isLeaf(state);
+            return (state.getMaterial().isMovementBlocker() || HeightMapType.hasFluid(state)) && !HeightMapType.isLeaf(state);
         }
     },
     OCEAN_FLOOR {
         @Override
         public boolean includes(BlockState state) {
-            return state.getMaterial().isSolid();
+            return state.getMaterial().isMovementBlocker();
         }
     },
     WORLD_SURFACE {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2819

## Description
<!-- Please describe what this pull request does. -->

The concepts of `isSolid()` and `isMovementBlocker()` diverged. While it had the same meaning in older versions, it's now different. That means we need to adjust the includes check.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
