### PR TITLE
Fix parseFromInput Method for Masks and Patterns When Called via API

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/MaskFactory.java
@@ -53,6 +53,7 @@ import com.sk89q.worldedit.extension.factory.parser.mask.NoiseMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.OffsetMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.RegionMaskParser;
 import com.sk89q.worldedit.extension.factory.parser.mask.SolidMaskParser;
+import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.NoMatchException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.mask.Mask;
@@ -131,6 +132,11 @@ public final class MaskFactory extends AbstractFactory<Mask> {
     }
 
     //FAWE start - rich mask parsing
+
+    @Override
+    public Mask parseFromInput(String input, ParserContext context) throws InputParseException {
+        return super.parseFromInput(input, context);
+    }
 
     @Override
     protected Mask getParsed(final String input, final List<Mask> masks) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/PatternFactory.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/PatternFactory.java
@@ -60,7 +60,9 @@ import com.sk89q.worldedit.extension.factory.parser.pattern.RandomPatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.RandomStatePatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.SingleBlockPatternParser;
 import com.sk89q.worldedit.extension.factory.parser.pattern.TypeOrStateApplyingPatternParser;
+import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.NoMatchException;
+import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.function.pattern.RandomPattern;
 import com.sk89q.worldedit.internal.registry.AbstractFactory;
@@ -128,6 +130,13 @@ public final class PatternFactory extends AbstractFactory<Pattern> {
         register(new SurfaceRandomOffsetPatternParser(worldEdit));
         register(new TypeSwapPatternParser(worldEdit));
         register(new VoronoiPatternParser(worldEdit));
+    }
+
+    //FAWE start - rich pattern parsing
+
+    @Override
+    public Pattern parseFromInput(String input, ParserContext context) throws InputParseException {
+        return super.parseFromInput(input, context);
     }
 
     @Override


### PR DESCRIPTION
## Overview
Following the updates in https://github.com/IntellectualSites/FastAsyncWorldEdit/pull/2786, usage of Mask/Pattern factory parseFromInput() within a RichParser paser does not work and causes the surrounding parser to error.

This resolves that error.

Fixes #2825

## Description
From my limited testing it appears that this line was not returning the correct type https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/561ef4afdd3dd717d1f040b6440af39354d5826f/worldedit-core/src/main/java/com/sk89q/worldedit/internal/registry/AbstractFactory.java#L113C14-L113C73 which seems to line up with the errors seen in #2825.

By explicitely using Mask/Pattern in the parseFromInput method the issue is resolved.

I am unsure if this is the best way to solve the problem, but it seems to work without breaking the new functionality from #2786 

Usage in an Arceon pattern:
![image](https://github.com/user-attachments/assets/36721d6d-2972-4f48-a20b-ad6553a8c155)

Usage in an ezEdits mask, with the new FAWE support for quotations and spaces for `&`:
![image](https://github.com/user-attachments/assets/6dc4c34b-c9f9-4c98-9f85-2bbd0cb83b52)

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
