### PR TITLE
Add worldedit.tool.none to fawe.permpack.basic

### DIFF
--- a/worldedit-bukkit/src/main/resources/plugin.yml
+++ b/worldedit-bukkit/src/main/resources/plugin.yml
@@ -135,6 +135,7 @@ permissions:
       worldedit.brush.options.transform: true
       worldedit.brush.options.scroll: true
       worldedit.brush.options.visualize: true
+      worldedit.tool.none: true
       worldedit.tool.deltree: true
       worldedit.tool.farwand: true
       worldedit.tool.lrbuild: true


### PR DESCRIPTION
If node "fawe.permpack.basic" exist in other platform than bukkit,this minor bug would exist here too,but i lack the knowledge of finding it out.

A really minor fix , so I just ignore all the contributing requirements :)