### PR TITLE
fix: improve FAWE stream history

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/CopyPastaBrush.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/CopyPastaBrush.java
@@ -91,7 +91,7 @@ public class CopyPastaBrush implements Brush, ResettableTool {
             newClipboard.setOrigin(position);
             ClipboardHolder holder = new ClipboardHolder(newClipboard);
             session.setClipboard(holder);
-            int blocks = builder.size();
+            long blocks = builder.longSize();
             player.print(Caption.of("fawe.worldedit.copy.command.copy", blocks));
         } else {
             AffineTransform transform = null;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -306,7 +306,7 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     }
 
     public boolean isEmpty() {
-        return queue.isEmpty() && workerSemaphore.availablePermits() == 1 && size() == 0;
+        return queue.isEmpty() && workerSemaphore.availablePermits() == 1 && longSize() == 0;
     }
 
     public void add(BlockVector3 loc, BaseBlock from, BaseBlock to) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractDelegateChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractDelegateChangeSet.java
@@ -177,6 +177,11 @@ public class AbstractDelegateChangeSet extends AbstractChangeSet {
     }
 
     @Override
+    public long longSize() {
+        return parent.longSize();
+    }
+
+    @Override
     public void delete() {
         parent.delete();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
@@ -37,8 +37,8 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
 
     public static final int HEADER_SIZE = 9;
     private static final int VERSION = 2;
-    // equivalent to Short#MIN_VALUE three times
-    private static final byte[] MAGIC_NEW_RELATIVE = new byte[]{(byte) 128, 0, (byte) 128, 0, (byte) 128, 0};
+    // equivalent to Short#MIN_VALUE three times stored with [(x) & 0xff, ((rx) >> 8) & 0xff]
+    private static final byte[] MAGIC_NEW_RELATIVE = new byte[]{0, (byte) 128, 0, (byte) 128, 0, (byte) 128};
     private int mode;
     private final int compression;
     private final int minY;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
@@ -25,6 +25,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -35,10 +36,17 @@ import java.util.NoSuchElementException;
 public abstract class FaweStreamChangeSet extends AbstractChangeSet {
 
     public static final int HEADER_SIZE = 9;
-    private static final int version = 1;
+    private static final int VERSION = 2;
+    // equivalent to Short#MIN_VALUE three times
+    private static final byte[] MAGIC_NEW_RELATIVE = new byte[]{(byte) 128, 0, (byte) 128, 0, (byte) 128, 0};
     private int mode;
     private final int compression;
     private final int minY;
+
+    protected long blockSize;
+    private int originX;
+    private int originZ;
+    private int version;
 
     protected FaweStreamIdDelegate idDel;
     protected FaweStreamPositionDelegate posDel;
@@ -192,6 +200,20 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
                     int rx = -lx + (lx = x);
                     int ry = -ly + (ly = y);
                     int rz = -lz + (lz = z);
+                    // Use LE/GE to ensure we don't accidentally write MAGIC_NEW_RELATIVE
+                    if (rx >= Short.MAX_VALUE || rz >= Short.MAX_VALUE || rx <= Short.MIN_VALUE || rz <= Short.MIN_VALUE) {
+                        stream.write(MAGIC_NEW_RELATIVE);
+                        stream.write((byte) (x >> 24));
+                        stream.write((byte) (x >> 16));
+                        stream.write((byte) (x >> 8));
+                        stream.write((byte) (x));
+                        stream.write((byte) (z >> 24));
+                        stream.write((byte) (z >> 16));
+                        stream.write((byte) (z >> 8));
+                        stream.write((byte) (z));
+                        rx = 0;
+                        rz = 0;
+                    }
                     stream.write((rx) & 0xff);
                     stream.write(((rx) >> 8) & 0xff);
                     stream.write((rz) & 0xff);
@@ -203,6 +225,12 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
                 @Override
                 public int readX(FaweInputStream is) throws IOException {
                     is.readFully(buffer);
+                    // Don't break reading version 1 history (just in case)
+                    if (version == 2 && Arrays.equals(buffer, MAGIC_NEW_RELATIVE)) {
+                        lx = ((is.read() << 24) + (is.read() << 16) + (is.read() << 8) + is.read());
+                        lz = ((is.read() << 24) + (is.read() << 16) + (is.read() << 8) + is.read());
+                        is.readFully(buffer);
+                    }
                     return lx = lx + ((buffer[0] & 0xFF) | (buffer[1] << 8));
                 }
 
@@ -222,7 +250,7 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
     public void writeHeader(OutputStream os, int x, int y, int z) throws IOException {
         os.write(mode);
         // Allows for version detection of history in case of changes to format.
-        os.write(version);
+        os.write(VERSION);
         setOrigin(x, z);
         os.write((byte) (x >> 24));
         os.write((byte) (x >> 16));
@@ -238,8 +266,8 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
     public void readHeader(InputStream is) throws IOException {
         // skip mode
         int mode = is.read();
-        int version = is.read();
-        if (version != FaweStreamChangeSet.version) {
+        version = is.read();
+        if (version != 1 && version != VERSION) { // version 1 is fine
             throw new UnsupportedOperationException(String.format("Version %s history not supported!", version));
         }
         // origin
@@ -266,10 +294,17 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
     }
 
     @Override
-    public int size() {
+    public long longSize() {
         // Flush so we can accurately get the size
         flush();
         return blockSize;
+    }
+
+    @Override
+    public int size() {
+        // Flush so we can accurately get the size
+        flush();
+        return (int) blockSize;
     }
 
     public abstract int getCompressedSize();
@@ -303,11 +338,6 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
     public abstract NBTInputStream getTileCreateIS() throws IOException;
 
     public abstract NBTInputStream getTileRemoveIS() throws IOException;
-
-    protected int blockSize;
-
-    private int originX;
-    private int originZ;
 
     public void setOrigin(int x, int z) {
         originX = x;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
@@ -302,9 +302,7 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
 
     @Override
     public int size() {
-        // Flush so we can accurately get the size
-        flush();
-        return (int) blockSize;
+        return (int) longSize();
     }
 
     public abstract int getCompressedSize();

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
@@ -217,7 +217,7 @@ public class MainUtil {
 //        } else if (changeSet instanceof CPUOptimizedChangeSet) {
 //            return changeSet.size() + 32;
         } else if (changeSet != null) {
-            return changeSet.size() * 128L;
+            return changeSet.longSize() * 128; // Approx
         } else {
             return 0;
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/LocalSession.java
@@ -500,7 +500,7 @@ public class LocalSession implements TextureHolder {
             if (Settings.settings().HISTORY.USE_DISK) {
                 LocalSession.MAX_HISTORY_SIZE = Integer.MAX_VALUE;
             }
-            if (changeSet.size() == 0) {
+            if (changeSet.longSize() == 0) {
                 return;
             }
             loadSessionHistoryFromDisk(player.getUniqueId(), world);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistorySubCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/HistorySubCommands.java
@@ -251,7 +251,7 @@ public class HistorySubCommands {
         long seconds = (System.currentTimeMillis() - edit.getBDFile().lastModified()) / 1000;
         String timeStr = MainUtil.secToTime(seconds);
 
-        int size = edit.size();
+        long size = edit.longSize();
         boolean biomes = edit.getBioFile().exists();
         boolean createdEnts = edit.getEnttFile().exists();
         boolean removedEnts = edit.getEntfFile().exists();
@@ -335,7 +335,7 @@ public class HistorySubCommands {
                             long seconds = (System.currentTimeMillis() - rollback.getBDFile().lastModified()) / 1000;
                             String timeStr = MainUtil.secToTime(seconds);
 
-                            int size = edit.size();
+                            long size = edit.longSize();
 
                             TranslatableComponent elem = Caption.of(
                                     "fawe.worldedit.history.find.element",

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/history/changeset/ChangeSet.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/history/changeset/ChangeSet.java
@@ -81,10 +81,23 @@ public interface ChangeSet extends Closeable {
      * Get the number of stored changes.
      *
      * @return the change count
+     * @deprecated History could be larger than int max value so FAWE prefers {@link ChangeSet#longSize()}
      */
+    @Deprecated(since = "TODO")
     int size();
 
     //FAWE start
+
+    /**
+     * Get the number of stored changes.
+     * History could be larger than int max value so FAWE prefers this method.
+     *
+     * @return the change count
+     * @since TODO
+     */
+    default long longSize() {
+        return size();
+    }
 
     /**
      * Close the changeset.


### PR DESCRIPTION
 - reset "origin"/relative X/Z when larger than short min/max value so we do not write incorrect positions
 - history size can be larger than int max value
 - fixes #2583