### PR TITLE
Support 1.21.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ allprojects {
 }
 
 applyCommonConfiguration()
-val supportedVersions = listOf("1.19.4", "1.20", "1.20.4", "1.20.5", "1.20.6", "1.21")
+val supportedVersions = listOf("1.19.4", "1.20", "1.20.4", "1.20.5", "1.20.6", "1.21.1")
 
 tasks {
     supportedVersions.forEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ allprojects {
 }
 
 applyCommonConfiguration()
-val supportedVersions = listOf("1.19.4", "1.20", "1.20.4", "1.20.5", "1.20.6", "1.21.1")
+val supportedVersions = listOf("1.19.4", "1.20", "1.20.4", "1.20.5", "1.20.6", "1.21", "1.21.1")
 
 tasks {
     supportedVersions.forEach {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation(gradleApi())
     implementation("org.ajoberstar.grgit:grgit-gradle:5.2.2")
     implementation("com.github.johnrengelman:shadow:8.1.1")
-    implementation("io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:1.7.1")
+    implementation("io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:1.7.2")
     constraints {
         val asmVersion = "[9.7,)"
         implementation("org.ow2.asm:asm:$asmVersion") {

--- a/worldedit-bukkit/adapters/adapter-1_21/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_21/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    // url=https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/1.21-R0.1-SNAPSHOT/
-    the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21-R0.1-20240629.091304-42")
+    // url=https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/1.21.1-R0.1-SNAPSHOT/
+    the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21.1-R0.1-20240810.223713-4")
     compileOnly(libs.paperlib)
 }

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_R1/PaperweightAdapter.java
@@ -195,8 +195,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
         CraftServer.class.cast(Bukkit.getServer());
 
         int dataVersion = CraftMagicNumbers.INSTANCE.getDataVersion();
-        if (dataVersion != 3953) {
-            throw new UnsupportedClassVersionError("Not 1.21!");
+        if (dataVersion != 3953 && dataVersion != 3955) {
+            throw new UnsupportedClassVersionError("Not 1.21(.1)!");
         }
 
         serverWorldsField = CraftServer.class.getDeclaredField("worlds");

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -624,15 +624,14 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     }
 
     private boolean wasAccessibleSinceLastSave(ChunkHolder holder) {
-        if (!PaperLib.isPaper() || !PaperweightPlatformAdapter.POST_CHUNK_REWRITE) {
-            try {
-                return (boolean) CHUNK_HOLDER_WAS_ACCESSIBLE_SINCE_LAST_SAVE.invoke(holder);
-            } catch (IllegalAccessException | InvocationTargetException ignored) {
-                // fall-through
-            }
+        if (PaperLib.isPaper()) { // Papers new chunk system has no related replacement - therefor we assume true.
+            return true;
         }
-        // Papers new chunk system has no related replacement - therefor we assume true.
-        return true;
+        try {
+            return (boolean) CHUNK_HOLDER_WAS_ACCESSIBLE_SINCE_LAST_SAVE.invoke(holder);
+        } catch (IllegalAccessException | InvocationTargetException ignored) {
+            return false;
+        }
     }
 
 }

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
@@ -648,7 +648,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                         .moonrise$getEntityLookup()
                         .getChunk(chunk.locX, chunk.locZ));
             } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new RuntimeException("Failed to lookup entities [POST_CHUNK_REWRITE=true]", e);
+                throw new RuntimeException("Failed to lookup entities [PAPER=true]", e);
             }
         }
         try {

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
@@ -116,10 +116,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
-    static final boolean POST_CHUNK_REWRITE;
     private static Method PAPER_CHUNK_GEN_ALL_ENTITIES;
-    private static Method PAPER_PRE_CHUNK_UPDATE_ENTITY_LIST_GET_RAW_DATA;
-    private static Field LEVEL_CHUNK_ENTITIES;
     private static Field SERVER_LEVEL_ENTITY_MANAGER;
 
     static {
@@ -189,30 +186,15 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             fieldRemove = BlockEntity.class.getDeclaredField(Refraction.pickName("remove", "p"));
             fieldRemove.setAccessible(true);
 
-            boolean chunkRewrite;
             try {
                 Level.class.getDeclaredMethod("moonrise$getEntityLookup");
-                chunkRewrite = true;
                 PAPER_CHUNK_GEN_ALL_ENTITIES = ChunkEntitySlices.class.getDeclaredMethod("getAllEntities");
                 PAPER_CHUNK_GEN_ALL_ENTITIES.setAccessible(true);
             } catch (NoSuchMethodException ignored) {
-                chunkRewrite = false;
-            }
-            try {
-                // Paper - Pre-Chunk-Update
-                LEVEL_CHUNK_ENTITIES = LevelChunk.class.getDeclaredField("entities");
-                LEVEL_CHUNK_ENTITIES.setAccessible(true);
-                Class<?> entityListClass = Class.forName("com.destroystokyo.paper.util.maplist.EntityList");
-                PAPER_PRE_CHUNK_UPDATE_ENTITY_LIST_GET_RAW_DATA = entityListClass.getDeclaredMethod("getRawData");
-            } catch (NoSuchFieldException | ClassNotFoundException ignored) {
-            }
-            try {
                 // Non-Paper
                 SERVER_LEVEL_ENTITY_MANAGER = ServerLevel.class.getDeclaredField(Refraction.pickName("entityManager", "N"));
                 SERVER_LEVEL_ENTITY_MANAGER.setAccessible(true);
-            } catch (NoSuchFieldException ignored) {
             }
-            POST_CHUNK_REWRITE = chunkRewrite;
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -659,32 +641,22 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     static List<Entity> getEntities(LevelChunk chunk) {
-        ExceptionCollector<RuntimeException> collector = new ExceptionCollector<>();
         if (PaperLib.isPaper()) {
-            if (POST_CHUNK_REWRITE) {
-                try {
-                    //noinspection unchecked
-                    return (List<Entity>) PAPER_CHUNK_GEN_ALL_ENTITIES.invoke(chunk.level.moonrise$getEntityLookup().getChunk(chunk.locX, chunk.locZ));
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    throw new RuntimeException("Failed to lookup entities [POST_CHUNK_REWRITE=true]", e);
-                }
-            }
             try {
-                Object entityList = LEVEL_CHUNK_ENTITIES.get(chunk);
-                return List.of((Entity[]) PAPER_PRE_CHUNK_UPDATE_ENTITY_LIST_GET_RAW_DATA.invoke(entityList));
+                //noinspection unchecked
+                return (List<Entity>) PAPER_CHUNK_GEN_ALL_ENTITIES.invoke(chunk.level
+                        .moonrise$getEntityLookup()
+                        .getChunk(chunk.locX, chunk.locZ));
             } catch (IllegalAccessException | InvocationTargetException e) {
-                collector.add(new RuntimeException("Failed to lookup entities [POST_CHUNK_REWRITE=false]", e));
-                // fall through
+                throw new RuntimeException("Failed to lookup entities [POST_CHUNK_REWRITE=true]", e);
             }
         }
         try {
             //noinspection unchecked
             return ((PersistentEntitySectionManager<Entity>) (SERVER_LEVEL_ENTITY_MANAGER.get(chunk.level))).getEntities(chunk.getPos());
         } catch (IllegalAccessException e) {
-            collector.add(new RuntimeException("Failed to lookup entities [PAPER=false]", e));
+            throw new RuntimeException("Failed to lookup entities [PAPER=false]", e);
         }
-        collector.throwIfPresent();
-        return List.of();
     }
 
     record FakeIdMapBlock(int size) implements IdMap<net.minecraft.world.level.block.state.BlockState> {


### PR DESCRIPTION
## Overview
Fixes #2876

## Description
Allow the new 1.21.1 dataversion for the 1.21 adapter. EntityList got removed, so I've added reflection calls (I'm actually not even sure if there is a paper jar without the new chunk system - but no idea how forks handle that). Should work - but I haven't tested that (as I don't even know how). 1.21.1 works so far. Haven't explicitly tested 1.21

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
