### PR TITLE
Fix regen on modern versions

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/regen/PaperweightRegen.java
@@ -184,6 +184,11 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
     }
 
     @Override
+    protected void tickLevel(final BooleanSupplier shouldKeepTicking) {
+        this.freshWorld.tick(shouldKeepTicking);
+    }
+
+    @Override
     protected boolean prepare() {
         this.originalServerWorld = ((CraftWorld) originalBukkitWorld).getHandle();
         originalChunkProvider = originalServerWorld.getChunkSource();

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/regen/PaperweightRegen.java
@@ -4,162 +4,74 @@ import com.fastasyncworldedit.bukkit.adapter.Regenerator;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
+import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
 import com.google.common.collect.ImmutableList;
-import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Lifecycle;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.Refraction;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2.PaperweightGetBlocks;
 import com.sk89q.worldedit.extent.Extent;
-import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.io.file.SafeFiles;
 import com.sk89q.worldedit.world.RegenOptions;
-import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
-import net.minecraft.server.level.ChunkMap;
-import net.minecraft.server.level.ChunkTaskPriorityQueueSorter.Message;
-import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ThreadedLevelLightEngine;
 import net.minecraft.server.level.progress.ChunkProgressListener;
-import net.minecraft.util.thread.ProcessorHandle;
-import net.minecraft.util.thread.ProcessorMailbox;
+import net.minecraft.util.ProgressListener;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelHeightAccessor;
 import net.minecraft.world.level.LevelSettings;
 import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeSource;
-import net.minecraft.world.level.biome.FixedBiomeSource;
-import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.ChunkGenerator;
-import net.minecraft.world.level.chunk.ChunkGeneratorStructureState;
 import net.minecraft.world.level.chunk.ChunkStatus;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.level.chunk.ProtoChunk;
-import net.minecraft.world.level.chunk.UpgradeData;
 import net.minecraft.world.level.dimension.LevelStem;
-import net.minecraft.world.level.levelgen.FlatLevelSource;
 import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
-import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.WorldOptions;
-import net.minecraft.world.level.levelgen.blending.BlendingData;
-import net.minecraft.world.level.levelgen.flat.FlatLevelGeneratorSettings;
-import net.minecraft.world.level.levelgen.structure.placement.ConcentricRingsStructurePlacement;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.PrimaryLevelData;
-import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_20_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_20_R2.generator.CustomChunkGenerator;
 import org.bukkit.generator.BiomeProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 import static net.minecraft.core.registries.Registries.BIOME;
 
-public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, LevelChunk, PaperweightRegen.ChunkStatusWrap> {
-
-    private static final Logger LOGGER = LogManagerCompat.getLogger();
+public class PaperweightRegen extends Regenerator {
 
     private static final Field serverWorldsField;
     private static final Field paperConfigField;
-    private static final Field flatBedrockField;
-    private static final Field generatorSettingFlatField;
     private static final Field generatorSettingBaseSupplierField;
-    private static final Field delegateField;
-    private static final Field chunkSourceField;
-    private static final Field generatorStructureStateField;
-    private static final Field ringPositionsField;
-    private static final Field hasGeneratedPositionsField;
 
-    //list of chunk stati in correct order without FULL
-    private static final Map<ChunkStatus, Concurrency> chunkStati = new LinkedHashMap<>();
 
     static {
-        chunkStati.put(ChunkStatus.EMPTY, Concurrency.FULL);   // empty: radius -1, does nothing
-        chunkStati.put(ChunkStatus.STRUCTURE_STARTS, Concurrency.NONE);   // structure starts: uses unsynchronized maps
-        chunkStati.put(
-                ChunkStatus.STRUCTURE_REFERENCES,
-                Concurrency.FULL
-        );   // structure refs: radius 8, but only writes to current chunk
-        chunkStati.put(ChunkStatus.BIOMES, Concurrency.FULL);   // biomes: radius 0
-        chunkStati.put(ChunkStatus.NOISE, Concurrency.RADIUS); // noise: radius 8
-        chunkStati.put(ChunkStatus.SURFACE, Concurrency.NONE);   // surface: radius 0, requires NONE
-        chunkStati.put(ChunkStatus.CARVERS, Concurrency.NONE);   // carvers: radius 0, but RADIUS and FULL change results
-        /*chunkStati.put(
-                ChunkStatus.LIQUID_CARVERS,
-                Concurrency.NONE
-        );   // liquid carvers: radius 0, but RADIUS and FULL change results*/
-        chunkStati.put(ChunkStatus.FEATURES, Concurrency.NONE);   // features: uses unsynchronized maps
-        chunkStati.put(
-                ChunkStatus.LIGHT,
-                Concurrency.FULL
-        );   // light: radius 1, but no writes to other chunks, only current chunk
-        chunkStati.put(ChunkStatus.SPAWN, Concurrency.FULL);   // spawn: radius 0
-        // chunkStati.put(ChunkStatus.HEIGHTMAPS, Concurrency.FULL);   // heightmaps: radius 0
-
         try {
             serverWorldsField = CraftServer.class.getDeclaredField("worlds");
             serverWorldsField.setAccessible(true);
 
             Field tmpPaperConfigField;
-            Field tmpFlatBedrockField;
             try { //only present on paper
                 tmpPaperConfigField = Level.class.getDeclaredField("paperConfig");
                 tmpPaperConfigField.setAccessible(true);
-
-                tmpFlatBedrockField = tmpPaperConfigField.getType().getDeclaredField("generateFlatBedrock");
-                tmpFlatBedrockField.setAccessible(true);
             } catch (Exception e) {
                 tmpPaperConfigField = null;
-                tmpFlatBedrockField = null;
             }
             paperConfigField = tmpPaperConfigField;
-            flatBedrockField = tmpFlatBedrockField;
 
             generatorSettingBaseSupplierField = NoiseBasedChunkGenerator.class.getDeclaredField(Refraction.pickName(
                     "settings", "e"));
             generatorSettingBaseSupplierField.setAccessible(true);
-
-            generatorSettingFlatField = FlatLevelSource.class.getDeclaredField(Refraction.pickName("settings", "d"));
-            generatorSettingFlatField.setAccessible(true);
-
-            delegateField = CustomChunkGenerator.class.getDeclaredField("delegate");
-            delegateField.setAccessible(true);
-
-            chunkSourceField = ServerLevel.class.getDeclaredField(Refraction.pickName("chunkSource", "I"));
-            chunkSourceField.setAccessible(true);
-
-            generatorStructureStateField = ChunkMap.class.getDeclaredField(Refraction.pickName("chunkGeneratorState", "v"));
-            generatorStructureStateField.setAccessible(true);
-
-            ringPositionsField = ChunkGeneratorStructureState.class.getDeclaredField(Refraction.pickName("ringPositions", "g"));
-            ringPositionsField.setAccessible(true);
-
-            hasGeneratedPositionsField = ChunkGeneratorStructureState.class.getDeclaredField(
-                    Refraction.pickName("hasGeneratedPositions", "h")
-            );
-            hasGeneratedPositionsField.setAccessible(true);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -167,48 +79,37 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
 
     //runtime
     private ServerLevel originalServerWorld;
-    private ServerChunkCache originalChunkProvider;
     private ServerLevel freshWorld;
-    private ServerChunkCache freshChunkProvider;
     private LevelStorageSource.LevelStorageAccess session;
-    private StructureTemplateManager structureTemplateManager;
-    private ThreadedLevelLightEngine threadedLevelLightEngine;
-    private ChunkGenerator chunkGenerator;
 
     private Path tempDir;
 
-    private boolean generateFlatBedrock = false;
-
-    public PaperweightRegen(org.bukkit.World originalBukkitWorld, Region region, Extent target, RegenOptions options) {
+    public PaperweightRegen(
+            World originalBukkitWorld,
+            Region region,
+            Extent target,
+            RegenOptions options
+    ) {
         super(originalBukkitWorld, region, target, options);
     }
 
     @Override
-    protected void tickLevel(final BooleanSupplier shouldKeepTicking) {
-        this.freshWorld.tick(shouldKeepTicking);
+    protected void runTasks(final BooleanSupplier shouldKeepTicking) {
+        while (shouldKeepTicking.getAsBoolean()) {
+            if (!this.freshWorld.getChunkSource().pollTask()) {
+                return;
+            }
+        }
     }
 
     @Override
     protected boolean prepare() {
         this.originalServerWorld = ((CraftWorld) originalBukkitWorld).getHandle();
-        originalChunkProvider = originalServerWorld.getChunkSource();
-
-        //flat bedrock? (only on paper)
-        if (paperConfigField != null) {
-            try {
-                generateFlatBedrock = flatBedrockField.getBoolean(paperConfigField.get(originalServerWorld));
-            } catch (Exception ignored) {
-            }
-        }
-
         seed = options.getSeed().orElse(originalServerWorld.getSeed());
-        chunkStati.forEach((s, c) -> super.chunkStatuses.put(new ChunkStatusWrap(s), c));
-
         return true;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected boolean initNewWorld() throws Exception {
         //world folder
         tempDir = java.nio.file.Files.createTempDirectory("FastAsyncWorldEditWorldGen");
@@ -254,8 +155,10 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
                 session,
                 newWorldData,
                 originalServerWorld.dimension(),
-                DedicatedServer.getServer().registryAccess().registry(Registries.LEVEL_STEM).orElseThrow()
-                        .getOrThrow(levelStemResourceKey),
+                new LevelStem(
+                        originalServerWorld.dimensionTypeRegistration(),
+                        originalServerWorld.getChunkSource().getGenerator()
+                ),
                 new RegenNoOpWorldLoadListener(),
                 originalServerWorld.isDebug(),
                 seed,
@@ -273,17 +176,30 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
                     ) : null;
 
             @Override
-            public void tick(BooleanSupplier shouldKeepTicking) { //no ticking
-            }
-
-            @Override
-            public Holder<Biome> getUncachedNoiseBiome(int biomeX, int biomeY, int biomeZ) {
+            public @NotNull Holder<Biome> getUncachedNoiseBiome(int biomeX, int biomeY, int biomeZ) {
                 if (options.hasBiomeType()) {
                     return singleBiome;
                 }
-                return PaperweightRegen.this.chunkGenerator.getBiomeSource().getNoiseBiome(
-                        biomeX, biomeY, biomeZ, getChunkSource().randomState().sampler()
-                );
+                return super.getUncachedNoiseBiome(biomeX, biomeY, biomeZ);
+            }
+
+            @Override
+            public void save(
+                    @org.jetbrains.annotations.Nullable final ProgressListener progressListener,
+                    final boolean flush,
+                    final boolean savingDisabled
+            ) {
+                // noop, spigot
+            }
+
+            @Override
+            public void save(
+                    @Nullable final ProgressListener progressListener,
+                    final boolean flush,
+                    final boolean savingDisabled,
+                    final boolean close
+            ) {
+                // noop, paper
             }
         }).get();
         freshWorld.noSave = true;
@@ -292,89 +208,6 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         if (paperConfigField != null) {
             paperConfigField.set(freshWorld, originalServerWorld.paperConfig());
         }
-
-        ChunkGenerator originalGenerator = originalChunkProvider.getGenerator();
-        if (originalGenerator instanceof FlatLevelSource flatLevelSource) {
-            FlatLevelGeneratorSettings generatorSettingFlat = flatLevelSource.settings();
-            chunkGenerator = new FlatLevelSource(generatorSettingFlat);
-        } else if (originalGenerator instanceof NoiseBasedChunkGenerator noiseBasedChunkGenerator) {
-            Holder<NoiseGeneratorSettings> generatorSettingBaseSupplier = (Holder<NoiseGeneratorSettings>) generatorSettingBaseSupplierField.get(
-                    originalGenerator);
-            BiomeSource biomeSource;
-            if (options.hasBiomeType()) {
-
-                biomeSource = new FixedBiomeSource(
-                        DedicatedServer.getServer().registryAccess()
-                                .registryOrThrow(BIOME).asHolderIdMap().byIdOrThrow(
-                                        WorldEditPlugin.getInstance().getBukkitImplAdapter().getInternalBiomeId(options.getBiomeType())
-                                )
-                );
-            } else {
-                biomeSource = originalGenerator.getBiomeSource();
-            }
-            chunkGenerator = new NoiseBasedChunkGenerator(
-                    biomeSource,
-                    generatorSettingBaseSupplier
-            );
-        } else if (originalGenerator instanceof CustomChunkGenerator customChunkGenerator) {
-            chunkGenerator = customChunkGenerator.getDelegate();
-        } else {
-            LOGGER.error("Unsupported generator type {}", originalGenerator.getClass().getName());
-            return false;
-        }
-        if (generator != null) {
-            chunkGenerator = new CustomChunkGenerator(freshWorld, chunkGenerator, generator);
-            generateConcurrent = generator.isParallelCapable();
-        }
-//        chunkGenerator.conf = freshWorld.spigotConfig; - Does not exist anymore, may need to be re-addressed
-
-        freshChunkProvider = new ServerChunkCache(
-                freshWorld,
-                session,
-                server.getFixerUpper(),
-                server.getStructureManager(),
-                server.executor,
-                chunkGenerator,
-                freshWorld.spigotConfig.viewDistance,
-                freshWorld.spigotConfig.simulationDistance,
-                server.forceSynchronousWrites(),
-                new RegenNoOpWorldLoadListener(),
-                (chunkCoordIntPair, state) -> {
-                },
-                () -> server.overworld().getDataStorage()
-        ) {
-            // redirect to LevelChunks created in #createChunks
-            @Override
-            public ChunkAccess getChunk(int x, int z, ChunkStatus chunkstatus, boolean create) {
-                ChunkAccess chunkAccess = getChunkAt(x, z);
-                if (chunkAccess == null && create) {
-                    chunkAccess = createChunk(getProtoChunkAt(x, z));
-                }
-                return chunkAccess;
-            }
-        };
-
-        if (seed == originalOpts.seed() && !options.hasBiomeType()) {
-            // Optimisation for needless ring position calculation when the seed and biome is the same.
-            ChunkGeneratorStructureState state = (ChunkGeneratorStructureState) generatorStructureStateField.get(originalChunkProvider.chunkMap);
-            boolean hasGeneratedPositions = hasGeneratedPositionsField.getBoolean(state);
-            if (hasGeneratedPositions) {
-                Map<ConcentricRingsStructurePlacement, CompletableFuture<List<ChunkPos>>> origPositions =
-                        (Map<ConcentricRingsStructurePlacement, CompletableFuture<List<ChunkPos>>>) ringPositionsField.get(state);
-                Map<ConcentricRingsStructurePlacement, CompletableFuture<List<ChunkPos>>> copy = new Object2ObjectArrayMap<>(
-                        origPositions);
-                ChunkGeneratorStructureState newState = (ChunkGeneratorStructureState) generatorStructureStateField.get(freshChunkProvider.chunkMap);
-                ringPositionsField.set(newState, copy);
-                hasGeneratedPositionsField.setBoolean(newState, true);
-            }
-        }
-
-
-        chunkSourceField.set(freshWorld, freshChunkProvider);
-        //let's start then
-        structureTemplateManager = server.getStructureManager();
-        threadedLevelLightEngine = new NoOpLightEngine(freshChunkProvider);
-
         return true;
     }
 
@@ -389,7 +222,8 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         try {
             Fawe.instance().getQueueHandler().sync(() -> {
                 try {
-                    freshChunkProvider.close(false);
+                    freshWorld.getChunkSource().getDataStorage().cache.clear();
+                    freshWorld.getChunkSource().close(false);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -411,42 +245,19 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
     }
 
     @Override
-    protected ProtoChunk createProtoChunk(int x, int z) {
-        return new FastProtoChunk(new ChunkPos(x, z), UpgradeData.EMPTY, freshWorld,
-                this.freshWorld.registryAccess().registryOrThrow(BIOME), null
-        );
-    }
-
-    @Override
-    protected LevelChunk createChunk(ProtoChunk protoChunk) {
-        return new LevelChunk(
-                freshWorld,
-                protoChunk,
-                null // we don't want to add entities
-        );
-    }
-
-    @Override
     protected IChunkCache<IChunkGet> initSourceQueueCache() {
-        return (chunkX, chunkZ) -> new PaperweightGetBlocks(freshWorld, chunkX, chunkZ) {
-            @Override
-            public LevelChunk ensureLoaded(ServerLevel nmsWorld, int x, int z) {
-                return getChunkAt(x, z);
-            }
-        };
+        return new ChunkCache<>(BukkitAdapter.adapt(freshWorld.getWorld()));
     }
 
     //util
     @SuppressWarnings("unchecked")
     private void removeWorldFromWorldsMap() {
-        Fawe.instance().getQueueHandler().sync(() -> {
-            try {
-                Map<String, org.bukkit.World> map = (Map<String, org.bukkit.World>) serverWorldsField.get(Bukkit.getServer());
-                map.remove("faweregentempworld");
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        try {
+            Map<String, org.bukkit.World> map = (Map<String, org.bukkit.World>) serverWorldsField.get(Bukkit.getServer());
+            map.remove("faweregentempworld");
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private ResourceKey<LevelStem> getWorldDimKey(org.bukkit.World.Environment env) {
@@ -463,11 +274,15 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         }
 
         @Override
-        public void updateSpawnPos(ChunkPos spawnPos) {
+        public void updateSpawnPos(@NotNull ChunkPos spawnPos) {
         }
 
         @Override
-        public void onStatusChange(ChunkPos pos, @Nullable ChunkStatus status) {
+        public void onStatusChange(
+                final @NotNull ChunkPos pos,
+                @org.jetbrains.annotations.Nullable final ChunkStatus status
+        ) {
+
         }
 
         @Override
@@ -481,89 +296,6 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
 
         // TODO Paper only(?) @Override
         public void setChunkRadius(int radius) {
-        }
-
-    }
-
-    private class FastProtoChunk extends ProtoChunk {
-
-        public FastProtoChunk(
-                final ChunkPos pos,
-                final UpgradeData upgradeData,
-                final LevelHeightAccessor world,
-                final Registry<Biome> biomeRegistry,
-                @Nullable final BlendingData blendingData
-        ) {
-            super(pos, upgradeData, world, biomeRegistry, blendingData);
-        }
-
-        // avoid warning on paper
-
-        // compatibility with spigot
-
-        public boolean generateFlatBedrock() {
-            return generateFlatBedrock;
-        }
-
-        // no one will ever see the entities!
-        @Override
-        public List<CompoundTag> getEntities() {
-            return Collections.emptyList();
-        }
-
-    }
-
-    protected class ChunkStatusWrap extends ChunkStatusWrapper<ChunkAccess> {
-
-        private final ChunkStatus chunkStatus;
-
-        public ChunkStatusWrap(ChunkStatus chunkStatus) {
-            this.chunkStatus = chunkStatus;
-        }
-
-        @Override
-        public int requiredNeighborChunkRadius() {
-            return chunkStatus.getRange();
-        }
-
-        @Override
-        public String name() {
-            return chunkStatus.toString();
-        }
-
-        @Override
-        public CompletableFuture<?> processChunk(List<ChunkAccess> accessibleChunks) {
-            return chunkStatus.generate(
-                    Runnable::run, // TODO revisit, we might profit from this somehow?
-                    freshWorld,
-                    chunkGenerator,
-                    structureTemplateManager,
-                    threadedLevelLightEngine,
-                    c -> CompletableFuture.completedFuture(Either.left(c)),
-                    accessibleChunks
-            );
-        }
-
-    }
-
-    /**
-     * A light engine that does nothing. As light is calculated after pasting anyway, we can avoid
-     * work this way.
-     */
-    static class NoOpLightEngine extends ThreadedLevelLightEngine {
-
-        private static final ProcessorMailbox<Runnable> MAILBOX = ProcessorMailbox.create(task -> {
-        }, "fawe-no-op");
-        private static final ProcessorHandle<Message<Runnable>> HANDLE = ProcessorHandle.of("fawe-no-op", m -> {
-        });
-
-        public NoOpLightEngine(final ServerChunkCache chunkProvider) {
-            super(chunkProvider, chunkProvider.chunkMap, false, MAILBOX, HANDLE);
-        }
-
-        @Override
-        public CompletableFuture<ChunkAccess> lightChunk(final ChunkAccess chunk, final boolean excludeBlocks) {
-            return CompletableFuture.completedFuture(chunk);
         }
 
     }

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/regen/PaperweightRegen.java
@@ -4,8 +4,6 @@ import com.fastasyncworldedit.bukkit.adapter.Regenerator;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
-import com.fastasyncworldedit.core.util.ReflectionUtils;
-import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Lifecycle;
@@ -60,12 +58,10 @@ import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.PrimaryLevelData;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
 import org.bukkit.craftbukkit.v1_20_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R2.generator.CustomChunkGenerator;
 import org.bukkit.generator.BiomeProvider;
-import org.bukkit.generator.BlockPopulator;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
@@ -75,7 +71,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -424,26 +419,6 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
                 protoChunk,
                 null // we don't want to add entities
         );
-    }
-
-    @Override
-    protected ChunkStatusWrap getFullChunkStatus() {
-        return new ChunkStatusWrap(ChunkStatus.FULL);
-    }
-
-    @Override
-    protected List<BlockPopulator> getBlockPopulators() {
-        return originalServerWorld.getWorld().getPopulators();
-    }
-
-    @Override
-    protected void populate(LevelChunk levelChunk, Random random, BlockPopulator blockPopulator) {
-        // BlockPopulator#populate has to be called synchronously for TileEntity access
-        TaskManager.taskManager().task(() -> {
-            final CraftWorld world = freshWorld.getWorld();
-            final Chunk chunk = world.getChunkAt(levelChunk.locX, levelChunk.locZ);
-            blockPopulator.populate(world, random, chunk);
-        });
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/regen/PaperweightRegen.java
@@ -184,6 +184,11 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
     }
 
     @Override
+    protected void tickLevel(final BooleanSupplier shouldKeepTicking) {
+        this.freshWorld.tick(shouldKeepTicking);
+    }
+
+    @Override
     protected boolean prepare() {
         this.originalServerWorld = ((CraftWorld) originalBukkitWorld).getHandle();
         originalChunkProvider = originalServerWorld.getChunkSource();

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/regen/PaperweightRegen.java
@@ -4,7 +4,6 @@ import com.fastasyncworldedit.bukkit.adapter.Regenerator;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
-import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Lifecycle;
@@ -59,12 +58,10 @@ import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.PrimaryLevelData;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
 import org.bukkit.craftbukkit.v1_20_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R3.generator.CustomChunkGenerator;
 import org.bukkit.generator.BiomeProvider;
-import org.bukkit.generator.BlockPopulator;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
@@ -74,7 +71,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -423,26 +419,6 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
                 protoChunk,
                 null // we don't want to add entities
         );
-    }
-
-    @Override
-    protected ChunkStatusWrap getFullChunkStatus() {
-        return new ChunkStatusWrap(ChunkStatus.FULL);
-    }
-
-    @Override
-    protected List<BlockPopulator> getBlockPopulators() {
-        return originalServerWorld.getWorld().getPopulators();
-    }
-
-    @Override
-    protected void populate(LevelChunk levelChunk, Random random, BlockPopulator blockPopulator) {
-        // BlockPopulator#populate has to be called synchronously for TileEntity access
-        TaskManager.taskManager().task(() -> {
-            final CraftWorld world = freshWorld.getWorld();
-            final Chunk chunk = world.getChunkAt(levelChunk.locX, levelChunk.locZ);
-            blockPopulator.populate(world, random, chunk);
-        });
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/regen/PaperweightRegen.java
@@ -4,162 +4,74 @@ import com.fastasyncworldedit.bukkit.adapter.Regenerator;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
+import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
 import com.google.common.collect.ImmutableList;
-import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Lifecycle;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.Refraction;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3.PaperweightGetBlocks;
 import com.sk89q.worldedit.extent.Extent;
-import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.io.file.SafeFiles;
 import com.sk89q.worldedit.world.RegenOptions;
-import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
-import net.minecraft.server.level.ChunkMap;
-import net.minecraft.server.level.ChunkTaskPriorityQueueSorter.Message;
-import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ThreadedLevelLightEngine;
 import net.minecraft.server.level.progress.ChunkProgressListener;
-import net.minecraft.util.thread.ProcessorHandle;
-import net.minecraft.util.thread.ProcessorMailbox;
+import net.minecraft.util.ProgressListener;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelHeightAccessor;
 import net.minecraft.world.level.LevelSettings;
 import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeSource;
-import net.minecraft.world.level.biome.FixedBiomeSource;
-import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.ChunkGenerator;
-import net.minecraft.world.level.chunk.ChunkGeneratorStructureState;
 import net.minecraft.world.level.chunk.ChunkStatus;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.level.chunk.ProtoChunk;
-import net.minecraft.world.level.chunk.UpgradeData;
 import net.minecraft.world.level.dimension.LevelStem;
-import net.minecraft.world.level.levelgen.FlatLevelSource;
 import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
-import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.WorldOptions;
-import net.minecraft.world.level.levelgen.blending.BlendingData;
-import net.minecraft.world.level.levelgen.flat.FlatLevelGeneratorSettings;
-import net.minecraft.world.level.levelgen.structure.placement.ConcentricRingsStructurePlacement;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.PrimaryLevelData;
-import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_20_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
-import org.bukkit.craftbukkit.v1_20_R3.generator.CustomChunkGenerator;
 import org.bukkit.generator.BiomeProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 import static net.minecraft.core.registries.Registries.BIOME;
 
-public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, LevelChunk, PaperweightRegen.ChunkStatusWrap> {
-
-    private static final Logger LOGGER = LogManagerCompat.getLogger();
+public class PaperweightRegen extends Regenerator {
 
     private static final Field serverWorldsField;
     private static final Field paperConfigField;
-    private static final Field flatBedrockField;
-    private static final Field generatorSettingFlatField;
     private static final Field generatorSettingBaseSupplierField;
-    private static final Field delegateField;
-    private static final Field chunkSourceField;
-    private static final Field generatorStructureStateField;
-    private static final Field ringPositionsField;
-    private static final Field hasGeneratedPositionsField;
 
-    //list of chunk stati in correct order without FULL
-    private static final Map<ChunkStatus, Concurrency> chunkStati = new LinkedHashMap<>();
 
     static {
-        chunkStati.put(ChunkStatus.EMPTY, Concurrency.FULL);   // empty: radius -1, does nothing
-        chunkStati.put(ChunkStatus.STRUCTURE_STARTS, Concurrency.NONE);   // structure starts: uses unsynchronized maps
-        chunkStati.put(
-                ChunkStatus.STRUCTURE_REFERENCES,
-                Concurrency.FULL
-        );   // structure refs: radius 8, but only writes to current chunk
-        chunkStati.put(ChunkStatus.BIOMES, Concurrency.FULL);   // biomes: radius 0
-        chunkStati.put(ChunkStatus.NOISE, Concurrency.RADIUS); // noise: radius 8
-        chunkStati.put(ChunkStatus.SURFACE, Concurrency.NONE);   // surface: radius 0, requires NONE
-        chunkStati.put(ChunkStatus.CARVERS, Concurrency.NONE);   // carvers: radius 0, but RADIUS and FULL change results
-        /*chunkStati.put(
-                ChunkStatus.LIQUID_CARVERS,
-                Concurrency.NONE
-        );   // liquid carvers: radius 0, but RADIUS and FULL change results*/
-        chunkStati.put(ChunkStatus.FEATURES, Concurrency.NONE);   // features: uses unsynchronized maps
-        chunkStati.put(
-                ChunkStatus.LIGHT,
-                Concurrency.FULL
-        );   // light: radius 1, but no writes to other chunks, only current chunk
-        chunkStati.put(ChunkStatus.SPAWN, Concurrency.FULL);   // spawn: radius 0
-        // chunkStati.put(ChunkStatus.HEIGHTMAPS, Concurrency.FULL);   // heightmaps: radius 0
-
         try {
             serverWorldsField = CraftServer.class.getDeclaredField("worlds");
             serverWorldsField.setAccessible(true);
 
             Field tmpPaperConfigField;
-            Field tmpFlatBedrockField;
             try { //only present on paper
                 tmpPaperConfigField = Level.class.getDeclaredField("paperConfig");
                 tmpPaperConfigField.setAccessible(true);
-
-                tmpFlatBedrockField = tmpPaperConfigField.getType().getDeclaredField("generateFlatBedrock");
-                tmpFlatBedrockField.setAccessible(true);
             } catch (Exception e) {
                 tmpPaperConfigField = null;
-                tmpFlatBedrockField = null;
             }
             paperConfigField = tmpPaperConfigField;
-            flatBedrockField = tmpFlatBedrockField;
 
             generatorSettingBaseSupplierField = NoiseBasedChunkGenerator.class.getDeclaredField(Refraction.pickName(
                     "settings", "e"));
             generatorSettingBaseSupplierField.setAccessible(true);
-
-            generatorSettingFlatField = FlatLevelSource.class.getDeclaredField(Refraction.pickName("settings", "d"));
-            generatorSettingFlatField.setAccessible(true);
-
-            delegateField = CustomChunkGenerator.class.getDeclaredField("delegate");
-            delegateField.setAccessible(true);
-
-            chunkSourceField = ServerLevel.class.getDeclaredField(Refraction.pickName("chunkSource", "I"));
-            chunkSourceField.setAccessible(true);
-
-            generatorStructureStateField = ChunkMap.class.getDeclaredField(Refraction.pickName("chunkGeneratorState", "v"));
-            generatorStructureStateField.setAccessible(true);
-
-            ringPositionsField = ChunkGeneratorStructureState.class.getDeclaredField(Refraction.pickName("ringPositions", "g"));
-            ringPositionsField.setAccessible(true);
-
-            hasGeneratedPositionsField = ChunkGeneratorStructureState.class.getDeclaredField(
-                    Refraction.pickName("hasGeneratedPositions", "h")
-            );
-            hasGeneratedPositionsField.setAccessible(true);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -167,48 +79,37 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
 
     //runtime
     private ServerLevel originalServerWorld;
-    private ServerChunkCache originalChunkProvider;
     private ServerLevel freshWorld;
-    private ServerChunkCache freshChunkProvider;
     private LevelStorageSource.LevelStorageAccess session;
-    private StructureTemplateManager structureTemplateManager;
-    private ThreadedLevelLightEngine threadedLevelLightEngine;
-    private ChunkGenerator chunkGenerator;
 
     private Path tempDir;
 
-    private boolean generateFlatBedrock = false;
-
-    public PaperweightRegen(org.bukkit.World originalBukkitWorld, Region region, Extent target, RegenOptions options) {
+    public PaperweightRegen(
+            World originalBukkitWorld,
+            Region region,
+            Extent target,
+            RegenOptions options
+    ) {
         super(originalBukkitWorld, region, target, options);
     }
 
     @Override
-    protected void tickLevel(final BooleanSupplier shouldKeepTicking) {
-        this.freshWorld.tick(shouldKeepTicking);
+    protected void runTasks(final BooleanSupplier shouldKeepTicking) {
+        while (shouldKeepTicking.getAsBoolean()) {
+            if (!this.freshWorld.getChunkSource().pollTask()) {
+                return;
+            }
+        }
     }
 
     @Override
     protected boolean prepare() {
         this.originalServerWorld = ((CraftWorld) originalBukkitWorld).getHandle();
-        originalChunkProvider = originalServerWorld.getChunkSource();
-
-        //flat bedrock? (only on paper)
-        if (paperConfigField != null) {
-            try {
-                generateFlatBedrock = flatBedrockField.getBoolean(paperConfigField.get(originalServerWorld));
-            } catch (Exception ignored) {
-            }
-        }
-
         seed = options.getSeed().orElse(originalServerWorld.getSeed());
-        chunkStati.forEach((s, c) -> super.chunkStatuses.put(new ChunkStatusWrap(s), c));
-
         return true;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected boolean initNewWorld() throws Exception {
         //world folder
         tempDir = java.nio.file.Files.createTempDirectory("FastAsyncWorldEditWorldGen");
@@ -254,8 +155,10 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
                 session,
                 newWorldData,
                 originalServerWorld.dimension(),
-                DedicatedServer.getServer().registryAccess().registry(Registries.LEVEL_STEM).orElseThrow()
-                        .getOrThrow(levelStemResourceKey),
+                new LevelStem(
+                        originalServerWorld.dimensionTypeRegistration(),
+                        originalServerWorld.getChunkSource().getGenerator()
+                ),
                 new RegenNoOpWorldLoadListener(),
                 originalServerWorld.isDebug(),
                 seed,
@@ -273,17 +176,30 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
                     ) : null;
 
             @Override
-            public void tick(BooleanSupplier shouldKeepTicking) { //no ticking
-            }
-
-            @Override
-            public Holder<Biome> getUncachedNoiseBiome(int biomeX, int biomeY, int biomeZ) {
+            public @NotNull Holder<Biome> getUncachedNoiseBiome(int biomeX, int biomeY, int biomeZ) {
                 if (options.hasBiomeType()) {
                     return singleBiome;
                 }
-                return PaperweightRegen.this.chunkGenerator.getBiomeSource().getNoiseBiome(
-                        biomeX, biomeY, biomeZ, getChunkSource().randomState().sampler()
-                );
+                return super.getUncachedNoiseBiome(biomeX, biomeY, biomeZ);
+            }
+
+            @Override
+            public void save(
+                    @org.jetbrains.annotations.Nullable final ProgressListener progressListener,
+                    final boolean flush,
+                    final boolean savingDisabled
+            ) {
+                // noop, spigot
+            }
+
+            @Override
+            public void save(
+                    @Nullable final ProgressListener progressListener,
+                    final boolean flush,
+                    final boolean savingDisabled,
+                    final boolean close
+            ) {
+                // noop, paper
             }
         }).get();
         freshWorld.noSave = true;
@@ -292,89 +208,6 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         if (paperConfigField != null) {
             paperConfigField.set(freshWorld, originalServerWorld.paperConfig());
         }
-
-        ChunkGenerator originalGenerator = originalChunkProvider.getGenerator();
-        if (originalGenerator instanceof FlatLevelSource flatLevelSource) {
-            FlatLevelGeneratorSettings generatorSettingFlat = flatLevelSource.settings();
-            chunkGenerator = new FlatLevelSource(generatorSettingFlat);
-        } else if (originalGenerator instanceof NoiseBasedChunkGenerator noiseBasedChunkGenerator) {
-            Holder<NoiseGeneratorSettings> generatorSettingBaseSupplier = (Holder<NoiseGeneratorSettings>) generatorSettingBaseSupplierField.get(
-                    originalGenerator);
-            BiomeSource biomeSource;
-            if (options.hasBiomeType()) {
-
-                biomeSource = new FixedBiomeSource(
-                        DedicatedServer.getServer().registryAccess()
-                                .registryOrThrow(BIOME).asHolderIdMap().byIdOrThrow(
-                                        WorldEditPlugin.getInstance().getBukkitImplAdapter().getInternalBiomeId(options.getBiomeType())
-                                )
-                );
-            } else {
-                biomeSource = originalGenerator.getBiomeSource();
-            }
-            chunkGenerator = new NoiseBasedChunkGenerator(
-                    biomeSource,
-                    generatorSettingBaseSupplier
-            );
-        } else if (originalGenerator instanceof CustomChunkGenerator customChunkGenerator) {
-            chunkGenerator = customChunkGenerator.getDelegate();
-        } else {
-            LOGGER.error("Unsupported generator type {}", originalGenerator.getClass().getName());
-            return false;
-        }
-        if (generator != null) {
-            chunkGenerator = new CustomChunkGenerator(freshWorld, chunkGenerator, generator);
-            generateConcurrent = generator.isParallelCapable();
-        }
-//        chunkGenerator.conf = freshWorld.spigotConfig; - Does not exist anymore, may need to be re-addressed
-
-        freshChunkProvider = new ServerChunkCache(
-                freshWorld,
-                session,
-                server.getFixerUpper(),
-                server.getStructureManager(),
-                server.executor,
-                chunkGenerator,
-                freshWorld.spigotConfig.viewDistance,
-                freshWorld.spigotConfig.simulationDistance,
-                server.forceSynchronousWrites(),
-                new RegenNoOpWorldLoadListener(),
-                (chunkCoordIntPair, state) -> {
-                },
-                () -> server.overworld().getDataStorage()
-        ) {
-            // redirect to LevelChunks created in #createChunks
-            @Override
-            public ChunkAccess getChunk(int x, int z, ChunkStatus chunkstatus, boolean create) {
-                ChunkAccess chunkAccess = getChunkAt(x, z);
-                if (chunkAccess == null && create) {
-                    chunkAccess = createChunk(getProtoChunkAt(x, z));
-                }
-                return chunkAccess;
-            }
-        };
-
-        if (seed == originalOpts.seed() && !options.hasBiomeType()) {
-            // Optimisation for needless ring position calculation when the seed and biome is the same.
-            ChunkGeneratorStructureState state = (ChunkGeneratorStructureState) generatorStructureStateField.get(originalChunkProvider.chunkMap);
-            boolean hasGeneratedPositions = hasGeneratedPositionsField.getBoolean(state);
-            if (hasGeneratedPositions) {
-                Map<ConcentricRingsStructurePlacement, CompletableFuture<List<ChunkPos>>> origPositions =
-                        (Map<ConcentricRingsStructurePlacement, CompletableFuture<List<ChunkPos>>>) ringPositionsField.get(state);
-                Map<ConcentricRingsStructurePlacement, CompletableFuture<List<ChunkPos>>> copy = new Object2ObjectArrayMap<>(
-                        origPositions);
-                ChunkGeneratorStructureState newState = (ChunkGeneratorStructureState) generatorStructureStateField.get(freshChunkProvider.chunkMap);
-                ringPositionsField.set(newState, copy);
-                hasGeneratedPositionsField.setBoolean(newState, true);
-            }
-        }
-
-
-        chunkSourceField.set(freshWorld, freshChunkProvider);
-        //let's start then
-        structureTemplateManager = server.getStructureManager();
-        threadedLevelLightEngine = new NoOpLightEngine(freshChunkProvider);
-
         return true;
     }
 
@@ -389,7 +222,8 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         try {
             Fawe.instance().getQueueHandler().sync(() -> {
                 try {
-                    freshChunkProvider.close(false);
+                    freshWorld.getChunkSource().getDataStorage().cache.clear();
+                    freshWorld.getChunkSource().close(false);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -411,42 +245,19 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
     }
 
     @Override
-    protected ProtoChunk createProtoChunk(int x, int z) {
-        return new FastProtoChunk(new ChunkPos(x, z), UpgradeData.EMPTY, freshWorld,
-                this.freshWorld.registryAccess().registryOrThrow(BIOME), null
-        );
-    }
-
-    @Override
-    protected LevelChunk createChunk(ProtoChunk protoChunk) {
-        return new LevelChunk(
-                freshWorld,
-                protoChunk,
-                null // we don't want to add entities
-        );
-    }
-
-    @Override
     protected IChunkCache<IChunkGet> initSourceQueueCache() {
-        return (chunkX, chunkZ) -> new PaperweightGetBlocks(freshWorld, chunkX, chunkZ) {
-            @Override
-            public LevelChunk ensureLoaded(ServerLevel nmsWorld, int x, int z) {
-                return getChunkAt(x, z);
-            }
-        };
+        return new ChunkCache<>(BukkitAdapter.adapt(freshWorld.getWorld()));
     }
 
     //util
     @SuppressWarnings("unchecked")
     private void removeWorldFromWorldsMap() {
-        Fawe.instance().getQueueHandler().sync(() -> {
-            try {
-                Map<String, org.bukkit.World> map = (Map<String, org.bukkit.World>) serverWorldsField.get(Bukkit.getServer());
-                map.remove("faweregentempworld");
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        try {
+            Map<String, org.bukkit.World> map = (Map<String, org.bukkit.World>) serverWorldsField.get(Bukkit.getServer());
+            map.remove("faweregentempworld");
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private ResourceKey<LevelStem> getWorldDimKey(org.bukkit.World.Environment env) {
@@ -463,11 +274,15 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         }
 
         @Override
-        public void updateSpawnPos(ChunkPos spawnPos) {
+        public void updateSpawnPos(@NotNull ChunkPos spawnPos) {
         }
 
         @Override
-        public void onStatusChange(ChunkPos pos, @Nullable ChunkStatus status) {
+        public void onStatusChange(
+                final @NotNull ChunkPos pos,
+                @org.jetbrains.annotations.Nullable final ChunkStatus status
+        ) {
+
         }
 
         @Override
@@ -481,89 +296,6 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
 
         // TODO Paper only(?) @Override
         public void setChunkRadius(int radius) {
-        }
-
-    }
-
-    private class FastProtoChunk extends ProtoChunk {
-
-        public FastProtoChunk(
-                final ChunkPos pos,
-                final UpgradeData upgradeData,
-                final LevelHeightAccessor world,
-                final Registry<Biome> biomeRegistry,
-                @Nullable final BlendingData blendingData
-        ) {
-            super(pos, upgradeData, world, biomeRegistry, blendingData);
-        }
-
-        // avoid warning on paper
-
-        // compatibility with spigot
-
-        public boolean generateFlatBedrock() {
-            return generateFlatBedrock;
-        }
-
-        // no one will ever see the entities!
-        @Override
-        public List<CompoundTag> getEntities() {
-            return Collections.emptyList();
-        }
-
-    }
-
-    protected class ChunkStatusWrap extends ChunkStatusWrapper<ChunkAccess> {
-
-        private final ChunkStatus chunkStatus;
-
-        public ChunkStatusWrap(ChunkStatus chunkStatus) {
-            this.chunkStatus = chunkStatus;
-        }
-
-        @Override
-        public int requiredNeighborChunkRadius() {
-            return chunkStatus.getRange();
-        }
-
-        @Override
-        public String name() {
-            return chunkStatus.toString();
-        }
-
-        @Override
-        public CompletableFuture<?> processChunk(List<ChunkAccess> accessibleChunks) {
-            return chunkStatus.generate(
-                    Runnable::run, // TODO revisit, we might profit from this somehow?
-                    freshWorld,
-                    chunkGenerator,
-                    structureTemplateManager,
-                    threadedLevelLightEngine,
-                    c -> CompletableFuture.completedFuture(Either.left(c)),
-                    accessibleChunks
-            );
-        }
-
-    }
-
-    /**
-     * A light engine that does nothing. As light is calculated after pasting anyway, we can avoid
-     * work this way.
-     */
-    static class NoOpLightEngine extends ThreadedLevelLightEngine {
-
-        private static final ProcessorMailbox<Runnable> MAILBOX = ProcessorMailbox.create(task -> {
-        }, "fawe-no-op");
-        private static final ProcessorHandle<Message<Runnable>> HANDLE = ProcessorHandle.of("fawe-no-op", m -> {
-        });
-
-        public NoOpLightEngine(final ServerChunkCache chunkProvider) {
-            super(chunkProvider, chunkProvider.chunkMap, false, MAILBOX, HANDLE);
-        }
-
-        @Override
-        public CompletableFuture<ChunkAccess> lightChunk(final ChunkAccess chunk, final boolean excludeBlocks) {
-            return CompletableFuture.completedFuture(chunk);
         }
 
     }

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/regen/PaperweightRegen.java
@@ -185,6 +185,11 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
     }
 
     @Override
+    protected void tickLevel(final BooleanSupplier shouldKeepTicking) {
+        this.freshWorld.tick(shouldKeepTicking);
+    }
+
+    @Override
     protected boolean prepare() {
         this.originalServerWorld = ((CraftWorld) originalBukkitWorld).getHandle();
         originalChunkProvider = originalServerWorld.getChunkSource();

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/regen/PaperweightRegen.java
@@ -4,7 +4,6 @@ import com.fastasyncworldedit.bukkit.adapter.Regenerator;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
-import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Lifecycle;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
@@ -59,12 +58,10 @@ import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.PrimaryLevelData;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.generator.CustomChunkGenerator;
 import org.bukkit.generator.BiomeProvider;
-import org.bukkit.generator.BlockPopulator;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -75,7 +72,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -429,26 +425,6 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
                 protoChunk,
                 null // we don't want to add entities
         );
-    }
-
-    @Override
-    protected ChunkStatusWrap getFullChunkStatus() {
-        return new ChunkStatusWrap(ChunkStatus.FULL);
-    }
-
-    @Override
-    protected List<BlockPopulator> getBlockPopulators() {
-        return originalServerWorld.getWorld().getPopulators();
-    }
-
-    @Override
-    protected void populate(LevelChunk levelChunk, Random random, BlockPopulator blockPopulator) {
-        // BlockPopulator#populate has to be called synchronously for TileEntity access
-        TaskManager.taskManager().task(() -> {
-            final CraftWorld world = freshWorld.getWorld();
-            final Chunk chunk = world.getChunkAt(levelChunk.locX, levelChunk.locZ);
-            blockPopulator.populate(world, random, chunk);
-        });
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/regen/PaperweightRegen.java
@@ -4,162 +4,73 @@ import com.fastasyncworldedit.bukkit.adapter.Regenerator;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
+import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Lifecycle;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.Refraction;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R4.PaperweightGetBlocks;
 import com.sk89q.worldedit.extent.Extent;
-import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.util.io.file.SafeFiles;
 import com.sk89q.worldedit.world.RegenOptions;
-import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
-import net.minecraft.server.level.ChunkMap;
-import net.minecraft.server.level.ChunkTaskPriorityQueueSorter.Message;
-import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ThreadedLevelLightEngine;
 import net.minecraft.server.level.progress.ChunkProgressListener;
-import net.minecraft.util.thread.ProcessorHandle;
-import net.minecraft.util.thread.ProcessorMailbox;
+import net.minecraft.util.ProgressListener;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelHeightAccessor;
 import net.minecraft.world.level.LevelSettings;
 import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeSource;
-import net.minecraft.world.level.biome.FixedBiomeSource;
-import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.ChunkGenerator;
-import net.minecraft.world.level.chunk.ChunkGeneratorStructureState;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.level.chunk.ProtoChunk;
-import net.minecraft.world.level.chunk.UpgradeData;
-import net.minecraft.world.level.chunk.status.ChunkStatus;
-import net.minecraft.world.level.chunk.status.WorldGenContext;
 import net.minecraft.world.level.dimension.LevelStem;
-import net.minecraft.world.level.levelgen.FlatLevelSource;
 import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
-import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.WorldOptions;
-import net.minecraft.world.level.levelgen.blending.BlendingData;
-import net.minecraft.world.level.levelgen.flat.FlatLevelGeneratorSettings;
-import net.minecraft.world.level.levelgen.structure.placement.ConcentricRingsStructurePlacement;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.PrimaryLevelData;
-import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
-import org.bukkit.craftbukkit.generator.CustomChunkGenerator;
 import org.bukkit.generator.BiomeProvider;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 import static net.minecraft.core.registries.Registries.BIOME;
 
-public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, LevelChunk, PaperweightRegen.ChunkStatusWrap> {
-
-    private static final Logger LOGGER = LogManagerCompat.getLogger();
+public class PaperweightRegen extends Regenerator {
 
     private static final Field serverWorldsField;
     private static final Field paperConfigField;
-    private static final Field flatBedrockField;
-    private static final Field generatorSettingFlatField;
     private static final Field generatorSettingBaseSupplierField;
-    private static final Field delegateField;
-    private static final Field chunkSourceField;
-    private static final Field generatorStructureStateField;
-    private static final Field ringPositionsField;
-    private static final Field hasGeneratedPositionsField;
 
-    //list of chunk stati in correct order without FULL
-    private static final Map<ChunkStatus, Concurrency> chunkStati = new LinkedHashMap<>();
 
     static {
-        chunkStati.put(ChunkStatus.EMPTY, Concurrency.FULL);   // empty: radius -1, does nothing
-        chunkStati.put(ChunkStatus.STRUCTURE_STARTS, Concurrency.NONE);   // structure starts: uses unsynchronized maps
-        chunkStati.put(
-                ChunkStatus.STRUCTURE_REFERENCES,
-                Concurrency.NONE
-        );   // structure refs: radius 8, but only writes to current chunk
-        chunkStati.put(ChunkStatus.BIOMES, Concurrency.NONE);   // biomes: radius 0
-        chunkStati.put(ChunkStatus.NOISE, Concurrency.RADIUS); // noise: radius 8
-        chunkStati.put(ChunkStatus.SURFACE, Concurrency.NONE);   // surface: radius 0, requires NONE
-        chunkStati.put(ChunkStatus.CARVERS, Concurrency.NONE);   // carvers: radius 0, but RADIUS and FULL change results
-        chunkStati.put(ChunkStatus.FEATURES, Concurrency.NONE);   // features: uses unsynchronized maps
-        chunkStati.put(
-                ChunkStatus.INITIALIZE_LIGHT,
-                Concurrency.FULL
-        ); // initialize_light: radius 0
-        chunkStati.put(
-                ChunkStatus.LIGHT,
-                Concurrency.FULL
-        );   // light: radius 1, but no writes to other chunks, only current chunk
-        chunkStati.put(ChunkStatus.SPAWN, Concurrency.NONE);   // spawn: radius 0
-
         try {
             serverWorldsField = CraftServer.class.getDeclaredField("worlds");
             serverWorldsField.setAccessible(true);
 
             Field tmpPaperConfigField;
-            Field tmpFlatBedrockField;
             try { //only present on paper
                 tmpPaperConfigField = Level.class.getDeclaredField("paperConfig");
                 tmpPaperConfigField.setAccessible(true);
-
-                tmpFlatBedrockField = tmpPaperConfigField.getType().getDeclaredField("generateFlatBedrock");
-                tmpFlatBedrockField.setAccessible(true);
             } catch (Exception e) {
                 tmpPaperConfigField = null;
-                tmpFlatBedrockField = null;
             }
             paperConfigField = tmpPaperConfigField;
-            flatBedrockField = tmpFlatBedrockField;
 
             generatorSettingBaseSupplierField = NoiseBasedChunkGenerator.class.getDeclaredField(Refraction.pickName(
                     "settings", "e"));
             generatorSettingBaseSupplierField.setAccessible(true);
-
-            generatorSettingFlatField = FlatLevelSource.class.getDeclaredField(Refraction.pickName("settings", "d"));
-            generatorSettingFlatField.setAccessible(true);
-
-            delegateField = CustomChunkGenerator.class.getDeclaredField("delegate");
-            delegateField.setAccessible(true);
-
-            chunkSourceField = ServerLevel.class.getDeclaredField(Refraction.pickName("chunkSource", "I"));
-            chunkSourceField.setAccessible(true);
-
-            generatorStructureStateField = ChunkMap.class.getDeclaredField(Refraction.pickName("chunkGeneratorState", "v"));
-            generatorStructureStateField.setAccessible(true);
-
-            ringPositionsField = ChunkGeneratorStructureState.class.getDeclaredField(Refraction.pickName("ringPositions", "g"));
-            ringPositionsField.setAccessible(true);
-
-            hasGeneratedPositionsField = ChunkGeneratorStructureState.class.getDeclaredField(
-                    Refraction.pickName("hasGeneratedPositions", "h")
-            );
-            hasGeneratedPositionsField.setAccessible(true);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -167,49 +78,37 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
 
     //runtime
     private ServerLevel originalServerWorld;
-    private ServerChunkCache originalChunkProvider;
     private ServerLevel freshWorld;
-    private ServerChunkCache freshChunkProvider;
     private LevelStorageSource.LevelStorageAccess session;
-    private StructureTemplateManager structureTemplateManager;
-    private ThreadedLevelLightEngine threadedLevelLightEngine;
-    private ChunkGenerator chunkGenerator;
-    private WorldGenContext worldGenContext;
 
     private Path tempDir;
 
-    private boolean generateFlatBedrock = false;
-
-    public PaperweightRegen(org.bukkit.World originalBukkitWorld, Region region, Extent target, RegenOptions options) {
+    public PaperweightRegen(
+            World originalBukkitWorld,
+            Region region,
+            Extent target,
+            RegenOptions options
+    ) {
         super(originalBukkitWorld, region, target, options);
     }
 
     @Override
-    protected void tickLevel(final BooleanSupplier shouldKeepTicking) {
-        this.freshWorld.tick(shouldKeepTicking);
+    protected void runTasks(final BooleanSupplier shouldKeepTicking) {
+        while (shouldKeepTicking.getAsBoolean()) {
+            if (!this.freshWorld.getChunkSource().pollTask()) {
+                return;
+            }
+        }
     }
 
     @Override
     protected boolean prepare() {
         this.originalServerWorld = ((CraftWorld) originalBukkitWorld).getHandle();
-        originalChunkProvider = originalServerWorld.getChunkSource();
-
-        //flat bedrock? (only on paper)
-        if (paperConfigField != null) {
-            try {
-                generateFlatBedrock = flatBedrockField.getBoolean(paperConfigField.get(originalServerWorld));
-            } catch (Exception ignored) {
-            }
-        }
-
         seed = options.getSeed().orElse(originalServerWorld.getSeed());
-        chunkStati.forEach((s, c) -> super.chunkStatuses.put(new ChunkStatusWrap(s), c));
-
         return true;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected boolean initNewWorld() throws Exception {
         //world folder
         tempDir = java.nio.file.Files.createTempDirectory("FastAsyncWorldEditWorldGen");
@@ -255,8 +154,10 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
                 session,
                 newWorldData,
                 originalServerWorld.dimension(),
-                DedicatedServer.getServer().registryAccess().registry(Registries.LEVEL_STEM).orElseThrow()
-                        .getOrThrow(levelStemResourceKey),
+                new LevelStem(
+                        originalServerWorld.dimensionTypeRegistration(),
+                        originalServerWorld.getChunkSource().getGenerator()
+                ),
                 new RegenNoOpWorldLoadListener(),
                 originalServerWorld.isDebug(),
                 seed,
@@ -274,19 +175,31 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
                     ) : null;
 
             @Override
-            public void tick(@NotNull BooleanSupplier shouldKeepTicking) { //no ticking
-            }
-
-            @Override
             public @NotNull Holder<Biome> getUncachedNoiseBiome(int biomeX, int biomeY, int biomeZ) {
                 if (options.hasBiomeType()) {
                     return singleBiome;
                 }
-                return PaperweightRegen.this.chunkGenerator.getBiomeSource().getNoiseBiome(
-                        biomeX, biomeY, biomeZ, getChunkSource().randomState().sampler()
-                );
+                return super.getUncachedNoiseBiome(biomeX, biomeY, biomeZ);
             }
 
+            @Override
+            public void save(
+                    @org.jetbrains.annotations.Nullable final ProgressListener progressListener,
+                    final boolean flush,
+                    final boolean savingDisabled
+            ) {
+                // noop, spigot
+            }
+
+            @Override
+            public void save(
+                    @Nullable final ProgressListener progressListener,
+                    final boolean flush,
+                    final boolean savingDisabled,
+                    final boolean close
+            ) {
+                // noop, paper
+            }
         }).get();
         freshWorld.noSave = true;
         removeWorldFromWorldsMap();
@@ -294,93 +207,6 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         if (paperConfigField != null) {
             paperConfigField.set(freshWorld, originalServerWorld.paperConfig());
         }
-
-        ChunkGenerator originalGenerator = originalChunkProvider.getGenerator();
-        if (originalGenerator instanceof FlatLevelSource flatLevelSource) {
-            FlatLevelGeneratorSettings generatorSettingFlat = flatLevelSource.settings();
-            chunkGenerator = new FlatLevelSource(generatorSettingFlat);
-        } else if (originalGenerator instanceof NoiseBasedChunkGenerator noiseBasedChunkGenerator) {
-            Holder<NoiseGeneratorSettings> generatorSettingBaseSupplier = (Holder<NoiseGeneratorSettings>)
-                    generatorSettingBaseSupplierField.get(noiseBasedChunkGenerator);
-            BiomeSource biomeSource;
-            if (options.hasBiomeType()) {
-                biomeSource = new FixedBiomeSource(
-                        DedicatedServer.getServer().registryAccess()
-                                .registryOrThrow(BIOME).asHolderIdMap().byIdOrThrow(
-                                        WorldEditPlugin.getInstance().getBukkitImplAdapter().getInternalBiomeId(options.getBiomeType())
-                                )
-                );
-            } else {
-                biomeSource = originalGenerator.getBiomeSource();
-            }
-            chunkGenerator = new NoiseBasedChunkGenerator(
-                    biomeSource,
-                    generatorSettingBaseSupplier
-            );
-        } else if (originalGenerator instanceof CustomChunkGenerator customChunkGenerator) {
-            chunkGenerator = customChunkGenerator.getDelegate();
-        } else {
-            LOGGER.error("Unsupported generator type {}", originalGenerator.getClass().getName());
-            return false;
-        }
-        if (generator != null) {
-            chunkGenerator = new CustomChunkGenerator(freshWorld, chunkGenerator, generator);
-            generateConcurrent = generator.isParallelCapable();
-        }
-//        chunkGenerator.conf = freshWorld.spigotConfig; - Does not exist anymore, may need to be re-addressed
-
-        freshChunkProvider = new ServerChunkCache(
-                freshWorld,
-                session,
-                server.getFixerUpper(),
-                server.getStructureManager(),
-                server.executor,
-                chunkGenerator,
-                freshWorld.spigotConfig.viewDistance,
-                freshWorld.spigotConfig.simulationDistance,
-                server.forceSynchronousWrites(),
-                new RegenNoOpWorldLoadListener(),
-                (chunkCoordIntPair, state) -> {
-                },
-                () -> server.overworld().getDataStorage()
-        ) {
-            // redirect to LevelChunks created in #createChunks
-            @Override
-            public ChunkAccess getChunk(int x, int z, @NotNull ChunkStatus chunkstatus, boolean create) {
-                ChunkAccess chunkAccess = getChunkAt(x, z);
-                if (chunkAccess == null && create) {
-                    chunkAccess = createChunk(getProtoChunkAt(x, z));
-                }
-                return chunkAccess;
-            }
-        };
-
-        if (seed == originalOpts.seed() && !options.hasBiomeType()) {
-            // Optimisation for needless ring position calculation when the seed and biome is the same.
-            ChunkGeneratorStructureState state = (ChunkGeneratorStructureState) generatorStructureStateField.get(
-                    originalChunkProvider.chunkMap);
-            boolean hasGeneratedPositions = hasGeneratedPositionsField.getBoolean(state);
-            if (hasGeneratedPositions) {
-                Map<ConcentricRingsStructurePlacement, CompletableFuture<List<ChunkPos>>> origPositions =
-                        (Map<ConcentricRingsStructurePlacement, CompletableFuture<List<ChunkPos>>>) ringPositionsField.get(state);
-                Map<ConcentricRingsStructurePlacement, CompletableFuture<List<ChunkPos>>> copy = new Object2ObjectArrayMap<>(
-                        origPositions);
-                ChunkGeneratorStructureState newState = (ChunkGeneratorStructureState) generatorStructureStateField.get(
-                        freshChunkProvider.chunkMap);
-                ringPositionsField.set(newState, copy);
-                hasGeneratedPositionsField.setBoolean(newState, true);
-            }
-        }
-
-
-        chunkSourceField.set(freshWorld, freshChunkProvider);
-        //let's start then
-        structureTemplateManager = server.getStructureManager();
-        threadedLevelLightEngine = new NoOpLightEngine(freshChunkProvider);
-
-        this.worldGenContext = new WorldGenContext(freshWorld, chunkGenerator, structureTemplateManager,
-                threadedLevelLightEngine
-        );
         return true;
     }
 
@@ -395,7 +221,8 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
         try {
             Fawe.instance().getQueueHandler().sync(() -> {
                 try {
-                    freshChunkProvider.close(false);
+                    freshWorld.getChunkSource().getDataStorage().cache.clear();
+                    freshWorld.getChunkSource().close(false);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -417,29 +244,8 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
     }
 
     @Override
-    protected ProtoChunk createProtoChunk(int x, int z) {
-        return new FastProtoChunk(new ChunkPos(x, z), UpgradeData.EMPTY, freshWorld,
-                this.freshWorld.registryAccess().registryOrThrow(BIOME), null
-        );
-    }
-
-    @Override
-    protected LevelChunk createChunk(ProtoChunk protoChunk) {
-        return new LevelChunk(
-                freshWorld,
-                protoChunk,
-                null // we don't want to add entities
-        );
-    }
-
-    @Override
     protected IChunkCache<IChunkGet> initSourceQueueCache() {
-        return (chunkX, chunkZ) -> new PaperweightGetBlocks(freshWorld, chunkX, chunkZ) {
-            @Override
-            public LevelChunk ensureLoaded(ServerLevel nmsWorld, int x, int z) {
-                return getChunkAt(x, z);
-            }
-        };
+        return new ChunkCache<>(BukkitAdapter.adapt(freshWorld.getWorld()));
     }
 
     //util
@@ -489,85 +295,6 @@ public class PaperweightRegen extends Regenerator<ChunkAccess, ProtoChunk, Level
 
         // TODO Paper only(?) @Override
         public void setChunkRadius(int radius) {
-        }
-
-    }
-
-    private class FastProtoChunk extends ProtoChunk {
-
-        public FastProtoChunk(
-                final ChunkPos pos,
-                final UpgradeData upgradeData,
-                final LevelHeightAccessor world,
-                final Registry<Biome> biomeRegistry,
-                @Nullable final BlendingData blendingData
-        ) {
-            super(pos, upgradeData, world, biomeRegistry, blendingData);
-        }
-
-        // avoid warning on paper
-
-        @SuppressWarnings("unused") // compatibility with spigot
-        public boolean generateFlatBedrock() {
-            return generateFlatBedrock;
-        }
-
-        // no one will ever see the entities!
-        @Override
-        public @NotNull List<CompoundTag> getEntities() {
-            return Collections.emptyList();
-        }
-
-    }
-
-    protected class ChunkStatusWrap extends ChunkStatusWrapper<ChunkAccess> {
-
-        private final ChunkStatus chunkStatus;
-
-        public ChunkStatusWrap(ChunkStatus chunkStatus) {
-            this.chunkStatus = chunkStatus;
-        }
-
-        @Override
-        public int requiredNeighborChunkRadius() {
-            return chunkStatus.getRange();
-        }
-
-        @Override
-        public String name() {
-            return chunkStatus.toString();
-        }
-
-        @Override
-        public CompletableFuture<?> processChunk(List<ChunkAccess> accessibleChunks) {
-            return chunkStatus.generate(
-                    worldGenContext,
-                    Runnable::run,
-                    CompletableFuture::completedFuture,
-                    accessibleChunks
-            );
-        }
-
-    }
-
-    /**
-     * A light engine that does nothing. As light is calculated after pasting anyway, we can avoid
-     * work this way.
-     */
-    static class NoOpLightEngine extends ThreadedLevelLightEngine {
-
-        private static final ProcessorMailbox<Runnable> MAILBOX = ProcessorMailbox.create(task -> {
-        }, "fawe-no-op");
-        private static final ProcessorHandle<Message<Runnable>> HANDLE = ProcessorHandle.of("fawe-no-op", m -> {
-        });
-
-        public NoOpLightEngine(final ServerChunkCache chunkProvider) {
-            super(chunkProvider, chunkProvider.chunkMap, false, MAILBOX, HANDLE);
-        }
-
-        @Override
-        public @NotNull CompletableFuture<ChunkAccess> lightChunk(final @NotNull ChunkAccess chunk, final boolean excludeBlocks) {
-            return CompletableFuture.completedFuture(chunk);
         }
 
     }

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_R1/PaperweightAdapter.java
@@ -854,7 +854,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
     }
 
     @SuppressWarnings("unchecked")
-    public List<CompletableFuture<ChunkAccess>> submitChunkLoadTasks(Region region, ServerLevel serverWorld) {
+    private List<CompletableFuture<ChunkAccess>> submitChunkLoadTasks(Region region, ServerLevel serverWorld) {
         ServerChunkCache chunkManager = serverWorld.getChunkSource();
         List<CompletableFuture<ChunkAccess>> chunkLoadings = new ArrayList<>();
         // Pre-gen all the chunks

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_R1/PaperweightAdapter.java
@@ -854,7 +854,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
     }
 
     @SuppressWarnings("unchecked")
-    private List<CompletableFuture<ChunkAccess>> submitChunkLoadTasks(Region region, ServerLevel serverWorld) {
+    public List<CompletableFuture<ChunkAccess>> submitChunkLoadTasks(Region region, ServerLevel serverWorld) {
         ServerChunkCache chunkManager = serverWorld.getChunkSource();
         List<CompletableFuture<ChunkAccess>> chunkLoadings = new ArrayList<>();
         // Pre-gen all the chunks

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -558,7 +558,7 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     public boolean regenerate(org.bukkit.World bukkitWorld, Region region, Extent target, RegenOptions options) throws Exception {
-        return new PaperweightRegen(bukkitWorld, region, target, options, this.parent).regenerate();
+        return new PaperweightRegen(bukkitWorld, region, target, options).regenerate();
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -18,6 +18,7 @@ import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1.nbt.PaperweightLazyCompoundTag;
+import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1.regen.PaperweightRegen;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.internal.block.BlockStateIdAccess;
@@ -557,7 +558,7 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     public boolean regenerate(org.bukkit.World bukkitWorld, Region region, Extent target, RegenOptions options) throws Exception {
-        throw new UnsupportedOperationException("Regen support for 1.21 not yet implemented.");
+        return new PaperweightRegen(bukkitWorld, region, target, options, this.parent).regenerate();
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/Regenerator.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/Regenerator.java
@@ -3,46 +3,30 @@ package com.fastasyncworldedit.bukkit.adapter;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.SingleThreadQueueExtent;
-import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.pattern.Pattern;
-import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.RegenOptions;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
-import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-import org.apache.logging.log4j.Logger;
 import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.WorldInfo;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
 /**
  * Represents an abstract regeneration handler.
- *
- * @param <IChunkAccess> the type of the {@code IChunkAccess} of the current Minecraft implementation
- * @param <ProtoChunk>   the type of the {@code ProtoChunk} of the current Minecraft implementation
- * @param <Chunk>        the type of the {@code Chunk} of the current Minecraft implementation
- * @param <ChunkStatus>  the type of the {@code ChunkStatusWrapper} wrapping the {@code ChunkStatus} enum
  */
-public abstract class Regenerator<IChunkAccess, ProtoChunk extends IChunkAccess, Chunk extends IChunkAccess, ChunkStatus> {
-
-    private static final Logger LOGGER = LogManagerCompat.getLogger();
+public abstract class Regenerator {
 
     protected final org.bukkit.World originalBukkitWorld;
     protected final Region region;
@@ -50,10 +34,6 @@ public abstract class Regenerator<IChunkAccess, ProtoChunk extends IChunkAccess,
     protected final RegenOptions options;
 
     //runtime
-    protected final LinkedHashMap<ChunkStatus, Concurrency> chunkStatuses = new LinkedHashMap<>(); // TODO (j21): use SequencedMap
-    private final Long2ObjectLinkedOpenHashMap<ProtoChunk> protoChunks = new Long2ObjectLinkedOpenHashMap<>();
-    private final Long2ObjectOpenHashMap<Chunk> chunks = new Long2ObjectOpenHashMap<>();
-    protected boolean generateConcurrent = true;
     protected long seed;
     protected SingleThreadQueueExtent source;
 
@@ -104,29 +84,10 @@ public abstract class Regenerator<IChunkAccess, ProtoChunk extends IChunkAccess,
         return true;
     }
 
-    protected abstract void tickLevel(BooleanSupplier shouldKeepTicking);
-
     /**
-     * Returns the {@code ProtoChunk} at the given chunk coordinates.
-     *
-     * @param x the chunk x coordinate
-     * @param z the chunk z coordinate
-     * @return the {@code ProtoChunk} at the given chunk coordinates or null if it is not part of the regeneration process or has not been initialized yet.
+     * Execute tasks on the main thread during regen.
      */
-    protected ProtoChunk getProtoChunkAt(int x, int z) {
-        return protoChunks.get(MathMan.pairInt(x, z));
-    }
-
-    /**
-     * Returns the {@code Chunk} at the given chunk coordinates.
-     *
-     * @param x the chunk x coordinate
-     * @param z the chunk z coordinate
-     * @return the {@code Chunk} at the given chunk coordinates or null if it is not part of the regeneration process or has not been converted yet.
-     */
-    protected Chunk getChunkAt(int x, int z) {
-        return chunks.get(MathMan.pairInt(x, z));
-    }
+    protected abstract void runTasks(BooleanSupplier shouldKeepTicking);
 
     private void createSource() {
 
@@ -142,7 +103,7 @@ public abstract class Regenerator<IChunkAccess, ProtoChunk extends IChunkAccess,
         final long timeoutPerTick = TimeUnit.MILLISECONDS.toNanos(10);
         int taskId = TaskManager.taskManager().repeat(() -> {
             final long startTime = System.nanoTime();
-            tickLevel(() -> System.nanoTime() - startTime < timeoutPerTick);
+            runTasks(() -> System.nanoTime() - startTime < timeoutPerTick);
         }, 1);
         //Setting Blocks
         boolean genbiomes = options.shouldRegenBiomes();
@@ -228,23 +189,6 @@ public abstract class Regenerator<IChunkAccess, ProtoChunk extends IChunkAccess,
     protected abstract void cleanup();
 
     /**
-     * Implement the initialization of a {@code ProtoChunk} here.
-     *
-     * @param x the x coorinate of the {@code ProtoChunk} to create
-     * @param z the z coorinate of the {@code ProtoChunk} to create
-     * @return an initialized {@code ProtoChunk}
-     */
-    protected abstract ProtoChunk createProtoChunk(int x, int z);
-
-    /**
-     * Implement the convertion of a {@code ProtoChunk} to a {@code Chunk} here.
-     *
-     * @param protoChunk the {@code ProtoChunk} to be converted to a {@code Chunk}
-     * @return the converted {@code Chunk}
-     */
-    protected abstract Chunk createChunk(ProtoChunk protoChunk);
-
-    /**
      * Implement the initialization an {@code IChunkCache<IChunkGet>} here. Use will need the {@code getChunkAt} function
      *
      * @return an initialized {@code IChunkCache<IChunkGet>}
@@ -264,103 +208,6 @@ public abstract class Regenerator<IChunkAccess, ProtoChunk extends IChunkAccess,
         FULL,
         RADIUS,
         NONE
-    }
-
-    /**
-     * This class is used to wrap the ChunkStatus of the current Minecraft implementation and as the implementation to execute a chunk generation step.
-     *
-     * @param <IChunkAccess> the IChunkAccess class of the current Minecraft implementation
-     */
-    public static abstract class ChunkStatusWrapper<IChunkAccess> {
-
-        /**
-         * Return the required neighbor chunk radius the wrapped {@code ChunkStatus} requires.
-         *
-         * @return the radius of required neighbor chunks
-         */
-        public abstract int requiredNeighborChunkRadius();
-
-        int requiredNeighborChunkRadius0() {
-            return Math.max(0, requiredNeighborChunkRadius());
-        }
-
-        /**
-         * Return the name of the wrapped {@code ChunkStatus}.
-         *
-         * @return the radius of required neighbor chunks
-         */
-        public abstract String name();
-
-        /**
-         * Return the name of the wrapped {@code ChunkStatus}.
-         *
-         * @param accessibleChunks a list of chunks that will be used during the execution of the wrapped {@code ChunkStatus}.
-         *                         This list is order in the correct order required by the {@code ChunkStatus}, unless Mojang suddenly decides to do things differently.
-         */
-        public abstract CompletableFuture<?> processChunk(List<IChunkAccess> accessibleChunks);
-
-        void processChunkSave(long xz, List<IChunkAccess> accessibleChunks) {
-            try {
-                processChunk(accessibleChunks).get();
-            } catch (Exception e) {
-                LOGGER.error("Error while running {} on chunk {}/{}",
-                        name(), MathMan.unpairIntX(xz), MathMan.unpairIntY(xz), e);
-            }
-        }
-
-        @Override
-        public String toString() {
-            return name();
-        }
-
-    }
-
-    public static class SequentialTasks<T> extends Tasks<T> {
-
-        public SequentialTasks(int expectedSize) {
-            super(expectedSize);
-        }
-
-    }
-
-    public static class ConcurrentTasks<T> extends Tasks<T> {
-
-        public ConcurrentTasks(int expectedSize) {
-            super(expectedSize);
-        }
-
-    }
-
-    public static class Tasks<T> implements Iterable<T> {
-
-        private final List<T> tasks;
-
-        public Tasks(int expectedSize) {
-            tasks = new ArrayList<>(expectedSize);
-        }
-
-        public void add(T task) {
-            tasks.add(task);
-        }
-
-        public List<T> list() {
-            return tasks;
-        }
-
-        public int size() {
-            return tasks.size();
-        }
-
-        @Override
-        public Iterator<T> iterator() {
-            return tasks.iterator();
-        }
-
-        @Override
-        public String toString() {
-            return tasks.toString();
-        }
-
     }
 
     public class SingleBiomeProvider extends BiomeProvider {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2818
Fixes #2861

## Description
<!-- Please describe what this pull request does. -->

We can greatly simplify the regeneration logic by relying on the server's chunk system instead of trying to run the generation ourselves. This works well on Paper, and probably good enough on Spigot. Conceptually, the change is similar to how a `//lazycopy` would work, just with the temporary world as a source. I think this is far better in terms of maintainability.

Tested on Paper 1.21(.1), only, but the code should work on older versions too and as there isn't much low-level implementation details, I also expect Spigot to work.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
