### PR TITLE
Avoid deprecated CompoundTag in API

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightBlockMaterial.java
@@ -14,7 +14,8 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.craftbukkit.v1_20_R2.block.data.CraftBlockData;
-import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nullable;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
 

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightBlockMaterial.java
@@ -1,10 +1,8 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2;
 
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.util.ReflectionUtil;
 import com.sk89q.worldedit.bukkit.adapter.Refraction;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -16,6 +14,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.craftbukkit.v1_20_R2.block.data.CraftBlockData;
+import org.jetbrains.annotations.Nullable;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
 
@@ -25,7 +24,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     private final CraftBlockData craftBlockData;
     private final org.bukkit.Material craftMaterial;
     private final int opacity;
-    private final CompoundTag tile;
+    private final FaweCompoundTag tile;
 
     public PaperweightBlockMaterial(Block block) {
         this(block, block.defaultBlockState());
@@ -48,7 +47,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         );
         tile = tileEntity == null
                 ? null
-                : new PaperweightLazyCompoundTag(Suppliers.memoize(tileEntity::saveWithId));
+                : PaperweightGetBlocks.NMS_TO_TILE.apply(tileEntity);
     }
 
     public Block getBlock() {
@@ -173,7 +172,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public CompoundTag getDefaultTile() {
+    public @Nullable FaweCompoundTag defaultTile() {
         return tile;
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.bukkit.adapter.NMSRelighterFactory;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.entity.LazyBaseEntity;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
@@ -97,6 +98,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -127,6 +129,12 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public PaperweightFaweAdapter() throws NoSuchFieldException, NoSuchMethodException {
         this.parent = new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R2.PaperweightAdapter();
+    }
+
+    public Function<BlockEntity, FaweCompoundTag> blockEntityToCompoundTag() {
+        return blockEntity -> FaweCompoundTag.of(
+                () -> (LinCompoundTag) toNativeLin(blockEntity.saveWithId())
+        );
     }
 
     @Nullable

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -7,20 +7,16 @@ import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.queue.implementation.QueueHandler;
 import com.fastasyncworldedit.core.queue.implementation.blocks.CharGetBlocks;
 import com.fastasyncworldedit.core.util.MathMan;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.jnbt.ListTag;
-import com.sk89q.jnbt.StringTag;
-import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -34,6 +30,7 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
@@ -61,11 +58,19 @@ import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_20_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R2.block.CraftBlock;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.enginehub.linbus.tree.LinCompoundTag;
+import org.enginehub.linbus.tree.LinDoubleTag;
+import org.enginehub.linbus.tree.LinFloatTag;
+import org.enginehub.linbus.tree.LinListTag;
+import org.enginehub.linbus.tree.LinStringTag;
+import org.enginehub.linbus.tree.LinTagType;
 
 import javax.annotation.Nonnull;
-import java.util.AbstractSet;
+import javax.annotation.Nullable;
+import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,7 +87,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static net.minecraft.core.registries.Registries.BIOME;
 
@@ -91,8 +95,9 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private static final Function<BlockPos, BlockVector3> posNms2We = v -> BlockVector3.at(v.getX(), v.getY(), v.getZ());
-    private static final Function<BlockEntity, CompoundTag> nmsTile2We =
-            tileEntity -> new PaperweightLazyCompoundTag(Suppliers.memoize(tileEntity::saveWithId));
+    public static final Function<BlockEntity, FaweCompoundTag> NMS_TO_TILE = ((PaperweightFaweAdapter) WorldEditPlugin
+            .getInstance()
+            .getBukkitImplAdapter()).blockEntityToCompoundTag();
     private final PaperweightFaweAdapter adapter = ((PaperweightFaweAdapter) WorldEditPlugin
             .getInstance()
             .getBukkitImplAdapter());
@@ -256,23 +261,24 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public CompoundTag getTile(int x, int y, int z) {
+    public FaweCompoundTag tile(final int x, final int y, final int z) {
         BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
                 chunkX << 4), y, (z & 15) + (
                 chunkZ << 4)));
         if (blockEntity == null) {
             return null;
         }
-        return new PaperweightLazyCompoundTag(Suppliers.memoize(blockEntity::saveWithId));
+        return NMS_TO_TILE.apply(blockEntity);
+
     }
 
     @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
         Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
         if (nmsTiles.isEmpty()) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, nmsTile2We);
+        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -335,7 +341,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public CompoundTag getEntity(UUID uuid) {
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
         ensureLoaded(serverLevel, chunkX, chunkZ);
         List<Entity> entities = PaperweightPlatformAdapter.getEntities(getChunk());
         Entity entity = null;
@@ -347,10 +353,10 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         }
         if (entity != null) {
             org.bukkit.entity.Entity bukkitEnt = entity.getBukkitEntity();
-            return BukkitAdapter.adapt(bukkitEnt).getState().getNbtData();
+            return FaweCompoundTag.of(BukkitAdapter.adapt(bukkitEnt).getState().getNbt());
         }
-        for (CompoundTag tag : getEntities()) {
-            if (uuid.equals(tag.getUUID())) {
+        for (FaweCompoundTag tag : entities()) {
+            if (uuid.equals(NbtUtils.uuid(tag))) {
                 return tag;
             }
         }
@@ -358,14 +364,14 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
+    public Collection<FaweCompoundTag> entities() {
         ensureLoaded(serverLevel, chunkX, chunkZ);
         List<Entity> entities = PaperweightPlatformAdapter.getEntities(getChunk());
         if (entities.isEmpty()) {
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
         int size = entities.size();
-        return new AbstractSet<>() {
+        return new AbstractCollection<>() {
             @Override
             public int size() {
                 return size;
@@ -378,10 +384,10 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
             @Override
             public boolean contains(Object get) {
-                if (!(get instanceof CompoundTag getTag)) {
+                if (!(get instanceof FaweCompoundTag getTag)) {
                     return false;
                 }
-                UUID getUUID = getTag.getUUID();
+                UUID getUUID = NbtUtils.uuid(getTag);
                 for (Entity entity : entities) {
                     UUID uuid = entity.getUUID();
                     if (uuid.equals(getUUID)) {
@@ -393,12 +399,12 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
             @Nonnull
             @Override
-            public Iterator<CompoundTag> iterator() {
-                Iterable<CompoundTag> result = entities.stream().map(input -> {
-                    net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
+            public Iterator<FaweCompoundTag> iterator() {
+                Iterable<FaweCompoundTag> result = entities.stream().map(input -> {
+                    CompoundTag tag = new CompoundTag();
                     input.save(tag);
-                    return (CompoundTag) adapter.toNative(tag);
-                }).collect(Collectors.toList());
+                    return FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(tag));
+                })::iterator;
                 return result.iterator();
             }
         };
@@ -728,43 +734,42 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                     };
                 }
 
-                Set<CompoundTag> entities = set.getEntities();
+                Collection<FaweCompoundTag> entities = set.entities();
                 if (entities != null && !entities.isEmpty()) {
                     if (syncTasks == null) {
                         syncTasks = new Runnable[2];
                     }
 
                     syncTasks[1] = () -> {
-                        Iterator<CompoundTag> iterator = entities.iterator();
+                        Iterator<FaweCompoundTag> iterator = entities.iterator();
                         while (iterator.hasNext()) {
-                            final CompoundTag nativeTag = iterator.next();
-                            final Map<String, Tag<?, ?>> entityTagMap = nativeTag.getValue();
-                            final StringTag idTag = (StringTag) entityTagMap.get("Id");
-                            final ListTag posTag = (ListTag) entityTagMap.get("Pos");
-                            final ListTag rotTag = (ListTag) entityTagMap.get("Rotation");
+                            final FaweCompoundTag nativeTag = iterator.next();
+                            final LinCompoundTag linTag = nativeTag.linTag();
+                            final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                            final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                            final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                             if (idTag == null || posTag == null || rotTag == null) {
                                 LOGGER.error("Unknown entity tag: {}", nativeTag);
                                 continue;
                             }
-                            final double x = posTag.getDouble(0);
-                            final double y = posTag.getDouble(1);
-                            final double z = posTag.getDouble(2);
-                            final float yaw = rotTag.getFloat(0);
-                            final float pitch = rotTag.getFloat(1);
-                            final String id = idTag.getValue();
+                            final double x = posTag.get(0).valueAsDouble();
+                            final double y = posTag.get(1).valueAsDouble();
+                            final double z = posTag.get(2).valueAsDouble();
+                            final float yaw = rotTag.get(0).valueAsFloat();
+                            final float pitch = rotTag.get(1).valueAsFloat();
+                            final String id = idTag.value();
 
                             EntityType<?> type = EntityType.byString(id).orElse(null);
                             if (type != null) {
                                 Entity entity = type.create(nmsWorld);
                                 if (entity != null) {
-                                    final net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) adapter.fromNative(
-                                            nativeTag);
+                                    final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
                                     for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                         tag.remove(name);
                                     }
                                     entity.load(tag);
                                     entity.absMoveTo(x, y, z, yaw, pitch);
-                                    entity.setUUID(nativeTag.getUUID());
+                                    entity.setUUID(NbtUtils.uuid(nativeTag));
                                     if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
                                         LOGGER.warn(
                                                 "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
@@ -784,15 +789,15 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                 }
 
                 // set tiles
-                Map<BlockVector3, CompoundTag> tiles = set.getTiles();
+                Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
                 if (tiles != null && !tiles.isEmpty()) {
                     if (syncTasks == null) {
                         syncTasks = new Runnable[1];
                     }
 
                     syncTasks[0] = () -> {
-                        for (final Map.Entry<BlockVector3, CompoundTag> entry : tiles.entrySet()) {
-                            final CompoundTag nativeTag = entry.getValue();
+                        for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                            final FaweCompoundTag nativeTag = entry.getValue();
                             final BlockVector3 blockHash = entry.getKey();
                             final int x = blockHash.x() + bx;
                             final int y = blockHash.y();
@@ -806,8 +811,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                                     tileEntity = nmsWorld.getBlockEntity(pos);
                                 }
                                 if (tileEntity != null) {
-                                    final net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) adapter.fromNative(
-                                            nativeTag);
+                                    final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
                                     tag.put("x", IntTag.valueOf(x));
                                     tag.put("y", IntTag.valueOf(y));
                                     tag.put("z", IntTag.valueOf(z));

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks_Copy.java
@@ -1,14 +1,13 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2;
 
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -16,6 +15,7 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import net.minecraft.core.Holder;
+import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.biome.Biome;
@@ -24,9 +24,11 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
+import org.enginehub.linbus.tree.LinCompoundTag;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -38,8 +40,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
-    private final Map<BlockVector3, CompoundTag> tiles = new HashMap<>();
-    private final Set<CompoundTag> entities = new HashSet<>();
+    private final Map<BlockVector3, FaweCompoundTag> tiles = new HashMap<>();
+    private final Set<FaweCompoundTag> entities = new HashSet<>();
     private final char[][] blocks;
     private final int minHeight;
     private final int maxHeight;
@@ -56,44 +58,35 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     protected void storeTile(BlockEntity blockEntity) {
+        @SuppressWarnings("unchecked")
+        BukkitImplAdapter<Tag> adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         tiles.put(
                 BlockVector3.at(
                         blockEntity.getBlockPos().getX(),
                         blockEntity.getBlockPos().getY(),
                         blockEntity.getBlockPos().getZ()
                 ),
-                new PaperweightLazyCompoundTag(Suppliers.memoize(blockEntity::saveWithId))
+                FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(blockEntity.saveWithId()))
         );
     }
 
-    @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
-        return tiles;
-    }
-
-    @Override
-    @Nullable
-    public CompoundTag getTile(int x, int y, int z) {
-        return tiles.get(BlockVector3.at(x, y, z));
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void storeEntity(Entity entity) {
-        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
+        @SuppressWarnings("unchecked")
+        BukkitImplAdapter<Tag> adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         net.minecraft.nbt.CompoundTag compoundTag = new net.minecraft.nbt.CompoundTag();
         entity.save(compoundTag);
-        entities.add((CompoundTag) adapter.toNative(compoundTag));
+        entities.add(FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(compoundTag)));
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
+    public Collection<FaweCompoundTag> entities() {
         return this.entities;
     }
 
     @Override
-    public CompoundTag getEntity(UUID uuid) {
-        for (CompoundTag tag : entities) {
-            if (uuid.equals(tag.getUUID())) {
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
+        for (FaweCompoundTag tag : entities) {
+            if (uuid.equals(NbtUtils.uuid(tag))) {
                 return tag;
             }
         }
@@ -194,7 +187,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BaseBlock getFullBlock(int x, int y, int z) {
         BlockState state = BlockTypesCache.states[get(x, y, z)];
-        return state.toBaseBlock(this, x, y, z);
+        return state.toBaseBlock((IBlocks) this, x, y, z);
     }
 
     @Override
@@ -222,6 +215,16 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BlockState getBlock(int x, int y, int z) {
         return BlockTypesCache.states[get(x, y, z)];
+    }
+
+    @Override
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
+        return tiles;
+    }
+
+    @Override
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
+        return tiles.get(BlockVector3.at(x, y, z));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks_Copy.java
@@ -25,8 +25,8 @@ import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
 import org.enginehub.linbus.tree.LinCompoundTag;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightBlockMaterial.java
@@ -1,8 +1,6 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3;
 
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3.nbt.PaperweightLazyCompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -13,6 +11,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.craftbukkit.v1_20_R3.block.data.CraftBlockData;
+import org.jetbrains.annotations.Nullable;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
 
@@ -21,7 +20,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     private final CraftBlockData craftBlockData;
     private final org.bukkit.Material craftMaterial;
     private final int opacity;
-    private final CompoundTag tile;
+    private final FaweCompoundTag tile;
 
     public PaperweightBlockMaterial(Block block) {
         this(block, block.defaultBlockState());
@@ -39,7 +38,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         );
         tile = tileEntity == null
                 ? null
-                : new PaperweightLazyCompoundTag(Suppliers.memoize(tileEntity::saveWithId));
+                : PaperweightGetBlocks.NMS_TO_TILE.apply(tileEntity);
     }
 
     public Block getBlock() {
@@ -163,7 +162,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public CompoundTag getDefaultTile() {
+    public @Nullable FaweCompoundTag defaultTile() {
         return tile;
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightBlockMaterial.java
@@ -11,7 +11,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.craftbukkit.v1_20_R3.block.data.CraftBlockData;
-import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nullable;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
 

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.bukkit.adapter.NMSRelighterFactory;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.entity.LazyBaseEntity;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
@@ -97,6 +98,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -127,6 +129,12 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public PaperweightFaweAdapter() throws NoSuchFieldException, NoSuchMethodException {
         this.parent = new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R3.PaperweightAdapter();
+    }
+
+    public Function<BlockEntity, FaweCompoundTag> blockEntityToCompoundTag() {
+        return blockEntity -> FaweCompoundTag.of(
+                () -> (LinCompoundTag) toNativeLin(blockEntity.saveWithId())
+        );
     }
 
     @Nullable

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
@@ -7,20 +7,16 @@ import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.queue.implementation.QueueHandler;
 import com.fastasyncworldedit.core.queue.implementation.blocks.CharGetBlocks;
 import com.fastasyncworldedit.core.util.MathMan;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.jnbt.ListTag;
-import com.sk89q.jnbt.StringTag;
-import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -34,6 +30,7 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
@@ -61,11 +58,19 @@ import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R3.block.CraftBlock;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.enginehub.linbus.tree.LinCompoundTag;
+import org.enginehub.linbus.tree.LinDoubleTag;
+import org.enginehub.linbus.tree.LinFloatTag;
+import org.enginehub.linbus.tree.LinListTag;
+import org.enginehub.linbus.tree.LinStringTag;
+import org.enginehub.linbus.tree.LinTagType;
 
 import javax.annotation.Nonnull;
-import java.util.AbstractSet;
+import javax.annotation.Nullable;
+import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,7 +87,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static net.minecraft.core.registries.Registries.BIOME;
 
@@ -91,8 +95,9 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private static final Function<BlockPos, BlockVector3> posNms2We = v -> BlockVector3.at(v.getX(), v.getY(), v.getZ());
-    private static final Function<BlockEntity, CompoundTag> nmsTile2We =
-            tileEntity -> new PaperweightLazyCompoundTag(Suppliers.memoize(tileEntity::saveWithId));
+    public static final Function<BlockEntity, FaweCompoundTag> NMS_TO_TILE = ((PaperweightFaweAdapter) WorldEditPlugin
+            .getInstance()
+            .getBukkitImplAdapter()).blockEntityToCompoundTag();
     private final PaperweightFaweAdapter adapter = ((PaperweightFaweAdapter) WorldEditPlugin
             .getInstance()
             .getBukkitImplAdapter());
@@ -108,6 +113,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     private final Registry<Biome> biomeRegistry;
     private final IdMap<Holder<Biome>> biomeHolderIdMap;
     private final ConcurrentHashMap<Integer, PaperweightGetBlocks_Copy> copies = new ConcurrentHashMap<>();
+    private final Object sendLock = new Object();
     private LevelChunkSection[] sections;
     private LevelChunk levelChunk;
     private DataLayer[] blockLight;
@@ -255,23 +261,24 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public CompoundTag getTile(int x, int y, int z) {
+    public FaweCompoundTag tile(final int x, final int y, final int z) {
         BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
                 chunkX << 4), y, (z & 15) + (
                 chunkZ << 4)));
         if (blockEntity == null) {
             return null;
         }
-        return new PaperweightLazyCompoundTag(Suppliers.memoize(blockEntity::saveWithId));
+        return NMS_TO_TILE.apply(blockEntity);
+
     }
 
     @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
         Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
         if (nmsTiles.isEmpty()) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, nmsTile2We);
+        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -334,7 +341,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public CompoundTag getEntity(UUID uuid) {
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
         ensureLoaded(serverLevel, chunkX, chunkZ);
         List<Entity> entities = PaperweightPlatformAdapter.getEntities(getChunk());
         Entity entity = null;
@@ -346,10 +353,10 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         }
         if (entity != null) {
             org.bukkit.entity.Entity bukkitEnt = entity.getBukkitEntity();
-            return BukkitAdapter.adapt(bukkitEnt).getState().getNbtData();
+            return FaweCompoundTag.of(BukkitAdapter.adapt(bukkitEnt).getState().getNbt());
         }
-        for (CompoundTag tag : getEntities()) {
-            if (uuid.equals(tag.getUUID())) {
+        for (FaweCompoundTag tag : entities()) {
+            if (uuid.equals(NbtUtils.uuid(tag))) {
                 return tag;
             }
         }
@@ -357,14 +364,14 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
+    public Collection<FaweCompoundTag> entities() {
         ensureLoaded(serverLevel, chunkX, chunkZ);
         List<Entity> entities = PaperweightPlatformAdapter.getEntities(getChunk());
         if (entities.isEmpty()) {
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
         int size = entities.size();
-        return new AbstractSet<>() {
+        return new AbstractCollection<>() {
             @Override
             public int size() {
                 return size;
@@ -377,10 +384,10 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
             @Override
             public boolean contains(Object get) {
-                if (!(get instanceof CompoundTag getTag)) {
+                if (!(get instanceof FaweCompoundTag getTag)) {
                     return false;
                 }
-                UUID getUUID = getTag.getUUID();
+                UUID getUUID = NbtUtils.uuid(getTag);
                 for (Entity entity : entities) {
                     UUID uuid = entity.getUUID();
                     if (uuid.equals(getUUID)) {
@@ -392,12 +399,12 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
             @Nonnull
             @Override
-            public Iterator<CompoundTag> iterator() {
-                Iterable<CompoundTag> result = entities.stream().map(input -> {
+            public Iterator<FaweCompoundTag> iterator() {
+                Iterable<FaweCompoundTag> result = entities.stream().map(input -> {
                     net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
                     input.save(tag);
-                    return (CompoundTag) adapter.toNative(tag);
-                }).collect(Collectors.toList());
+                    return FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(tag));
+                })::iterator;
                 return result.iterator();
             }
         };
@@ -727,43 +734,42 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                     };
                 }
 
-                Set<CompoundTag> entities = set.getEntities();
+                Collection<FaweCompoundTag> entities = set.entities();
                 if (entities != null && !entities.isEmpty()) {
                     if (syncTasks == null) {
                         syncTasks = new Runnable[2];
                     }
 
                     syncTasks[1] = () -> {
-                        Iterator<CompoundTag> iterator = entities.iterator();
+                        Iterator<FaweCompoundTag> iterator = entities.iterator();
                         while (iterator.hasNext()) {
-                            final CompoundTag nativeTag = iterator.next();
-                            final Map<String, Tag<?, ?>> entityTagMap = nativeTag.getValue();
-                            final StringTag idTag = (StringTag) entityTagMap.get("Id");
-                            final ListTag posTag = (ListTag) entityTagMap.get("Pos");
-                            final ListTag rotTag = (ListTag) entityTagMap.get("Rotation");
+                            final FaweCompoundTag nativeTag = iterator.next();
+                            final LinCompoundTag linTag = nativeTag.linTag();
+                            final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                            final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                            final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                             if (idTag == null || posTag == null || rotTag == null) {
                                 LOGGER.error("Unknown entity tag: {}", nativeTag);
                                 continue;
                             }
-                            final double x = posTag.getDouble(0);
-                            final double y = posTag.getDouble(1);
-                            final double z = posTag.getDouble(2);
-                            final float yaw = rotTag.getFloat(0);
-                            final float pitch = rotTag.getFloat(1);
-                            final String id = idTag.getValue();
+                            final double x = posTag.get(0).valueAsDouble();
+                            final double y = posTag.get(1).valueAsDouble();
+                            final double z = posTag.get(2).valueAsDouble();
+                            final float yaw = rotTag.get(0).valueAsFloat();
+                            final float pitch = rotTag.get(1).valueAsFloat();
+                            final String id = idTag.value();
 
                             EntityType<?> type = EntityType.byString(id).orElse(null);
                             if (type != null) {
                                 Entity entity = type.create(nmsWorld);
                                 if (entity != null) {
-                                    final net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) adapter.fromNative(
-                                            nativeTag);
+                                    final net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) adapter.fromNativeLin(linTag);
                                     for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                         tag.remove(name);
                                     }
                                     entity.load(tag);
                                     entity.absMoveTo(x, y, z, yaw, pitch);
-                                    entity.setUUID(nativeTag.getUUID());
+                                    entity.setUUID(NbtUtils.uuid(nativeTag));
                                     if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
                                         LOGGER.warn(
                                                 "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
@@ -783,15 +789,15 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                 }
 
                 // set tiles
-                Map<BlockVector3, CompoundTag> tiles = set.getTiles();
+                Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
                 if (tiles != null && !tiles.isEmpty()) {
                     if (syncTasks == null) {
                         syncTasks = new Runnable[1];
                     }
 
                     syncTasks[0] = () -> {
-                        for (final Map.Entry<BlockVector3, CompoundTag> entry : tiles.entrySet()) {
-                            final CompoundTag nativeTag = entry.getValue();
+                        for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                            final FaweCompoundTag nativeTag = entry.getValue();
                             final BlockVector3 blockHash = entry.getKey();
                             final int x = blockHash.x() + bx;
                             final int y = blockHash.y();
@@ -805,8 +811,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                                     tileEntity = nmsWorld.getBlockEntity(pos);
                                 }
                                 if (tileEntity != null) {
-                                    final net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) adapter.fromNative(
-                                            nativeTag);
+                                    final net.minecraft.nbt.CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
                                     tag.put("x", IntTag.valueOf(x));
                                     tag.put("y", IntTag.valueOf(y));
                                     tag.put("z", IntTag.valueOf(z));

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks_Copy.java
@@ -1,14 +1,13 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3;
 
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -16,6 +15,7 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import net.minecraft.core.Holder;
+import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.biome.Biome;
@@ -24,9 +24,11 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
+import org.enginehub.linbus.tree.LinCompoundTag;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -38,8 +40,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
-    private final Map<BlockVector3, CompoundTag> tiles = new HashMap<>();
-    private final Set<CompoundTag> entities = new HashSet<>();
+    private final Map<BlockVector3, FaweCompoundTag> tiles = new HashMap<>();
+    private final Set<FaweCompoundTag> entities = new HashSet<>();
     private final char[][] blocks;
     private final int minHeight;
     private final int maxHeight;
@@ -56,44 +58,35 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     protected void storeTile(BlockEntity blockEntity) {
+        @SuppressWarnings("unchecked")
+        BukkitImplAdapter<Tag> adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         tiles.put(
                 BlockVector3.at(
                         blockEntity.getBlockPos().getX(),
                         blockEntity.getBlockPos().getY(),
                         blockEntity.getBlockPos().getZ()
                 ),
-                new PaperweightLazyCompoundTag(Suppliers.memoize(blockEntity::saveWithId))
+                FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(blockEntity.saveWithId()))
         );
     }
 
-    @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
-        return tiles;
-    }
-
-    @Override
-    @Nullable
-    public CompoundTag getTile(int x, int y, int z) {
-        return tiles.get(BlockVector3.at(x, y, z));
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void storeEntity(Entity entity) {
-        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
+        @SuppressWarnings("unchecked")
+        BukkitImplAdapter<Tag> adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         net.minecraft.nbt.CompoundTag compoundTag = new net.minecraft.nbt.CompoundTag();
         entity.save(compoundTag);
-        entities.add((CompoundTag) adapter.toNative(compoundTag));
+        entities.add(FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(compoundTag)));
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
+    public Collection<FaweCompoundTag> entities() {
         return this.entities;
     }
 
     @Override
-    public CompoundTag getEntity(UUID uuid) {
-        for (CompoundTag tag : entities) {
-            if (uuid.equals(tag.getUUID())) {
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
+        for (FaweCompoundTag tag : entities) {
+            if (uuid.equals(NbtUtils.uuid(tag))) {
                 return tag;
             }
         }
@@ -194,7 +187,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BaseBlock getFullBlock(int x, int y, int z) {
         BlockState state = BlockTypesCache.states[get(x, y, z)];
-        return state.toBaseBlock(this, x, y, z);
+        return state.toBaseBlock((IBlocks) this, x, y, z);
     }
 
     @Override
@@ -222,6 +215,16 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BlockState getBlock(int x, int y, int z) {
         return BlockTypesCache.states[get(x, y, z)];
+    }
+
+    @Override
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
+        return tiles;
+    }
+
+    @Override
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
+        return tiles.get(BlockVector3.at(x, y, z));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks_Copy.java
@@ -25,8 +25,8 @@ import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
 import org.enginehub.linbus.tree.LinCompoundTag;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightBlockMaterial.java
@@ -1,11 +1,8 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R4;
 
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R4.nbt.PaperweightLazyCompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
@@ -14,6 +11,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
+import org.jetbrains.annotations.Nullable;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
 
@@ -22,7 +20,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     private final CraftBlockData craftBlockData;
     private final org.bukkit.Material craftMaterial;
     private final int opacity;
-    private final CompoundTag tile;
+    private final FaweCompoundTag tile;
 
     public PaperweightBlockMaterial(Block block) {
         this(block, block.defaultBlockState());
@@ -38,9 +36,9 @@ public class PaperweightBlockMaterial implements BlockMaterial {
                 BlockPos.ZERO,
                 blockState
         );
-        tile = tileEntity == null ? null : new PaperweightLazyCompoundTag(
-                Suppliers.memoize(() -> tileEntity.saveWithId(DedicatedServer.getServer().registryAccess()))
-        );
+        tile = tileEntity == null
+                ? null
+                : PaperweightGetBlocks.NMS_TO_TILE.apply(tileEntity);
     }
 
     public Block getBlock() {
@@ -164,7 +162,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public CompoundTag getDefaultTile() {
+    public @Nullable FaweCompoundTag defaultTile() {
         return tile;
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightBlockMaterial.java
@@ -11,7 +11,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
-import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nullable;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
 

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.bukkit.adapter.NMSRelighterFactory;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.entity.LazyBaseEntity;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
@@ -103,6 +104,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -136,6 +138,12 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public PaperweightFaweAdapter() throws NoSuchFieldException, NoSuchMethodException {
         this.parent = new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R4.PaperweightAdapter();
+    }
+
+    public Function<BlockEntity, FaweCompoundTag> blockEntityToCompoundTag() {
+        return blockEntity -> FaweCompoundTag.of(
+                () -> (LinCompoundTag) toNativeLin(blockEntity.saveWithId(DedicatedServer.getServer().registryAccess()))
+        );
     }
 
     @Nullable

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks_Copy.java
@@ -26,8 +26,8 @@ import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
 import org.enginehub.linbus.tree.LinCompoundTag;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -87,7 +87,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     @Override
-    public @org.jetbrains.annotations.Nullable FaweCompoundTag entity(final UUID uuid) {
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
         for (FaweCompoundTag tag : entities) {
             if (uuid.equals(NbtUtils.uuid(tag))) {
                 return tag;

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks_Copy.java
@@ -1,14 +1,13 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R4;
 
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R4.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -16,6 +15,7 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import net.minecraft.core.Holder;
+import net.minecraft.nbt.Tag;
 import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
@@ -25,9 +25,11 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
+import org.enginehub.linbus.tree.LinCompoundTag;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -39,8 +41,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
-    private final Map<BlockVector3, CompoundTag> tiles = new HashMap<>();
-    private final Set<CompoundTag> entities = new HashSet<>();
+    private final Map<BlockVector3, FaweCompoundTag> tiles = new HashMap<>();
+    private final Set<FaweCompoundTag> entities = new HashSet<>();
     private final char[][] blocks;
     private final int minHeight;
     private final int maxHeight;
@@ -57,44 +59,37 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     protected void storeTile(BlockEntity blockEntity) {
+        @SuppressWarnings("unchecked")
+        BukkitImplAdapter<Tag> adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         tiles.put(
                 BlockVector3.at(
                         blockEntity.getBlockPos().getX(),
                         blockEntity.getBlockPos().getY(),
                         blockEntity.getBlockPos().getZ()
                 ),
-                new PaperweightLazyCompoundTag(Suppliers.memoize(() -> blockEntity.saveWithId(DedicatedServer.getServer().registryAccess())))
+                FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(blockEntity.saveWithId(DedicatedServer
+                        .getServer()
+                        .registryAccess())))
         );
     }
 
-    @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
-        return tiles;
-    }
-
-    @Override
-    @Nullable
-    public CompoundTag getTile(int x, int y, int z) {
-        return tiles.get(BlockVector3.at(x, y, z));
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void storeEntity(Entity entity) {
-        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
+        @SuppressWarnings("unchecked")
+        BukkitImplAdapter<Tag> adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         net.minecraft.nbt.CompoundTag compoundTag = new net.minecraft.nbt.CompoundTag();
         entity.save(compoundTag);
-        entities.add((CompoundTag) adapter.toNative(compoundTag));
+        entities.add(FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(compoundTag)));
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
+    public Collection<FaweCompoundTag> entities() {
         return this.entities;
     }
 
     @Override
-    public CompoundTag getEntity(UUID uuid) {
-        for (CompoundTag tag : entities) {
-            if (uuid.equals(tag.getUUID())) {
+    public @org.jetbrains.annotations.Nullable FaweCompoundTag entity(final UUID uuid) {
+        for (FaweCompoundTag tag : entities) {
+            if (uuid.equals(NbtUtils.uuid(tag))) {
                 return tag;
             }
         }
@@ -195,7 +190,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BaseBlock getFullBlock(int x, int y, int z) {
         BlockState state = BlockTypesCache.states[get(x, y, z)];
-        return state.toBaseBlock(this, x, y, z);
+        return state.toBaseBlock((IBlocks) this, x, y, z);
     }
 
     @Override
@@ -223,6 +218,16 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BlockState getBlock(int x, int y, int z) {
         return BlockTypesCache.states[get(x, y, z)];
+    }
+
+    @Override
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
+        return tiles;
+    }
+
+    @Override
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
+        return tiles.get(BlockVector3.at(x, y, z));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightBlockMaterial.java
@@ -1,11 +1,8 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1;
 
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1.nbt.PaperweightLazyCompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
@@ -14,6 +11,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
+import org.jetbrains.annotations.Nullable;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
 
@@ -22,7 +20,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     private final CraftBlockData craftBlockData;
     private final org.bukkit.Material craftMaterial;
     private final int opacity;
-    private final CompoundTag tile;
+    private final FaweCompoundTag tile;
 
     public PaperweightBlockMaterial(Block block) {
         this(block, block.defaultBlockState());
@@ -38,9 +36,9 @@ public class PaperweightBlockMaterial implements BlockMaterial {
                 BlockPos.ZERO,
                 blockState
         );
-        tile = tileEntity == null ? null : new PaperweightLazyCompoundTag(
-                Suppliers.memoize(() -> tileEntity.saveWithId(DedicatedServer.getServer().registryAccess()))
-        );
+        tile = tileEntity == null
+                ? null
+                : PaperweightGetBlocks.NMS_TO_TILE.apply(tileEntity);
     }
 
     public Block getBlock() {
@@ -164,7 +162,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public CompoundTag getDefaultTile() {
+    public @Nullable FaweCompoundTag defaultTile() {
         return tile;
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightBlockMaterial.java
@@ -11,7 +11,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.PushReaction;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
-import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nullable;
 
 public class PaperweightBlockMaterial implements BlockMaterial {
 

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.bukkit.adapter.NMSRelighterFactory;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.entity.LazyBaseEntity;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
@@ -102,6 +103,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -135,6 +137,12 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public PaperweightFaweAdapter() throws NoSuchFieldException, NoSuchMethodException {
         this.parent = new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_21_R1.PaperweightAdapter();
+    }
+
+    public Function<BlockEntity, FaweCompoundTag> blockEntityToCompoundTag() {
+        return blockEntity -> FaweCompoundTag.of(
+                () -> (LinCompoundTag) toNativeLin(blockEntity.saveWithId(DedicatedServer.getServer().registryAccess()))
+        );
     }
 
     @Nullable

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
@@ -7,20 +7,16 @@ import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.queue.implementation.QueueHandler;
 import com.fastasyncworldedit.core.queue.implementation.blocks.CharGetBlocks;
 import com.fastasyncworldedit.core.util.MathMan;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.jnbt.ListTag;
-import com.sk89q.jnbt.StringTag;
-import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -34,6 +30,7 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.level.ServerLevel;
@@ -62,11 +59,19 @@ import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.CraftBlock;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.enginehub.linbus.tree.LinCompoundTag;
+import org.enginehub.linbus.tree.LinDoubleTag;
+import org.enginehub.linbus.tree.LinFloatTag;
+import org.enginehub.linbus.tree.LinListTag;
+import org.enginehub.linbus.tree.LinStringTag;
+import org.enginehub.linbus.tree.LinTagType;
 
 import javax.annotation.Nonnull;
-import java.util.AbstractSet;
+import javax.annotation.Nullable;
+import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,7 +88,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static net.minecraft.core.registries.Registries.BIOME;
 
@@ -92,9 +96,9 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
     private static final Function<BlockPos, BlockVector3> posNms2We = v -> BlockVector3.at(v.getX(), v.getY(), v.getZ());
-    private static final Function<BlockEntity, CompoundTag> nmsTile2We = tileEntity -> new PaperweightLazyCompoundTag(
-            Suppliers.memoize(() -> tileEntity.saveWithId(DedicatedServer.getServer().registryAccess()))
-    );
+    public static final Function<BlockEntity, FaweCompoundTag> NMS_TO_TILE = ((PaperweightFaweAdapter) WorldEditPlugin
+            .getInstance()
+            .getBukkitImplAdapter()).blockEntityToCompoundTag();
     private final PaperweightFaweAdapter adapter = ((PaperweightFaweAdapter) WorldEditPlugin
             .getInstance()
             .getBukkitImplAdapter());
@@ -258,23 +262,24 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public CompoundTag getTile(int x, int y, int z) {
+    public FaweCompoundTag tile(final int x, final int y, final int z) {
         BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
                 chunkX << 4), y, (z & 15) + (
                 chunkZ << 4)));
         if (blockEntity == null) {
             return null;
         }
-        return new PaperweightLazyCompoundTag(Suppliers.memoize(() -> blockEntity.saveWithId(DedicatedServer.getServer().registryAccess())));
+        return NMS_TO_TILE.apply(blockEntity);
+
     }
 
     @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
         Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
         if (nmsTiles.isEmpty()) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, nmsTile2We);
+        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -337,7 +342,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public CompoundTag getEntity(UUID uuid) {
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
         ensureLoaded(serverLevel, chunkX, chunkZ);
         List<Entity> entities = PaperweightPlatformAdapter.getEntities(getChunk());
         Entity entity = null;
@@ -349,10 +354,10 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
         }
         if (entity != null) {
             org.bukkit.entity.Entity bukkitEnt = entity.getBukkitEntity();
-            return BukkitAdapter.adapt(bukkitEnt).getState().getNbtData();
+            return FaweCompoundTag.of(BukkitAdapter.adapt(bukkitEnt).getState().getNbt());
         }
-        for (CompoundTag tag : getEntities()) {
-            if (uuid.equals(tag.getUUID())) {
+        for (FaweCompoundTag tag : entities()) {
+            if (uuid.equals(NbtUtils.uuid(tag))) {
                 return tag;
             }
         }
@@ -360,14 +365,14 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
+    public Collection<FaweCompoundTag> entities() {
         ensureLoaded(serverLevel, chunkX, chunkZ);
         List<Entity> entities = PaperweightPlatformAdapter.getEntities(getChunk());
         if (entities.isEmpty()) {
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
         int size = entities.size();
-        return new AbstractSet<>() {
+        return new AbstractCollection<>() {
             @Override
             public int size() {
                 return size;
@@ -380,10 +385,10 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
             @Override
             public boolean contains(Object get) {
-                if (!(get instanceof CompoundTag getTag)) {
+                if (!(get instanceof FaweCompoundTag getTag)) {
                     return false;
                 }
-                UUID getUUID = getTag.getUUID();
+                UUID getUUID = NbtUtils.uuid(getTag);
                 for (Entity entity : entities) {
                     UUID uuid = entity.getUUID();
                     if (uuid.equals(getUUID)) {
@@ -395,15 +400,16 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
 
             @Nonnull
             @Override
-            public Iterator<CompoundTag> iterator() {
-                Iterable<CompoundTag> result = entities.stream().map(input -> {
-                    net.minecraft.nbt.CompoundTag tag = new net.minecraft.nbt.CompoundTag();
+            public Iterator<FaweCompoundTag> iterator() {
+                Iterable<FaweCompoundTag> result = entities.stream().map(input -> {
+                    CompoundTag tag = new CompoundTag();
                     input.save(tag);
-                    return (CompoundTag) adapter.toNative(tag);
-                }).collect(Collectors.toList());
+                    return FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(tag));
+                })::iterator;
                 return result.iterator();
             }
         };
+
     }
 
     private void removeEntity(Entity entity) {
@@ -722,43 +728,42 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                     };
                 }
 
-                Set<CompoundTag> entities = set.getEntities();
+                Collection<FaweCompoundTag> entities = set.entities();
                 if (entities != null && !entities.isEmpty()) {
                     if (syncTasks == null) {
                         syncTasks = new Runnable[2];
                     }
 
                     syncTasks[1] = () -> {
-                        Iterator<CompoundTag> iterator = entities.iterator();
+                        Iterator<FaweCompoundTag> iterator = entities.iterator();
                         while (iterator.hasNext()) {
-                            final CompoundTag nativeTag = iterator.next();
-                            final Map<String, Tag<?, ?>> entityTagMap = nativeTag.getValue();
-                            final StringTag idTag = (StringTag) entityTagMap.get("Id");
-                            final ListTag posTag = (ListTag) entityTagMap.get("Pos");
-                            final ListTag rotTag = (ListTag) entityTagMap.get("Rotation");
+                            final FaweCompoundTag nativeTag = iterator.next();
+                            final LinCompoundTag linTag = nativeTag.linTag();
+                            final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                            final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                            final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                             if (idTag == null || posTag == null || rotTag == null) {
                                 LOGGER.error("Unknown entity tag: {}", nativeTag);
                                 continue;
                             }
-                            final double x = posTag.getDouble(0);
-                            final double y = posTag.getDouble(1);
-                            final double z = posTag.getDouble(2);
-                            final float yaw = rotTag.getFloat(0);
-                            final float pitch = rotTag.getFloat(1);
-                            final String id = idTag.getValue();
+                            final double x = posTag.get(0).valueAsDouble();
+                            final double y = posTag.get(1).valueAsDouble();
+                            final double z = posTag.get(2).valueAsDouble();
+                            final float yaw = rotTag.get(0).valueAsFloat();
+                            final float pitch = rotTag.get(1).valueAsFloat();
+                            final String id = idTag.value();
 
                             EntityType<?> type = EntityType.byString(id).orElse(null);
                             if (type != null) {
                                 Entity entity = type.create(nmsWorld);
                                 if (entity != null) {
-                                    final net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) adapter.fromNative(
-                                            nativeTag);
+                                    final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
                                     for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                         tag.remove(name);
                                     }
                                     entity.load(tag);
                                     entity.absMoveTo(x, y, z, yaw, pitch);
-                                    entity.setUUID(nativeTag.getUUID());
+                                    entity.setUUID(NbtUtils.uuid(nativeTag));
                                     if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
                                         LOGGER.warn(
                                                 "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
@@ -778,15 +783,15 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                 }
 
                 // set tiles
-                Map<BlockVector3, CompoundTag> tiles = set.getTiles();
+                Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
                 if (tiles != null && !tiles.isEmpty()) {
                     if (syncTasks == null) {
                         syncTasks = new Runnable[1];
                     }
 
                     syncTasks[0] = () -> {
-                        for (final Map.Entry<BlockVector3, CompoundTag> entry : tiles.entrySet()) {
-                            final CompoundTag nativeTag = entry.getValue();
+                        for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                            final FaweCompoundTag nativeTag = entry.getValue();
                             final BlockVector3 blockHash = entry.getKey();
                             final int x = blockHash.x() + bx;
                             final int y = blockHash.y();
@@ -800,8 +805,7 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                                     tileEntity = nmsWorld.getBlockEntity(pos);
                                 }
                                 if (tileEntity != null) {
-                                    final net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) adapter.fromNative(
-                                            nativeTag);
+                                    final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
                                     tag.put("x", IntTag.valueOf(x));
                                     tag.put("y", IntTag.valueOf(y));
                                     tag.put("z", IntTag.valueOf(z));

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks_Copy.java
@@ -26,8 +26,8 @@ import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
 import org.enginehub.linbus.tree.LinCompoundTag;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks_Copy.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks_Copy.java
@@ -1,14 +1,13 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1;
 
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
-import com.google.common.base.Suppliers;
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
-import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -16,6 +15,7 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import net.minecraft.core.Holder;
+import net.minecraft.nbt.Tag;
 import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
@@ -25,9 +25,11 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.PalettedContainerRO;
 import org.apache.logging.log4j.Logger;
+import org.enginehub.linbus.tree.LinCompoundTag;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -39,8 +41,8 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
-    private final Map<BlockVector3, CompoundTag> tiles = new HashMap<>();
-    private final Set<CompoundTag> entities = new HashSet<>();
+    private final Map<BlockVector3, FaweCompoundTag> tiles = new HashMap<>();
+    private final Set<FaweCompoundTag> entities = new HashSet<>();
     private final char[][] blocks;
     private final int minHeight;
     private final int maxHeight;
@@ -57,44 +59,37 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     }
 
     protected void storeTile(BlockEntity blockEntity) {
+        @SuppressWarnings("unchecked")
+        BukkitImplAdapter<Tag> adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         tiles.put(
                 BlockVector3.at(
                         blockEntity.getBlockPos().getX(),
                         blockEntity.getBlockPos().getY(),
                         blockEntity.getBlockPos().getZ()
                 ),
-                new PaperweightLazyCompoundTag(Suppliers.memoize(() -> blockEntity.saveWithId(DedicatedServer.getServer().registryAccess())))
+                FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(blockEntity.saveWithId(DedicatedServer
+                        .getServer()
+                        .registryAccess())))
         );
     }
 
-    @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
-        return tiles;
-    }
-
-    @Override
-    @Nullable
-    public CompoundTag getTile(int x, int y, int z) {
-        return tiles.get(BlockVector3.at(x, y, z));
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void storeEntity(Entity entity) {
-        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
+        @SuppressWarnings("unchecked")
+        BukkitImplAdapter<Tag> adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         net.minecraft.nbt.CompoundTag compoundTag = new net.minecraft.nbt.CompoundTag();
         entity.save(compoundTag);
-        entities.add((CompoundTag) adapter.toNative(compoundTag));
+        entities.add(FaweCompoundTag.of((LinCompoundTag) adapter.toNativeLin(compoundTag)));
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
+    public Collection<FaweCompoundTag> entities() {
         return this.entities;
     }
 
     @Override
-    public CompoundTag getEntity(UUID uuid) {
-        for (CompoundTag tag : entities) {
-            if (uuid.equals(tag.getUUID())) {
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
+        for (FaweCompoundTag tag : entities) {
+            if (uuid.equals(NbtUtils.uuid(tag))) {
                 return tag;
             }
         }
@@ -195,7 +190,7 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BaseBlock getFullBlock(int x, int y, int z) {
         BlockState state = BlockTypesCache.states[get(x, y, z)];
-        return state.toBaseBlock(this, x, y, z);
+        return state.toBaseBlock((IBlocks) this, x, y, z);
     }
 
     @Override
@@ -223,6 +218,16 @@ public class PaperweightGetBlocks_Copy implements IChunkGet {
     @Override
     public BlockState getBlock(int x, int y, int z) {
         return BlockTypesCache.states[get(x, y, z)];
+    }
+
+    @Override
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
+        return tiles;
+    }
+
+    @Override
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
+        return tiles.get(BlockVector3.at(x, y, z));
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -24,12 +24,12 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.internal.exception.FaweException;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.BaseItem;
@@ -665,7 +665,7 @@ public class BukkitWorld extends AbstractWorld {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
+    public boolean tile(int x, int y, int z, FaweCompoundTag tile) throws WorldEditException {
         return false;
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplLoader.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplLoader.java
@@ -165,9 +165,11 @@ public class BukkitImplLoader {
      * @throws AdapterLoadException thrown if no adapter could be found
      */
     public BukkitImplAdapter loadAdapter() throws AdapterLoadException {
+        // FAWE - do not initialize classes on lookup
+        final ClassLoader classLoader = this.getClass().getClassLoader();
         for (String className : adapterCandidates) {
             try {
-                Class<?> cls = Class.forName(className);
+                Class<?> cls = Class.forName(className, false, classLoader);
                 if (cls.isSynthetic()) {
                     continue;
                 }

--- a/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
+++ b/worldedit-cli/src/main/java/com/sk89q/worldedit/cli/schematic/ClipboardWorld.java
@@ -19,10 +19,10 @@
 
 package com.sk89q.worldedit.cli.schematic;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
 import com.google.common.collect.ImmutableSet;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
@@ -193,7 +193,7 @@ public class ClipboardWorld extends AbstractWorld implements Clipboard, CLIWorld
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
+    public boolean tile(int x, int y, int z, FaweCompoundTag tile) throws WorldEditException {
         return false;
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/HistoryExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/HistoryExtent.java
@@ -2,6 +2,7 @@ package com.fastasyncworldedit.core.extent;
 
 import com.fastasyncworldedit.core.history.changeset.AbstractChangeSet;
 import com.fastasyncworldedit.core.math.MutableBlockVector3;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
@@ -74,7 +75,7 @@ public class HistoryExtent extends AbstractDelegateExtent {
     public Entity createEntity(Location location, BaseEntity state) {
         final Entity entity = super.createEntity(location, state);
         if (state != null) {
-            this.changeSet.addEntityCreate(state.getNbtData());
+            this.changeSet.addEntityCreate(FaweCompoundTag.of(state.getNbt()));
         }
         return entity;
     }
@@ -84,7 +85,7 @@ public class HistoryExtent extends AbstractDelegateExtent {
     public Entity createEntity(Location location, BaseEntity state, UUID uuid) {
         final Entity entity = super.createEntity(location, state, uuid);
         if (state != null) {
-            this.changeSet.addEntityCreate(state.getNbtData());
+            this.changeSet.addEntityCreate(FaweCompoundTag.of(state.getNbt()));
         }
         return entity;
     }
@@ -154,11 +155,10 @@ public class HistoryExtent extends AbstractDelegateExtent {
 
         @Override
         public boolean remove() {
-            final Location location = this.entity.getLocation();
             final BaseEntity state = this.entity.getState();
             final boolean success = this.entity.remove();
             if (state != null && success) {
-                HistoryExtent.this.changeSet.addEntityRemove(state.getNbtData());
+                HistoryExtent.this.changeSet.addEntityRemove(FaweCompoundTag.of(state.getNbt()));
             }
             return success;
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/CPUOptimizedClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/CPUOptimizedClipboard.java
@@ -2,9 +2,11 @@ package com.fastasyncworldedit.core.extent.clipboard;
 
 import com.fastasyncworldedit.core.jnbt.streamer.IntValueReader;
 import com.fastasyncworldedit.core.math.IntTriple;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.IntTag;
 import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -173,6 +175,12 @@ public class CPUOptimizedClipboard extends LinearClipboard {
     public boolean setTile(int x, int y, int z, CompoundTag tag) {
         nbtMapLoc.put(new IntTriple(x, y, z), new CompoundTag(tag.getValue()));
         return true;
+    }
+
+    @Override
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tile) throws WorldEditException {
+        // TODO replace
+        return setTile(x, y, z, new CompoundTag(tile.linTag()));
     }
 
     private boolean setTile(int index, CompoundTag tag) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java
@@ -6,15 +6,17 @@ import com.fastasyncworldedit.core.internal.exception.FaweClipboardVersionMismat
 import com.fastasyncworldedit.core.internal.io.ByteBufferInputStream;
 import com.fastasyncworldedit.core.jnbt.streamer.IntValueReader;
 import com.fastasyncworldedit.core.math.IntTriple;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.util.MainUtil;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.ReflectionUtils;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.DoubleTag;
-import com.sk89q.jnbt.IntTag;
 import com.sk89q.jnbt.ListTag;
 import com.sk89q.jnbt.NBTInputStream;
 import com.sk89q.jnbt.NBTOutputStream;
 import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
@@ -65,6 +67,7 @@ public class DiskOptimizedClipboard extends LinearClipboard {
     private static final Map<String, LockHolder> LOCK_HOLDER_CACHE = new ConcurrentHashMap<>();
 
     private final HashMap<IntTriple, CompoundTag> nbtMap;
+    private final HashMap<IntTriple, FaweCompoundTag> nbtMap2;
     private final File file;
     private final int headerSize;
 
@@ -124,6 +127,7 @@ public class DiskOptimizedClipboard extends LinearClipboard {
             canHaveBiomes = false;
         }
         nbtMap = new HashMap<>();
+        nbtMap2 = new HashMap<>();
         try {
             this.file = file;
             try {
@@ -180,6 +184,7 @@ public class DiskOptimizedClipboard extends LinearClipboard {
         super(readSize(file, versionOverride), BlockVector3.ZERO);
         headerSize = getHeaderSizeOverrideFromVersion(versionOverride);
         nbtMap = new HashMap<>();
+        nbtMap2 = new HashMap<>();
         try {
             this.file = file;
             this.braf = new RandomAccessFile(file, "rw");
@@ -709,12 +714,8 @@ public class DiskOptimizedClipboard extends LinearClipboard {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tag) {
-        final Map<String, Tag<?, ?>> values = new HashMap<>(tag.getValue());
-        values.put("x", new IntTag(x));
-        values.put("y", new IntTag(y));
-        values.put("z", new IntTag(z));
-        nbtMap.put(new IntTriple(x, y, z), new CompoundTag(values));
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tile) throws WorldEditException {
+        nbtMap2.put(new IntTriple(x, y, z), NbtUtils.withPosition(tile, x, y, z));
         return true;
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/EmptyClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/EmptyClipboard.java
@@ -1,7 +1,7 @@
 package com.fastasyncworldedit.core.extent.clipboard;
 
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.Entity;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
@@ -84,7 +84,8 @@ public final class EmptyClipboard implements Clipboard {
         return false;
     }
 
-    public boolean setTile(int x, int y, int z, @Nonnull CompoundTag tile) throws WorldEditException {
+    @Override
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tile) throws WorldEditException {
         return false;
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/MemoryOptimizedClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/MemoryOptimizedClipboard.java
@@ -3,10 +3,12 @@ package com.fastasyncworldedit.core.extent.clipboard;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.jnbt.streamer.IntValueReader;
 import com.fastasyncworldedit.core.math.IntTriple;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.util.MainUtil;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.IntTag;
 import com.sk89q.jnbt.Tag;
+import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -260,6 +262,12 @@ public class MemoryOptimizedClipboard extends LinearClipboard {
         values.put("z", new IntTag(z));
         nbtMap.put(new IntTriple(x, y, z), new CompoundTag(values));
         return true;
+    }
+
+    @Override
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tile) throws WorldEditException {
+        // TODO replace
+        return setTile(x, y, z, new CompoundTag(tile.linTag()));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ReadOnlyClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ReadOnlyClipboard.java
@@ -1,7 +1,7 @@
 package com.fastasyncworldedit.core.extent.clipboard;
 
 import com.fastasyncworldedit.core.Fawe;
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
@@ -106,7 +106,7 @@ public abstract class ReadOnlyClipboard extends SimpleClipboard {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tag) {
+    public boolean tile(int x, int y, int z, FaweCompoundTag tag) {
         throw new UnsupportedOperationException("Clipboard is immutable");
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/io/FastSchematicReaderV3.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/io/FastSchematicReaderV3.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.core.extent.clipboard.SimpleClipboard;
 import com.fastasyncworldedit.core.internal.io.ResettableFileInputStream;
 import com.fastasyncworldedit.core.internal.io.VarIntStreamIterator;
 import com.fastasyncworldedit.core.math.MutableBlockVector3;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.util.IOUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.sk89q.jnbt.CompoundTag;
@@ -626,12 +627,11 @@ public class FastSchematicReaderV3 implements ClipboardReader {
     }
 
     private EntityTransformer provideTileEntityTransformer(Clipboard clipboard) {
-        //noinspection deprecation
-        return (x, y, z, id, tag) -> clipboard.setTile(
+        return (x, y, z, id, tag) -> clipboard.tile(
                 MathMan.roundInt(x + clipboard.getMinimumPoint().x()),
                 MathMan.roundInt(y + clipboard.getMinimumPoint().y()),
                 MathMan.roundInt(z + clipboard.getMinimumPoint().z()),
-                new CompoundTag(tag)
+                FaweCompoundTag.of(tag)
         );
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/block/ArrayFilterBlock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/block/ArrayFilterBlock.java
@@ -1,5 +1,6 @@
 package com.fastasyncworldedit.core.extent.filter.block;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.extent.Extent;
@@ -103,6 +104,11 @@ public class ArrayFilterBlock extends AbstractExtentFilterBlock {
     public <T extends BlockStateHolder<T>> boolean setBlock(int x, int y, int z, T block)
             throws WorldEditException {
         return getExtent().setBlock(x, y, z, block);
+    }
+
+    @Override
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tile) throws WorldEditException {
+        return false; // class is unused + deprecated, do not care about impl
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/block/FilterBlock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/block/FilterBlock.java
@@ -1,5 +1,6 @@
 package com.fastasyncworldedit.core.extent.filter.block;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.blocks.TileEntityBlock;
@@ -36,17 +37,6 @@ public abstract class FilterBlock extends BlockVector3 implements Extent, TileEn
     public abstract BiomeType getBiome();
 
     @Override
-    public abstract CompoundTag getNbtData();
-
-    @Override
-    public abstract void setNbtData(@Nullable CompoundTag nbtData);
-
-    @Override
-    public boolean hasNbtData() {
-        return getNbtData() != null;
-    }
-
-    @Override
     public BlockVector3 getMinimumPoint() {
         return getExtent().getMinimumPoint();
     }
@@ -61,10 +51,9 @@ public abstract class FilterBlock extends BlockVector3 implements Extent, TileEn
         return getExtent().getBlock(x, y, z);
     }
 
-
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
-        return getExtent().setTile(x, y, z, tile);
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tile) throws WorldEditException {
+        return getExtent().tile(x, y, z, tile);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -35,8 +35,8 @@ import com.sk89q.worldedit.world.block.BlockTypesCache;
 import org.apache.logging.log4j.Logger;
 import org.enginehub.linbus.tree.LinCompoundTag;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
@@ -248,7 +248,7 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     }
 
     @SuppressWarnings({"deprecation"})
-    private static @NotNull FaweCompoundTag adapt(CompoundTag tag) {
+    private static @Nonnull FaweCompoundTag adapt(CompoundTag tag) {
         return FaweCompoundTag.of(tag.toLinTag());
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -4,11 +4,12 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.extent.HistoryExtent;
 import com.fastasyncworldedit.core.extent.processor.ProcessorScope;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunk;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
-import com.fastasyncworldedit.core.util.MainUtil;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.util.concurrent.Futures;
 import com.sk89q.jnbt.CompoundTag;
@@ -32,9 +33,12 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import org.apache.logging.log4j.Logger;
+import org.enginehub.linbus.tree.LinCompoundTag;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -123,37 +127,38 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
         int bx = chunk.getX() << 4;
         int bz = chunk.getZ() << 4;
 
-        Map<BlockVector3, CompoundTag> tilesFrom = get.getTiles();
-        Map<BlockVector3, CompoundTag> tilesTo = set.getTiles();
+        Map<BlockVector3, FaweCompoundTag> tilesFrom = get.tiles();
+        Map<BlockVector3, FaweCompoundTag> tilesTo = set.tiles();
         if (!tilesFrom.isEmpty()) {
-            for (Map.Entry<BlockVector3, CompoundTag> entry : tilesFrom.entrySet()) {
+            for (Map.Entry<BlockVector3, FaweCompoundTag> entry : tilesFrom.entrySet()) {
                 BlockVector3 pos = entry.getKey();
                 BlockState fromBlock = get.getBlock(pos.x() & 15, pos.y(), pos.z() & 15);
                 BlockState toBlock = set.getBlock(pos.x() & 15, pos.y(), pos.z() & 15);
                 if (fromBlock != toBlock || tilesTo.containsKey(pos)) {
-                    addTileRemove(MainUtil.setPosition(entry.getValue(), entry.getKey().x(), entry.getKey().y(),
-                            entry.getKey().z()));
+                    addTileRemove(NbtUtils.withPosition(entry.getValue(), entry.getKey().x(), entry.getKey().y(),
+                            entry.getKey().z()
+                    ));
                 }
             }
         }
         if (!tilesTo.isEmpty()) {
-            for (Map.Entry<BlockVector3, CompoundTag> entry : tilesTo.entrySet()) {
+            for (Map.Entry<BlockVector3, FaweCompoundTag> entry : tilesTo.entrySet()) {
                 BlockVector3 pos = entry.getKey();
-                addTileCreate(MainUtil.setPosition(entry.getValue(), pos.x() + bx, pos.y(), pos.z() + bz));
+                addTileCreate(NbtUtils.withPosition(entry.getValue(), pos.x() + bx, pos.y(), pos.z() + bz));
             }
         }
         Set<UUID> entRemoves = set.getEntityRemoves();
         if (!entRemoves.isEmpty()) {
             for (UUID uuid : entRemoves) {
-                CompoundTag found = get.getEntity(uuid);
+                FaweCompoundTag found = get.entity(uuid);
                 if (found != null) {
                     addEntityRemove(found);
                 }
             }
         }
-        Set<CompoundTag> ents = set.getEntities();
+        Collection<FaweCompoundTag> ents = set.entities();
         if (!ents.isEmpty()) {
-            for (CompoundTag tag : ents) {
+            for (FaweCompoundTag tag : ents) {
                 addEntityCreate(tag);
             }
         }
@@ -204,9 +209,9 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
                 BiomeType[] biomeSection = biomes[layer - set.getMinSectionPosition()];
                 int index = 0;
                 int yy = layer << 4;
-                for (int y = 0; y < 16; y+= 4) {
-                    for (int z = 0; z < 16; z+= 4) {
-                        for (int x = 0; x < 16; x+= 4, index++) {
+                for (int y = 0; y < 16; y += 4) {
+                    for (int z = 0; z < 16; z += 4) {
+                        for (int x = 0; x < 16; x += 4, index++) {
                             BiomeType newBiome = biomeSection[index];
                             if (newBiome != null) {
                                 BiomeType oldBiome = get.getBiomeType(x, yy + y, z);
@@ -237,13 +242,62 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
         return ProcessorScope.READING_SET_BLOCKS;
     }
 
-    public abstract void addTileCreate(CompoundTag tag);
+    @Deprecated(forRemoval = true, since = "TODO")
+    public void addTileCreate(CompoundTag tag) {
+        addTileCreate(adapt(tag));
+    }
 
-    public abstract void addTileRemove(CompoundTag tag);
+    @SuppressWarnings({"deprecation"})
+    private static @NotNull FaweCompoundTag adapt(CompoundTag tag) {
+        return FaweCompoundTag.of(tag.toLinTag());
+    }
 
-    public abstract void addEntityRemove(CompoundTag tag);
+    /**
+     * Creates a tile/block entity create change to this change set.
+     *
+     * @param tag the tile/block entity to add.
+     * @since TODO
+     */
+    public abstract void addTileCreate(FaweCompoundTag tag);
 
-    public abstract void addEntityCreate(CompoundTag tag);
+    @Deprecated(forRemoval = true, since = "TODO")
+    public void addTileRemove(CompoundTag tag) {
+        addTileRemove(adapt(tag));
+    }
+
+    /**
+     * Creates a tile/block entity remove change to this change set.
+     *
+     * @param tag the tile/block entity to remove.
+     * @since TODO
+     */
+    public abstract void addTileRemove(FaweCompoundTag tag);
+
+    @Deprecated(forRemoval = true, since = "TODO")
+    public void addEntityRemove(CompoundTag tag) {
+        addEntityRemove(adapt(tag));
+    }
+
+    /**
+     * Creates an entity remove change to this change set.
+     *
+     * @param tag the entity to remove.
+     * @since TODO
+     */
+    public abstract void addEntityRemove(FaweCompoundTag tag);
+
+    @Deprecated(forRemoval = true, since = "TODO")
+    public void addEntityCreate(CompoundTag tag) {
+        addEntityCreate(adapt(tag));
+    }
+
+    /**
+     * Creates an entity create change to this change set.
+     *
+     * @param tag the entity to add.
+     * @since TODO
+     */
+    public abstract void addEntityCreate(FaweCompoundTag tag);
 
     public abstract void addBiomeChange(int x, int y, int z, BiomeType from, BiomeType to);
 
@@ -280,13 +334,15 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     }
 
     public void add(EntityCreate change) {
-        CompoundTag tag = change.state.getNbtData();
-        addEntityCreate(MainUtil.setEntityInfo(tag, change.getEntity()));
+        LinCompoundTag tag = change.state.getNbt();
+        assert tag != null;
+        addEntityCreate(FaweCompoundTag.of(NbtUtils.withEntityInfo(tag, change.getEntity())));
     }
 
     public void add(EntityRemove change) {
-        CompoundTag tag = change.state.getNbtData();
-        addEntityRemove(MainUtil.setEntityInfo(tag, change.getEntity()));
+        LinCompoundTag tag = change.state.getNbt();
+        assert tag != null;
+        addEntityRemove(FaweCompoundTag.of(NbtUtils.withEntityInfo(tag, change.getEntity())));
     }
 
     @Override
@@ -304,9 +360,9 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
 
     public void add(BlockChange change) {
         try {
-            BlockVector3 loc = change.getPosition();
+            BlockVector3 loc = change.position();
             BaseBlock from = change.previous();
-            BaseBlock to = change.getCurrent();
+            BaseBlock to = change.current();
             add(loc, from, to);
         } catch (Exception e) {
             LOGGER.catching(e);
@@ -326,31 +382,28 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
 
     public void add(int x, int y, int z, BaseBlock from, BaseBlock to) {
         try {
-            if (from.hasNbtData()) {
-                CompoundTag nbt = from.getNbtData();
-                assert nbt != null;
-                addTileRemove(MainUtil.setPosition(nbt, x, y, z));
+            LinCompoundTag nbt = from.getNbt();
+            if (nbt != null) {
+                addTileRemove(FaweCompoundTag.of(NbtUtils.withPosition(nbt, x, y, z)));
             }
-            if (to.hasNbtData()) {
-                CompoundTag nbt = to.getNbtData();
-                assert nbt != null;
-                addTileCreate(MainUtil.setPosition(nbt, x, y, z));
+            nbt = to.getNbt();
+            if (nbt != null) {
+                addTileCreate(FaweCompoundTag.of(NbtUtils.withPosition(nbt, x, y, z)));
             }
             int combinedFrom = from.getOrdinal();
             int combinedTo = to.getOrdinal();
             add(x, y, z, combinedFrom, combinedTo);
 
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.catching(e);
         }
     }
 
     public void add(int x, int y, int z, int combinedFrom, BaseBlock to) {
         try {
-            if (to.hasNbtData()) {
-                CompoundTag nbt = to.getNbtData();
-                assert nbt != null;
-                addTileCreate(MainUtil.setPosition(nbt, x, y, z));
+            LinCompoundTag nbt = to.getNbt();
+            if (nbt != null) {
+                addTileCreate(FaweCompoundTag.of(NbtUtils.withPosition(nbt, x, y, z)));
             }
             int combinedTo = to.getInternalId();
             add(x, y, z, combinedFrom, combinedTo);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractDelegateChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractDelegateChangeSet.java
@@ -1,6 +1,6 @@
 package com.fastasyncworldedit.core.history.changeset;
 
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
@@ -44,26 +44,6 @@ public class AbstractDelegateChangeSet extends AbstractChangeSet {
     @Override
     public void flush() {
         parent.flush();
-    }
-
-    @Override
-    public void addTileCreate(CompoundTag tag) {
-        parent.addTileCreate(tag);
-    }
-
-    @Override
-    public void addTileRemove(CompoundTag tag) {
-        parent.addTileRemove(tag);
-    }
-
-    @Override
-    public void addEntityRemove(CompoundTag tag) {
-        parent.addEntityRemove(tag);
-    }
-
-    @Override
-    public void addEntityCreate(CompoundTag tag) {
-        parent.addEntityCreate(tag);
     }
 
     @Override
@@ -144,6 +124,26 @@ public class AbstractDelegateChangeSet extends AbstractChangeSet {
     @Override
     public Iterator<Change> forwardIterator() {
         return parent.forwardIterator();
+    }
+
+    @Override
+    public void addTileCreate(final FaweCompoundTag tag) {
+        parent.addTileCreate(tag);
+    }
+
+    @Override
+    public void addTileRemove(final FaweCompoundTag tag) {
+        parent.addTileRemove(tag);
+    }
+
+    @Override
+    public void addEntityRemove(final FaweCompoundTag tag) {
+        parent.addEntityRemove(tag);
+    }
+
+    @Override
+    public void addEntityCreate(final FaweCompoundTag tag) {
+        parent.addEntityCreate(tag);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/BlockBagChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/BlockBagChangeSet.java
@@ -1,8 +1,6 @@
 package com.fastasyncworldedit.core.history.changeset;
 
 import com.fastasyncworldedit.core.FaweCache;
-import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.extent.inventory.BlockBagException;
 import com.sk89q.worldedit.extent.inventory.UnplaceableBlockException;
@@ -107,15 +105,6 @@ public class BlockBagChangeSet extends AbstractDelegateChangeSet {
         BlockType typeTo = BlockTypes.getFromStateId(combinedTo);
         check(typeFrom, typeTo);
         super.add(x, y, z, combinedFrom, combinedTo);
-    }
-
-    @Override
-    public void addTileCreate(CompoundTag nbt) {
-        if (nbt.containsKey("items")) {
-            Map<String, Tag<?, ?>> map = new HashMap<>(nbt.getValue());
-            map.remove("items");
-        }
-        super.addTileCreate(nbt);
     }
 
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
@@ -10,6 +10,7 @@ import com.fastasyncworldedit.core.history.change.MutableTileChange;
 import com.fastasyncworldedit.core.internal.exception.FaweSmallEditUnsupportedException;
 import com.fastasyncworldedit.core.internal.io.FaweInputStream;
 import com.fastasyncworldedit.core.internal.io.FaweOutputStream;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.util.MainUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.sk89q.jnbt.CompoundTag;
@@ -21,9 +22,12 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockTypes;
+import org.enginehub.linbus.stream.LinBinaryIO;
+import org.enginehub.linbus.tree.LinRootEntry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.DataOutput;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -398,56 +402,44 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
     }
 
     @Override
-    public void addTileCreate(CompoundTag tag) {
-        if (tag == null) {
-            return;
-        }
+    public void addTileCreate(final FaweCompoundTag tag) {
         blockSize++;
         try {
-            NBTOutputStream nbtos = getTileCreateOS();
-            nbtos.writeTag(tag);
+            DataOutput nbtos = getTileCreateOS();
+            LinBinaryIO.write(nbtos, new LinRootEntry("tile-create", tag.linTag()));
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
     @Override
-    public void addTileRemove(CompoundTag tag) {
-        if (tag == null) {
-            return;
-        }
+    public void addTileRemove(final FaweCompoundTag tag) {
         blockSize++;
         try {
-            NBTOutputStream nbtos = getTileRemoveOS();
-            nbtos.writeTag(tag);
+            DataOutput nbtos = getTileRemoveOS();
+            LinBinaryIO.write(nbtos, new LinRootEntry("tile-remove", tag.linTag()));
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
     @Override
-    public void addEntityRemove(CompoundTag tag) {
-        if (tag == null) {
-            return;
-        }
+    public void addEntityRemove(final FaweCompoundTag tag) {
         blockSize++;
         try {
-            NBTOutputStream nbtos = getEntityRemoveOS();
-            nbtos.writeTag(tag);
+            DataOutput nbtos = getEntityRemoveOS();
+            LinBinaryIO.write(nbtos, new LinRootEntry("entity-remove", tag.linTag()));
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
     @Override
-    public void addEntityCreate(CompoundTag tag) {
-        if (tag == null) {
-            return;
-        }
+    public void addEntityCreate(final FaweCompoundTag tag) {
         blockSize++;
         try {
-            NBTOutputStream nbtos = getEntityCreateOS();
-            nbtos.writeTag(tag);
+            DataOutput nbtos = getEntityCreateOS();
+            LinBinaryIO.write(nbtos, new LinRootEntry("entity-create", tag.linTag()));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/NullChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/NullChangeSet.java
@@ -1,6 +1,6 @@
 package com.fastasyncworldedit.core.history.changeset;
 
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.extent.inventory.BlockBag;
 import com.sk89q.worldedit.history.change.Change;
 import com.sk89q.worldedit.world.World;
@@ -25,22 +25,22 @@ public class NullChangeSet extends AbstractChangeSet {
     }
 
     @Override
-    public final void addTileCreate(CompoundTag tag) {
+    public void addTileCreate(final FaweCompoundTag tag) {
 
     }
 
     @Override
-    public final void addTileRemove(CompoundTag tag) {
+    public void addTileRemove(final FaweCompoundTag tag) {
 
     }
 
     @Override
-    public final void addEntityRemove(CompoundTag tag) {
+    public void addEntityRemove(final FaweCompoundTag tag) {
 
     }
 
     @Override
-    public final void addEntityCreate(CompoundTag tag) {
+    public void addEntityCreate(final FaweCompoundTag tag) {
 
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/nbt/EagerFaweCompoundTag.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/nbt/EagerFaweCompoundTag.java
@@ -1,0 +1,7 @@
+package com.fastasyncworldedit.core.nbt;
+
+import org.enginehub.linbus.tree.LinCompoundTag;
+
+record EagerFaweCompoundTag(LinCompoundTag linTag) implements FaweCompoundTag {
+
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/nbt/FaweCompoundTag.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/nbt/FaweCompoundTag.java
@@ -1,0 +1,44 @@
+package com.fastasyncworldedit.core.nbt;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.sk89q.worldedit.util.concurrency.LazyReference;
+import org.enginehub.linbus.tree.LinCompoundTag;
+
+/**
+ * A wrapper around compound tags, potentially lazily transformed.
+ * @since TODO
+ */
+public sealed interface FaweCompoundTag permits EagerFaweCompoundTag, LazyFaweCompoundTag {
+
+    /**
+     * {@return a lazy compound component backed by a lazy reference}
+     * @param lazyReference the lazy reference to the actual compound tag
+     */
+    static FaweCompoundTag of(LazyReference<? extends LinCompoundTag> lazyReference) {
+        return new LazyFaweCompoundTag(lazyReference::getValue);
+    }
+
+    /**
+     * {@return a lazy compound component backed by a supplier}
+     * Invocations to the supplier are memoized.
+     * @param supplier the supplier for the actual compound tag
+     */
+    static FaweCompoundTag of(Supplier<? extends LinCompoundTag> supplier) {
+        return new LazyFaweCompoundTag(Suppliers.memoize(supplier));
+    }
+
+    /**
+     * {@return a direct reference tho the given compound tag}
+     * @param linCompoundTag the tag to wrap
+     */
+    static FaweCompoundTag of(LinCompoundTag linCompoundTag) {
+        return new EagerFaweCompoundTag(linCompoundTag);
+    }
+
+    /**
+     * {@return the underlying tag}
+     */
+    LinCompoundTag linTag();
+
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/nbt/LazyFaweCompoundTag.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/nbt/LazyFaweCompoundTag.java
@@ -1,0 +1,14 @@
+package com.fastasyncworldedit.core.nbt;
+
+import org.enginehub.linbus.tree.LinCompoundTag;
+
+import java.util.function.Supplier;
+
+record LazyFaweCompoundTag(Supplier<? extends LinCompoundTag> linTagSupplier) implements FaweCompoundTag {
+
+    @Override
+    public LinCompoundTag linTag() {
+        return this.linTagSupplier().get();
+    }
+
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBlocks.java
@@ -13,8 +13,8 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import com.sk89q.worldedit.world.registry.BlockRegistry;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collection;
@@ -76,7 +76,7 @@ public interface IBlocks extends Trimable {
     }
 
     @SuppressWarnings({"deprecation"})
-    private static @NotNull CompoundTag toCompoundTag(FaweCompoundTag tile) {
+    private static @Nonnull CompoundTag toCompoundTag(FaweCompoundTag tile) {
         return new CompoundTag(tile.linTag());
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBlocks.java
@@ -3,6 +3,8 @@ package com.fastasyncworldedit.core.queue;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.internal.io.FastByteArrayOutputStream;
 import com.fastasyncworldedit.core.internal.io.FaweOutputStream;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
+import com.fastasyncworldedit.core.util.collection.AdaptedMap;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Capability;
@@ -11,11 +13,14 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import com.sk89q.worldedit.world.registry.BlockRegistry;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -54,11 +59,38 @@ public interface IBlocks extends Trimable {
 
     BlockState getBlock(int x, int y, int z);
 
-    Map<BlockVector3, CompoundTag> getTiles();
+    @Deprecated(forRemoval = true, since = "TODO")
+    default Map<BlockVector3, CompoundTag> getTiles() {
+        return AdaptedMap.immutable(tiles(), pos -> pos, IBlocks::toCompoundTag);
+    }
 
-    CompoundTag getTile(int x, int y, int z);
+    Map<BlockVector3, FaweCompoundTag> tiles();
 
-    Set<CompoundTag> getEntities();
+    @Deprecated(forRemoval = true, since = "TODO")
+    default CompoundTag getTile(int x, int y, int z) {
+        final FaweCompoundTag tile = tile(x, y, z);
+        if (tile == null) {
+            return null;
+        }
+        return toCompoundTag(tile);
+    }
+
+    @SuppressWarnings({"deprecation"})
+    private static @NotNull CompoundTag toCompoundTag(FaweCompoundTag tile) {
+        return new CompoundTag(tile.linTag());
+    }
+
+    @Nullable
+    FaweCompoundTag tile(int x, int y, int z);
+
+    @Deprecated(forRemoval = true, since = "TODO")
+    default Set<CompoundTag> getEntities() {
+        return entities().stream()
+                .map(IBlocks::toCompoundTag)
+                .collect(Collectors.toSet());
+    }
+
+    Collection<FaweCompoundTag> entities();
 
     BiomeType getBiomeType(int x, int y, int z);
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkExtent.java
@@ -1,11 +1,7 @@
 package com.fastasyncworldedit.core.queue;
 
-import com.sk89q.jnbt.CompoundTag;
-import com.sk89q.jnbt.DoubleTag;
-import com.sk89q.jnbt.ListTag;
-import com.sk89q.jnbt.NBTUtils;
-import com.sk89q.jnbt.StringTag;
-import com.sk89q.jnbt.Tag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
@@ -16,6 +12,12 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
+import org.enginehub.linbus.tree.LinCompoundTag;
+import org.enginehub.linbus.tree.LinDoubleTag;
+import org.enginehub.linbus.tree.LinListTag;
+import org.enginehub.linbus.tree.LinStringTag;
+import org.enginehub.linbus.tree.LinTag;
+import org.enginehub.linbus.tree.LinTagType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -39,9 +41,9 @@ public interface IChunkExtent<T extends IChunk> extends Extent {
     }
 
     @Override
-    default boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
+    default boolean tile(int x, int y, int z, FaweCompoundTag tile) throws WorldEditException {
         final IChunk chunk = getOrCreateChunk(x >> 4, z >> 4);
-        return chunk.setTile(x & 15, y, z & 15, tile);
+        return chunk.tile(x & 15, y, z & 15, tile);
     }
 
     @Override
@@ -124,19 +126,19 @@ public interface IChunkExtent<T extends IChunk> extends Extent {
     @Override
     default Entity createEntity(Location location, BaseEntity entity, UUID uuid) {
         final IChunk chunk = getOrCreateChunk(location.getBlockX() >> 4, location.getBlockZ() >> 4);
-        Map<String, Tag<?, ?>> map = new HashMap<>(entity.getNbtData().getValue()); //do not modify original entity data
-        map.put("Id", new StringTag(entity.getType().getName()));
+        Map<String, LinTag<?>> map = new HashMap<>(entity.getNbt().value()); //do not modify original entity data
+        map.put("Id", LinStringTag.of(entity.getType().getName()));
 
         //Set pos
-        List<DoubleTag> posList = new ArrayList<>();
-        posList.add(new DoubleTag(location.x()));
-        posList.add(new DoubleTag(location.y()));
-        posList.add(new DoubleTag(location.z()));
-        map.put("Pos", new ListTag(DoubleTag.class, posList));
+        List<LinDoubleTag> posList = new ArrayList<>();
+        posList.add(LinDoubleTag.of(location.x()));
+        posList.add(LinDoubleTag.of(location.y()));
+        posList.add(LinDoubleTag.of(location.z()));
+        map.put("Pos", LinListTag.of(LinTagType.doubleTag(), posList));
 
-        NBTUtils.addUUIDToMap(map, uuid);
+        NbtUtils.addUUIDToMap(map, uuid);
 
-        chunk.setEntity(new CompoundTag(map));
+        chunk.entity(FaweCompoundTag.of(LinCompoundTag.of(map)));
         return new IChunkEntity(this, location, uuid, entity);
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkGet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkGet.java
@@ -1,6 +1,7 @@
 package com.fastasyncworldedit.core.queue;
 
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.extent.InputExtent;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -46,7 +47,26 @@ public interface IChunkGet extends IBlocks, Trimable, InputExtent, ITileInput {
 
     <T extends Future<T>> T call(IChunkSet set, Runnable finalize);
 
-    CompoundTag getEntity(UUID uuid);
+    @Deprecated(forRemoval = true, since = "TODO")
+    default CompoundTag getEntity(UUID uuid) {
+        final FaweCompoundTag entity = entity(uuid);
+        if (entity == null) {
+            return null;
+        }
+        return new CompoundTag(entity.linTag());
+    }
+
+    /**
+     * {@return the compound tag describing the entity with the given UUID, if any}
+     * @param uuid the uuid of the entity
+     */
+    @Nullable FaweCompoundTag entity(UUID uuid);
+
+    @Override
+    @Deprecated(forRemoval = true, since = "TODO")
+    default CompoundTag getTile(int x, int y, int z) {
+        return IBlocks.super.getTile(x, y, z);
+    }
 
     boolean isCreateCopy();
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkSet.java
@@ -1,7 +1,9 @@
 package com.fastasyncworldedit.core.queue;
 
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.extent.OutputExtent;
 import com.sk89q.worldedit.function.operation.Operation;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -36,7 +38,12 @@ public interface IChunkSet extends IBlocks, OutputExtent {
     boolean isEmpty();
 
     @Override
-    boolean setTile(int x, int y, int z, CompoundTag tile);
+    @Deprecated(forRemoval = true, since = "TODO")
+    default boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
+        return tile(x, y, z, FaweCompoundTag.of(tile.toLinTag()));
+    }
+
+    boolean tile(int x, int y, int z, FaweCompoundTag tag);
 
     @Override
     void setBlockLight(int x, int y, int z, int value);
@@ -53,7 +60,12 @@ public interface IChunkSet extends IBlocks, OutputExtent {
 
     void setFullBright(int layer);
 
-    void setEntity(CompoundTag tag);
+    @Deprecated(forRemoval = true, since = "TODO")
+    default void setEntity(CompoundTag tag) {
+        entity(FaweCompoundTag.of(tag::toLinTag));
+    }
+
+    void entity(FaweCompoundTag tag);
 
     void removeEntity(UUID uuid);
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/ITileInput.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/ITileInput.java
@@ -2,6 +2,7 @@ package com.fastasyncworldedit.core.queue;
 
 import com.sk89q.jnbt.CompoundTag;
 
+@Deprecated(forRemoval = true, since = "TODO")
 public interface ITileInput {
 
     CompoundTag getTile(int x, int y, int z);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/BitSetBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/BitSetBlocks.java
@@ -2,9 +2,9 @@ package com.fastasyncworldedit.core.queue.implementation.blocks;
 
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.util.collection.MemBlockSet;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -13,6 +13,7 @@ import com.sk89q.worldedit.world.block.BlockTypesCache;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -74,7 +75,7 @@ public class BitSetBlocks implements IChunkSet {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) {
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tag) {
         return false;
     }
 
@@ -107,7 +108,7 @@ public class BitSetBlocks implements IChunkSet {
     }
 
     @Override
-    public void setEntity(CompoundTag tag) {
+    public void entity(final FaweCompoundTag tag) {
     }
 
     @Override
@@ -181,18 +182,18 @@ public class BitSetBlocks implements IChunkSet {
     }
 
     @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
         return Collections.emptyMap();
     }
 
     @Override
-    public CompoundTag getTile(int x, int y, int z) {
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
         return null;
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
-        return Collections.emptySet();
+    public Collection<FaweCompoundTag> entities() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharGetBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharGetBlocks.java
@@ -1,5 +1,6 @@
 package com.fastasyncworldedit.core.queue.implementation.blocks;
 
+import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.sk89q.worldedit.world.block.BaseBlock;
@@ -20,7 +21,7 @@ public abstract class CharGetBlocks extends CharBlocks implements IChunkGet {
     @Override
     public BaseBlock getFullBlock(int x, int y, int z) {
         BlockState state = BlockTypesCache.states[get(x, y, z)];
-        return state.toBaseBlock(this, x, y, z);
+        return state.toBaseBlock((IBlocks) this, x, y, z);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
@@ -12,8 +12,8 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java
@@ -4,16 +4,18 @@ import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
 import com.fastasyncworldedit.core.math.BlockVector3ChunkMap;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.queue.Pool;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -36,8 +38,8 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     public BiomeType[][] biomes;
     public char[][] light;
     public char[][] skyLight;
-    public BlockVector3ChunkMap<CompoundTag> tiles;
-    public HashSet<CompoundTag> entities;
+    public BlockVector3ChunkMap<FaweCompoundTag> tiles;
+    public HashSet<FaweCompoundTag> entities;
     public HashSet<UUID> entityRemoves;
     public EnumMap<HeightMapType, int[]> heightMaps;
     private boolean fastMode = false;
@@ -71,17 +73,17 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     }
 
     @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
         return tiles == null ? Collections.emptyMap() : tiles;
     }
 
     @Override
-    public CompoundTag getTile(int x, int y, int z) {
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
         return tiles == null ? null : tiles.get(x, y, z);
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
+    public Collection<FaweCompoundTag> entities() {
         return entities == null ? Collections.emptySet() : entities;
     }
 
@@ -132,12 +134,12 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) {
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tag) {
         if (tiles == null) {
             tiles = new BlockVector3ChunkMap<>();
         }
         updateSectionIndexRange(y >> 4);
-        tiles.put(x, y, z, tile);
+        tiles.put(x, y, z, tag);
         return true;
     }
 
@@ -259,7 +261,7 @@ public class CharSetBlocks extends CharBlocks implements IChunkSet {
     }
 
     @Override
-    public void setEntity(CompoundTag tag) {
+    public void entity(final FaweCompoundTag tag) {
         if (entities == null) {
             entities = new HashSet<>();
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/NullChunkGet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/NullChunkGet.java
@@ -2,10 +2,10 @@ package com.fastasyncworldedit.core.queue.implementation.blocks;
 
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.biome.BiomeTypes;
@@ -15,9 +15,9 @@ import com.sk89q.worldedit.world.block.BlockTypes;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Future;
 
@@ -48,24 +48,19 @@ public final class NullChunkGet implements IChunkGet {
         return BlockTypes.AIR.getDefaultState();
     }
 
-    @Nonnull
-    public Map<BlockVector3, CompoundTag> getTiles() {
+    @Override
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
         return Collections.emptyMap();
     }
 
-    @Nullable
-    public CompoundTag getTile(int x, int y, int z) {
+    @Override
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
         return null;
     }
 
-    @Nullable
-    public Set<CompoundTag> getEntities() {
-        return null;
-    }
-
-    @Nullable
-    public CompoundTag getEntity(@Nonnull UUID uuid) {
-        return null;
+    @Override
+    public Collection<FaweCompoundTag> entities() {
+        return Collections.emptyList();
     }
 
     @Override
@@ -120,6 +115,11 @@ public final class NullChunkGet implements IChunkGet {
 
     @Nullable
     public <T extends Future<T>> T call(@Nonnull IChunkSet set, @Nonnull Runnable finalize) {
+        return null;
+    }
+
+    @Override
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
         return null;
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/ThreadUnsafeCharBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/ThreadUnsafeCharBlocks.java
@@ -4,9 +4,9 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
 import com.fastasyncworldedit.core.math.BlockVector3ChunkMap;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.IChunkSet;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -44,8 +45,8 @@ public class ThreadUnsafeCharBlocks implements IChunkSet, IBlocks {
     private BiomeType[][] biomes;
     private char[][] light;
     private char[][] skyLight;
-    private BlockVector3ChunkMap<CompoundTag> tiles;
-    private HashSet<CompoundTag> entities;
+    private BlockVector3ChunkMap<FaweCompoundTag> tiles;
+    private HashSet<FaweCompoundTag> entities;
     private HashSet<UUID> entityRemoves;
     private Map<HeightMapType, int[]> heightMaps;
     private boolean fastMode;
@@ -64,8 +65,8 @@ public class ThreadUnsafeCharBlocks implements IChunkSet, IBlocks {
             int sectionCount,
             char[][] light,
             char[][] skyLight,
-            BlockVector3ChunkMap<CompoundTag> tiles,
-            HashSet<CompoundTag> entities,
+            BlockVector3ChunkMap<FaweCompoundTag> tiles,
+            HashSet<FaweCompoundTag> entities,
             HashSet<UUID> entityRemoves,
             Map<HeightMapType, int[]> heightMaps,
             char defaultOrdinal,
@@ -116,18 +117,18 @@ public class ThreadUnsafeCharBlocks implements IChunkSet, IBlocks {
     }
 
     @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
         return tiles == null ? Collections.emptyMap() : tiles;
     }
 
     @Override
-    public CompoundTag getTile(int x, int y, int z) {
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
         return tiles == null ? null : tiles.get(x, y, z);
     }
 
     @Override
-    public Set<CompoundTag> getEntities() {
-        return entities == null ? Collections.emptySet() : entities;
+    public Collection<FaweCompoundTag> entities() {
+        return entities == null ? Collections.emptyList() : entities;
     }
 
     @Override
@@ -268,12 +269,12 @@ public class ThreadUnsafeCharBlocks implements IChunkSet, IBlocks {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) {
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tag) {
         updateSectionIndexRange(y >> 4);
         if (tiles == null) {
             tiles = new BlockVector3ChunkMap<>();
         }
-        tiles.put(x, y, z, tile);
+        tiles.put(x, y, z, tag);
         return true;
     }
 
@@ -358,7 +359,7 @@ public class ThreadUnsafeCharBlocks implements IChunkSet, IBlocks {
     }
 
     @Override
-    public void setEntity(CompoundTag tag) {
+    public void entity(final FaweCompoundTag tag) {
         if (entities == null) {
             entities = new HashSet<>();
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -3,6 +3,7 @@ package com.fastasyncworldedit.core.queue.implementation.chunk;
 import com.fastasyncworldedit.core.extent.filter.block.ChunkFilterBlock;
 import com.fastasyncworldedit.core.extent.processor.EmptyBatchProcessor;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.Filter;
 import com.fastasyncworldedit.core.queue.IChunk;
 import com.fastasyncworldedit.core.queue.IChunkGet;
@@ -11,7 +12,6 @@ import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.fastasyncworldedit.core.queue.implementation.ParallelQueueExtent;
 import com.fastasyncworldedit.core.util.MemUtil;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
@@ -22,6 +22,7 @@ import com.sk89q.worldedit.world.block.BlockStateHolder;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -76,18 +77,8 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tag) {
-        return delegate.set(this).setTile(x, y, z, tag);
-    }
-
-    @Override
-    public CompoundTag getTile(int x, int y, int z) {
-        return delegate.set(this).getTile(x, y, z);
-    }
-
-    @Override
-    public void setEntity(CompoundTag tag) {
-        delegate.set(this).setEntity(tag);
+    public void entity(final FaweCompoundTag tag) {
+        delegate.set(this).entity(tag);
     }
 
     @Override
@@ -161,11 +152,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
 
     public boolean isInit() {
         return isInit;
-    }
-
-    @Override
-    public CompoundTag getEntity(UUID uuid) {
-        return delegate.get(this).getEntity(uuid);
     }
 
     @Override
@@ -880,16 +866,6 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
     };
 
     @Override
-    public Map<BlockVector3, CompoundTag> getTiles() {
-        return delegate.get(this).getTiles();
-    }
-
-    @Override
-    public Set<CompoundTag> getEntities() {
-        return delegate.get(this).getEntities();
-    }
-
-    @Override
     public boolean hasSection(int layer) {
         return chunkExisting != null && chunkExisting.hasSection(layer);
     }
@@ -944,6 +920,11 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
     @Override
     public boolean isEmpty() {
         return chunkSet == null || chunkSet.isEmpty();
+    }
+
+    @Override
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tag) {
+        return false;
     }
 
     /**
@@ -1094,6 +1075,21 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
     }
 
     @Override
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
+        return delegate.get(this).tiles();
+    }
+
+    @Override
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
+        return delegate.get(this).tile(x, y, z);
+    }
+
+    @Override
+    public Collection<FaweCompoundTag> entities() {
+        return delegate.get(this).entities();
+    }
+
+    @Override
     public BaseBlock getFullBlock(int x, int y, int z) {
         return delegate.getFullBlock(this, x, y, z);
     }
@@ -1156,6 +1152,11 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
     @Override
     public int[] getHeightMap(HeightMapType type) {
         return delegate.getHeightMap(this, type);
+    }
+
+    @Override
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
+        return delegate.get(this).entity(uuid);
     }
 
     public interface IBlockDelegate {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/NullChunk.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/NullChunk.java
@@ -2,10 +2,10 @@ package com.fastasyncworldedit.core.queue.implementation.chunk;
 
 import com.fastasyncworldedit.core.extent.filter.block.ChunkFilterBlock;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.Filter;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.queue.IQueueChunk;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.biome.BiomeType;
@@ -16,6 +16,7 @@ import com.sk89q.worldedit.world.block.BlockTypes;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -53,11 +54,9 @@ public final class NullChunk implements IQueueChunk {
         return false;
     }
 
-    public boolean setTile(int x, int y, int z, @Nonnull CompoundTag tag) {
+    @Override
+    public boolean tile(final int x, final int y, final int z, final FaweCompoundTag tag) {
         return false;
-    }
-
-    public void setEntity(@Nonnull CompoundTag tag) {
     }
 
     public void removeEntity(@Nonnull UUID uuid) {
@@ -112,6 +111,10 @@ public final class NullChunk implements IQueueChunk {
     public void setFullBright(int layer) {
     }
 
+    @Override
+    public void entity(final FaweCompoundTag tag) {
+    }
+
     public void removeSectionLighting(int layer, boolean sky) {
     }
 
@@ -147,25 +150,26 @@ public final class NullChunk implements IQueueChunk {
         return BlockTypes.__RESERVED__.getDefaultState();
     }
 
+    @Override
+    public Map<BlockVector3, FaweCompoundTag> tiles() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public @Nullable FaweCompoundTag tile(final int x, final int y, final int z) {
+        return null;
+    }
+
+    @Override
+    public Collection<FaweCompoundTag> entities() {
+        return Collections.emptyList();
+    }
+
     @Nonnull
     public BaseBlock getFullBlock(int x, int y, int z) {
         return BlockTypes.__RESERVED__.getDefaultState().toBaseBlock();
     }
 
-    @Nonnull
-    public Map<BlockVector3, CompoundTag> getTiles() {
-        return Collections.emptyMap();
-    }
-
-    @Nullable
-    public CompoundTag getTile(int x, int y, int z) {
-        return null;
-    }
-
-    @Nonnull
-    public Set<CompoundTag> getEntities() {
-        return Collections.emptySet();
-    }
 
     @Nullable
     public char[] load(int layer) {
@@ -175,11 +179,6 @@ public final class NullChunk implements IQueueChunk {
     @Nullable
     @Override
     public char[] loadIfPresent(final int layer) {
-        return null;
-    }
-
-    @Nullable
-    public CompoundTag getEntity(@Nonnull UUID uuid) {
         return null;
     }
 
@@ -227,6 +226,11 @@ public final class NullChunk implements IQueueChunk {
 
     @Nullable
     public <T extends Future<T>> T call(@Nullable IChunkSet set, @Nullable Runnable finalize) {
+        return null;
+    }
+
+    @Override
+    public @Nullable FaweCompoundTag entity(final UUID uuid) {
         return null;
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
@@ -34,6 +34,7 @@ import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;
 import org.apache.logging.log4j.Logger;
+import org.enginehub.linbus.tree.LinCompoundTag;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -424,8 +425,10 @@ public class MainUtil {
      * @param y   New Y coordinate
      * @param z   New Z coordinate
      * @return New tag
+     * @deprecated use {@link NbtUtils#withPosition} instead
      */
     @Nonnull
+    @Deprecated(forRemoval = true, since = "TODO")
     public static CompoundTag setPosition(@Nonnull CompoundTag tag, int x, int y, int z) {
         Map<String, Tag<?, ?>> value = new HashMap<>(tag.getValue());
         value.put("x", new IntTag(x));
@@ -440,8 +443,10 @@ public class MainUtil {
      * @param tag    Tag to copy
      * @param entity Entity
      * @return New tag
+     * @deprecated use {@link NbtUtils#withEntityInfo(LinCompoundTag, Entity)} instead
      */
     @Nonnull
+    @Deprecated(forRemoval = true, since = "TODO")
     public static CompoundTag setEntityInfo(@Nonnull CompoundTag tag, @Nonnull Entity entity) {
         Map<String, Tag<?, ?>> map = new HashMap<>(tag.getValue());
         map.put("Id", new StringTag(entity.getState().getType().id()));

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/NbtUtils.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/NbtUtils.java
@@ -1,17 +1,29 @@
 package com.fastasyncworldedit.core.util;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
+import com.sk89q.worldedit.entity.Entity;
+import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.storage.InvalidFormatException;
 import org.enginehub.linbus.tree.LinByteTag;
 import org.enginehub.linbus.tree.LinCompoundTag;
+import org.enginehub.linbus.tree.LinDoubleTag;
+import org.enginehub.linbus.tree.LinIntArrayTag;
 import org.enginehub.linbus.tree.LinIntTag;
+import org.enginehub.linbus.tree.LinListTag;
+import org.enginehub.linbus.tree.LinLongTag;
 import org.enginehub.linbus.tree.LinShortTag;
 import org.enginehub.linbus.tree.LinTag;
 import org.enginehub.linbus.tree.LinTagType;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
-public class NbtUtils {
+public final class NbtUtils {
+
+    private NbtUtils() {
+    }
 
     /**
      * Get child tag of a NBT structure.
@@ -77,6 +89,126 @@ public class NbtUtils {
         Map<String, LinTag<?>> value = new HashMap<>();
         value.putAll(tag.value());
         return value;
+    }
+
+    /**
+     * Tries to extract UUID information from a compound tag
+     *
+     * @param compoundTag the compound tag to extract uuid information from
+     * @return the extracted UUID
+     * @since TODO
+     */
+    public static UUID uuid(FaweCompoundTag compoundTag) {
+        final LinCompoundTag linTag = compoundTag.linTag();
+        {
+            final LinIntArrayTag uuidTag = linTag.findTag("UUID", LinTagType.intArrayTag());
+            if (uuidTag != null) {
+                int[] arr = uuidTag.value();
+                return new UUID((long) arr[0] << 32 | (arr[1] & 0xFFFFFFFFL), (long) arr[2] << 32 | (arr[3] & 0xFFFFFFFFL));
+            }
+        }
+        {
+            final LinLongTag uuidMostTag = linTag.findTag("UUIDMost", LinTagType.longTag());
+            if (uuidMostTag != null) {
+                return new UUID(uuidMostTag.valueAsLong(), linTag.getTag("UUIDLeast", LinTagType.longTag()).valueAsLong());
+            }
+        }
+        {
+            final LinLongTag uuidMostTag = linTag.findTag("WorldUUIDMost", LinTagType.longTag());
+            if (uuidMostTag != null) {
+                return new UUID(uuidMostTag.valueAsLong(), linTag.getTag("WorldUUIDLeast", LinTagType.longTag()).valueAsLong());
+            }
+
+        }
+        {
+            final LinLongTag uuidMostTag = linTag.findTag("PersistentIDMSB", LinTagType.longTag());
+            if (uuidMostTag != null) {
+                return new UUID(uuidMostTag.valueAsLong(), linTag.getTag("PersistentIDLSB", LinTagType.longTag()).valueAsLong());
+            }
+
+        }
+        throw new IllegalArgumentException("no uuid present");
+
+    }
+
+    /**
+     * Create a copy of the tag and modify the (x, y, z) coordinates
+     *
+     * @param tag Tag to copy
+     * @param x   New X coordinate
+     * @param y   New Y coordinate
+     * @param z   New Z coordinate
+     * @return New tag
+     * @since TODO
+     */
+    public static @Nonnull LinCompoundTag withPosition(@Nonnull LinCompoundTag tag, int x, int y, int z) {
+        return tag.toBuilder()
+                .putInt("x", x)
+                .putInt("y", y)
+                .putInt("z", z)
+                .build();
+    }
+
+    /**
+     * Create a copy of the tag and modify the (x, y, z) coordinates
+     *
+     * @param tag Tag to copy
+     * @param x   New X coordinate
+     * @param y   New Y coordinate
+     * @param z   New Z coordinate
+     * @return New tag
+     * @since TODO
+     */
+    public static @Nonnull FaweCompoundTag withPosition(@Nonnull FaweCompoundTag tag, int x, int y, int z) {
+        return FaweCompoundTag.of(withPosition(tag.linTag(), x, y, z));
+    }
+
+    /**
+     * {@return a copy of the given tag with the Id and the Pos of the given entity}
+     *
+     * @param tag    the tag to copy
+     * @param entity the entity to use the Id and the Pos from
+     * @since TODO
+     */
+    public static @Nonnull LinCompoundTag withEntityInfo(@Nonnull LinCompoundTag tag, @Nonnull Entity entity) {
+        final LinCompoundTag.Builder builder = tag.toBuilder()
+                .putString("Id", entity.getState().getType().id());
+        LinListTag<LinDoubleTag> pos = tag.findListTag("Pos", LinTagType.doubleTag());
+        if (pos != null) { // TODO why only if pos != null?
+            Location loc = entity.getLocation();
+            final LinListTag<LinDoubleTag> newPos = LinListTag.builder(LinTagType.doubleTag())
+                    .add(LinDoubleTag.of(loc.x()))
+                    .add(LinDoubleTag.of(loc.y()))
+                    .add(LinDoubleTag.of(loc.z()))
+                    .build();
+            builder.put("Pos", newPos);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Adds a UUID to the given map
+     *
+     * @param map  the map to insert to
+     * @param uuid the uuid to insert
+     * @since TODO
+     */
+    public static void addUUIDToMap(Map<String, LinTag<?>> map, UUID uuid) {
+        int[] uuidArray = new int[4];
+        uuidArray[0] = (int) (uuid.getMostSignificantBits() >> 32);
+        uuidArray[1] = (int) uuid.getMostSignificantBits();
+        uuidArray[2] = (int) (uuid.getLeastSignificantBits() >> 32);
+        uuidArray[3] = (int) uuid.getLeastSignificantBits();
+        map.put("UUID", LinIntArrayTag.of(uuidArray));
+
+        map.put("UUIDMost", LinLongTag.of(uuid.getMostSignificantBits()));
+        map.put("UUIDLeast", LinLongTag.of(uuid.getLeastSignificantBits()));
+
+        map.put("WorldUUIDMost", LinLongTag.of(uuid.getMostSignificantBits()));
+        map.put("WorldUUIDLeast", LinLongTag.of(uuid.getLeastSignificantBits()));
+
+        map.put("PersistentIDMSB", LinLongTag.of(uuid.getMostSignificantBits()));
+        map.put("PersistentIDLSB", LinLongTag.of(uuid.getLeastSignificantBits()));
     }
 
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/world/block/CompoundInput.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/world/block/CompoundInput.java
@@ -1,5 +1,7 @@
 package com.fastasyncworldedit.core.world.block;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
+import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.ITileInput;
 import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -11,9 +13,21 @@ public enum CompoundInput {
         public BaseBlock get(BlockState state, ITileInput input, int x, int y, int z) {
             return state.toBaseBlock(input.getTile(x, y, z));
         }
+
+        @Override
+        public BaseBlock get(final BlockState state, final IBlocks blocks, final int x, final int y, final int z) {
+            final FaweCompoundTag tile = blocks.tile(x, y, z);
+            assert tile != null : "container without tile entity";
+            return state.toBaseBlock(tile.linTag());
+        }
     };
 
+    @Deprecated(forRemoval = true, since = "TODO")
     public BaseBlock get(BlockState state, ITileInput input, int x, int y, int z) {
+        return state.toBaseBlock();
+    }
+
+    public BaseBlock get(BlockState state, IBlocks blocks, int x, int y, int z) {
         return state.toBaseBlock();
     }
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/wrappers/WorldWrapper.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/wrappers/WorldWrapper.java
@@ -1,5 +1,6 @@
 package com.fastasyncworldedit.core.wrappers;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
 import com.fastasyncworldedit.core.util.ExtentTraverser;
@@ -187,8 +188,8 @@ public class WorldWrapper extends AbstractWorld {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
-        return parent.setTile(x, y, z, tile);
+    public boolean tile(int x, int y, int z, FaweCompoundTag tile) throws WorldEditException {
+        return parent.tile(x, y, z, tile);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/jnbt/NBTUtils.java
+++ b/worldedit-core/src/main/java/com/sk89q/jnbt/NBTUtils.java
@@ -172,7 +172,9 @@ public final class NBTUtils {
      * @param map  Map to add uuid to
      * @param uuid {@link UUID} to add
      * @since 2.4.0
+     * @deprecated use {@link com.fastasyncworldedit.core.util.NbtUtils#addUUIDToMap(Map, UUID)} instead
      */
+    @Deprecated(forRemoval = true, since = "TODO")
     public static void addUUIDToMap(Map<String, Tag<?, ?>> map, UUID uuid) {
         int[] uuidArray = new int[4];
         uuidArray[0] = (int) (uuid.getMostSignificantBits() >> 32);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/AbstractDelegateExtent.java
@@ -25,6 +25,7 @@ import com.fastasyncworldedit.core.extent.HistoryExtent;
 import com.fastasyncworldedit.core.extent.NullExtent;
 import com.fastasyncworldedit.core.history.changeset.AbstractChangeSet;
 import com.fastasyncworldedit.core.internal.exception.FaweException;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.Filter;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.util.ExtentTraverser;
@@ -425,8 +426,8 @@ public class AbstractDelegateExtent implements Extent {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
-        return setBlock(x, y, z, getBlock(x, y, z).toBaseBlock(tile));
+    public boolean tile(int x, int y, int z, FaweCompoundTag tile) throws WorldEditException {
+        return setBlock(x, y, z, getBlock(x, y, z).toBaseBlock(tile.linTag()));
     }
     //FAWE end
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
@@ -736,7 +736,6 @@ public interface Extent extends InputExtent, OutputExtent {
     default <B extends BlockStateHolder<B>> int setBlocks(Region region, B block) throws MaxChangedBlocksException {
         checkNotNull(region);
         checkNotNull(block);
-        boolean hasNbt = block instanceof BaseBlock && block.hasNbtData();
 
         int changes = 0;
         for (BlockVector3 pos : region) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/NullExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/NullExtent.java
@@ -19,8 +19,8 @@
 
 package com.sk89q.worldedit.extent;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.entity.Entity;
@@ -108,7 +108,7 @@ public class NullExtent implements Extent {
     }
 
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
+    public boolean tile(int x, int y, int z, FaweCompoundTag tile) throws WorldEditException {
         return false;
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/OutputExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/OutputExtent.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.extent;
 
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
 import com.fastasyncworldedit.core.math.MutableBlockVector3;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
@@ -68,7 +69,24 @@ public interface OutputExtent {
         return setBlock(MutableBlockVector3.get(x, y, z), block);
     }
 
-    boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException;
+    /**
+     * @deprecated use {@link #tile(int, int, int, FaweCompoundTag)} instead
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
+    default boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
+        return tile(x, y, z, FaweCompoundTag.of(tile.toLinTag()));
+    }
+
+    /**
+     * Sets a tile/block entity at the given location.
+     * @param x the x position
+     * @param y the y position
+     * @param z the z position
+     * @param tile the tile/block entity to set
+     * @return {@code true} if the tile/block entity was placed
+     * @since TODO
+     */
+    boolean tile(int x, int y, int z, FaweCompoundTag tile) throws WorldEditException;
 
     /**
      * Check if this extent fully supports 3D biomes.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
@@ -23,6 +23,7 @@ import com.fastasyncworldedit.core.extent.clipboard.SimpleClipboard;
 import com.fastasyncworldedit.core.function.visitor.Order;
 import com.fastasyncworldedit.core.math.MutableBlockVector2;
 import com.fastasyncworldedit.core.math.OffsetBlockVector3;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.google.common.collect.Iterators;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.WorldEditException;
@@ -200,16 +201,17 @@ public class BlockArrayClipboard implements Clipboard {
 
     //FAWE start
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tag) {
+    public boolean tile(int x, int y, int z, FaweCompoundTag tag) {
         x -= offset.x();
         y -= offset.y();
         z -= offset.z();
-        return getParent().setTile(x, y, z, tag);
+        return getParent().tile(x, y, z, tag);
     }
 
 
+    @Deprecated(forRemoval = true, since = "TODO")
     public boolean setTile(BlockVector3 position, CompoundTag tag) {
-        return setTile(position.x(), position.y(), position.z(), tag);
+        return tile(position.x(), position.y(), position.z(), FaweCompoundTag.of(tag.toLinTag()));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/math/BlockVector3.java
@@ -852,6 +852,7 @@ public abstract class BlockVector3 {
         return orDefault.getBiome(this);
     }
 
+    @Deprecated(forRemoval = true, since = "TODO")
     public CompoundTag getNbtData(Extent orDefault) {
         return orDefault.getFullBlock(x(), y(), z()).getNbtData();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/session/request/RequestExtent.java
@@ -19,7 +19,7 @@
 
 package com.sk89q.worldedit.session.request;
 
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.entity.BaseEntity;
@@ -119,8 +119,8 @@ public class RequestExtent implements Extent {
 
     //FAWE start
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
-        return getExtent().setTile(x, y, z, tile);
+    public boolean tile(int x, int y, int z, FaweCompoundTag tile) throws WorldEditException {
+        return getExtent().tile(x, y, z, tile);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/NullWorld.java
@@ -19,11 +19,11 @@
 
 package com.sk89q.worldedit.world;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.blocks.NullChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
 import com.google.common.collect.ImmutableSet;
-import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
@@ -204,7 +204,7 @@ public class NullWorld extends AbstractWorld {
 
     //FAWE start
     @Override
-    public boolean setTile(int x, int y, int z, CompoundTag tile) throws WorldEditException {
+    public boolean tile(int x, int y, int z, FaweCompoundTag tile) throws WorldEditException {
         return false;
     }
     //FAWE end

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BaseBlock.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.world.block;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.worldedit.WorldEditException;
@@ -262,15 +263,15 @@ public class BaseBlock implements BlockStateHolder<BaseBlock>, TileEntityBlock {
 
     @Override
     public void applyTileEntity(OutputExtent output, int x, int y, int z) {
-        CompoundTag nbt = getNbtData();
+        LinCompoundTag nbt = getNbt();
         if (nbt != null) {
-            output.setTile(x, y, z, nbt);
+            output.tile(x, y, z, FaweCompoundTag.of(nbt));
         }
     }
 
     @Override
     public BaseBlock withPropertyId(int propertyId) {
-        return getBlockType().withPropertyId(propertyId).toBaseBlock(getNbtData());
+        return getBlockType().withPropertyId(propertyId).toBaseBlock(getNbtReference());
     }
 
     @Override
@@ -285,7 +286,7 @@ public class BaseBlock implements BlockStateHolder<BaseBlock>, TileEntityBlock {
 
     @Override
     public <V> BaseBlock with(PropertyKey property, V value) {
-        return toImmutableState().with(property, value).toBaseBlock(getNbtData());
+        return toImmutableState().with(property, value).toBaseBlock(getNbtReference());
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.world.block;
 import com.fastasyncworldedit.core.command.SuggestInputParseException;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.function.mask.SingleBlockStateMask;
+import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.ITileInput;
 import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.fastasyncworldedit.core.util.MutableCharSequence;
@@ -476,6 +477,12 @@ public class BlockState implements BlockStateHolder<BlockState>, Pattern {
     public BaseBlock toBaseBlock(ITileInput input, int x, int y, int z) {
         return compoundInput.get(this, input, x, y, z);
     }
+
+    @Override
+    public BaseBlock toBaseBlock(final IBlocks blocks, final int x, final int y, final int z) {
+        return compoundInput.get(this, blocks, x, y, z);
+    }
+
     //FAWE end
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockStateHolder.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.world.block;
 
+import com.fastasyncworldedit.core.queue.IBlocks;
 import com.fastasyncworldedit.core.queue.ITileInput;
 import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.sk89q.jnbt.CompoundTag;
@@ -199,6 +200,10 @@ public interface BlockStateHolder<B extends BlockStateHolder<B>> extends TileEnt
     void applyTileEntity(OutputExtent output, int x, int y, int z);
 
     default BaseBlock toBaseBlock(ITileInput input, int x, int y, int z) {
+        throw new UnsupportedOperationException("State is immutable");
+    }
+
+    default BaseBlock toBaseBlock(IBlocks blocks, int x, int y, int z) {
         throw new UnsupportedOperationException("State is immutable");
     }
     //FAWE end

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockMaterial.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.world.registry;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
 
 import javax.annotation.Nullable;
@@ -185,7 +186,19 @@ public interface BlockMaterial {
      * @return default tile entity data
      */
     @Nullable
-    CompoundTag getDefaultTile();
+    default CompoundTag getDefaultTile() {
+        final FaweCompoundTag faweCompoundTag = defaultTile();
+        if (faweCompoundTag == null) {
+            return null;
+        }
+        return new CompoundTag(faweCompoundTag.linTag());
+    }
+
+    /**
+     * {@return the default tile associated with this material, if any}
+     * @since TODO
+     */
+    @Nullable FaweCompoundTag defaultTile();
 
     /**
      * Get the map color.

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/PassthroughBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/PassthroughBlockMaterial.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.world.registry;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
 
 import javax.annotation.Nullable;
@@ -168,5 +169,11 @@ public class PassthroughBlockMaterial implements BlockMaterial {
     public CompoundTag getDefaultTile() {
         return blockMaterial.getDefaultTile();
     }
+
+    @Override
+    public @Nullable FaweCompoundTag defaultTile() {
+        return blockMaterial.defaultTile();
+    }
+
     //FAWE end
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleBlockMaterial.java
@@ -21,7 +21,8 @@ package com.sk89q.worldedit.world.registry;
 
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
-import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nullable;
 
 class SimpleBlockMaterial implements BlockMaterial {
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleBlockMaterial.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/SimpleBlockMaterial.java
@@ -19,7 +19,9 @@
 
 package com.sk89q.worldedit.world.registry;
 
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.jnbt.CompoundTag;
+import org.jetbrains.annotations.Nullable;
 
 class SimpleBlockMaterial implements BlockMaterial {
 
@@ -251,8 +253,12 @@ class SimpleBlockMaterial implements BlockMaterial {
     }
 
     @Override
-    public CompoundTag getDefaultTile() {
-        return tile;
+    public @Nullable FaweCompoundTag defaultTile() {
+        // this implementation is very lazy, but SimpleBlockMaterial isn't really used anyway
+        if (tile != null) {
+            return FaweCompoundTag.of(tile.toLinTag());
+        }
+        return null;
     }
     //FAWE end
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`CompoundTag` is deprecated and its implementation is now backed by `LinCompoundTag`. This causes significant overhead when access its data due to the needed transformation/copy.

This PR aims to address spots where `CompoundTag` is used in FAWE api, as well as some uses that can benefit from the reduced overhead. There is more to do to get `CompoundTag` fully out of FAWE, but more changes can be addressed later.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
