### PR TITLE
Introduce basic support for Vector API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ tasks {
             minecraftVersion(it)
             pluginJars(*project(":worldedit-bukkit").getTasksByName("shadowJar", false).map { (it as Jar).archiveFile }
                     .toTypedArray())
-            jvmArgs("-DPaper.IgnoreJavaVersion=true", "-Dcom.mojang.eula.agree=true")
+            jvmArgs("-DPaper.IgnoreJavaVersion=true", "-Dcom.mojang.eula.agree=true", "--add-modules=jdk.incubator.vector")
             group = "run paper"
             runDirectory.set(file("run-$it"))
         }

--- a/buildSrc/src/main/kotlin/CommonJavaConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonJavaConfig.kt
@@ -28,6 +28,7 @@ fun Project.applyCommonJavaConfiguration(sourcesJar: Boolean, banSlf4j: Boolean 
                 options.isDeprecation = true
                 options.encoding = "UTF-8"
                 options.compilerArgs.add("-parameters")
+                options.compilerArgs.add("--add-modules=jdk.incubator.vector")
             }
 
     configurations.all {

--- a/buildSrc/src/main/kotlin/CommonJavaConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonJavaConfig.kt
@@ -52,12 +52,14 @@ fun Project.applyCommonJavaConfiguration(sourcesJar: Boolean, banSlf4j: Boolean 
     tasks.withType<Javadoc>().configureEach {
         (options as StandardJavadocDocletOptions).apply {
             addStringOption("Xdoclint:none", "-quiet")
+            addStringOption("-add-modules", "jdk.incubator.vector")
             tags(
                     "apiNote:a:API Note:",
                     "implSpec:a:Implementation Requirements:",
                     "implNote:a:Implementation Note:"
             )
             options.encoding = "UTF-8"
+
             links(
                     "https://jd.advntr.dev/api/latest/",
                     "https://logging.apache.org/log4j/2.x/javadoc/log4j-api/",

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/configuration/Settings.java
@@ -675,6 +675,11 @@ public class Settings extends Config {
         })
         public boolean ALLOW_TICK_FLUIDS = false;
 
+        @Comment({
+                "Whether FAWE should use the incubator Vector API to accelerate some operations"
+        })
+        public boolean USE_VECTOR_API = false;
+
     }
 
     @Comment({"Web/HTTP connection related settings"})

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/CountFilter.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/CountFilter.java
@@ -1,8 +1,10 @@
 package com.fastasyncworldedit.core.extent.filter;
 
 import com.fastasyncworldedit.core.extent.filter.block.FilterBlock;
+import com.fastasyncworldedit.core.internal.simd.VectorizedFilter;
+import jdk.incubator.vector.ShortVector;
 
-public class CountFilter extends ForkedFilter<CountFilter> {
+public class CountFilter extends ForkedFilter<CountFilter> implements VectorizedFilter {
 
     private int total;
 
@@ -31,6 +33,12 @@ public class CountFilter extends ForkedFilter<CountFilter> {
 
     public int getTotal() {
         return total;
+    }
+
+    @Override
+    public ShortVector applyVector(final ShortVector get, final ShortVector set) {
+        total += set.length();
+        return set;
     }
 
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/LinkedFilter.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/LinkedFilter.java
@@ -2,7 +2,9 @@ package com.fastasyncworldedit.core.extent.filter;
 
 import com.fastasyncworldedit.core.extent.filter.block.DelegateFilter;
 import com.fastasyncworldedit.core.extent.filter.block.FilterBlock;
+import com.fastasyncworldedit.core.internal.simd.VectorizedFilter;
 import com.fastasyncworldedit.core.queue.Filter;
+import jdk.incubator.vector.ShortVector;
 
 /**
  * Filter which links two Filters together for single-filter-input operations.
@@ -10,9 +12,17 @@ import com.fastasyncworldedit.core.queue.Filter;
  * @param <T> Parent which extends Filter
  * @param <S> Child which extends Filter
  */
-public final class LinkedFilter<T extends Filter, S extends Filter> extends DelegateFilter<T> {
+public sealed class LinkedFilter<T extends Filter, S extends Filter> extends DelegateFilter<T> {
 
     private final S child;
+
+    @SuppressWarnings({"unchecked", "rawtypes"}) // we defeated the type system
+    public static <T extends Filter, S extends Filter> LinkedFilter<? extends T, ? extends S> of(T parent, S child) {
+        if (parent instanceof VectorizedFilter p && child instanceof VectorizedFilter c) {
+            return new VectorizedLinkedFilter(p, c);
+        }
+        return new LinkedFilter<>(parent, child);
+    }
 
     public LinkedFilter(T parent, S child) {
         super(parent);
@@ -30,8 +40,30 @@ public final class LinkedFilter<T extends Filter, S extends Filter> extends Dele
     }
 
     @Override
-    public LinkedFilter<LinkedFilter<T, S>, Filter> newInstance(Filter other) {
+    public LinkedFilter<? extends LinkedFilter<T, S>, ? extends Filter> newInstance(Filter other) {
         return new LinkedFilter<>(this, other);
+    }
+
+    private final static class VectorizedLinkedFilter<T extends VectorizedFilter, S extends VectorizedFilter>
+            extends LinkedFilter<T, S> implements VectorizedFilter {
+
+        public VectorizedLinkedFilter(final T parent, final S child) {
+            super(parent, child);
+        }
+
+        @Override
+        public ShortVector applyVector(final ShortVector get, final ShortVector set) {
+            ShortVector res = getParent().applyVector(get, set);
+            return getChild().applyVector(get, res);
+        }
+
+        @Override
+        public LinkedFilter<? extends LinkedFilter<T, S>, Filter> newInstance(Filter other) {
+            if (other instanceof VectorizedFilter o) {
+                return new VectorizedLinkedFilter(this, o);
+            }
+            return new LinkedFilter<>(this, other);
+        }
     }
 
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/block/CharFilterBlock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/block/CharFilterBlock.java
@@ -23,12 +23,14 @@ import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import org.enginehub.linbus.tree.LinCompoundTag;
+import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static com.sk89q.worldedit.world.block.BlockTypesCache.states;
 
+@ApiStatus.NonExtendable
 public class CharFilterBlock extends ChunkFilterBlock {
 
     private static final SetDelegate FULL = (block, value) -> block.setArr[block.index] = value;
@@ -38,10 +40,10 @@ public class CharFilterBlock extends ChunkFilterBlock {
     private int minLayer;
     private CharGetBlocks get;
     private IChunkSet set;
-    private char[] getArr;
+    protected char[] getArr;
     @Nullable
-    private char[] setArr;
-    private SetDelegate delegate;
+    protected char[] setArr;
+    protected SetDelegate delegate;
     // local
     private int layer;
     private int index;
@@ -172,7 +174,7 @@ public class CharFilterBlock extends ChunkFilterBlock {
     }
 
     @Override
-    public synchronized final void filter(Filter filter) {
+    public synchronized void filter(Filter filter) {
         for (y = 0, index = 0; y < 16; y++) {
             for (z = 0; z < 16; z++) {
                 for (x = 0; x < 16; x++, index++) {
@@ -396,7 +398,7 @@ public class CharFilterBlock extends ChunkFilterBlock {
     }
 
     //Set delegate
-    private SetDelegate initSet() {
+    protected final SetDelegate initSet() {
         setArr = set.load(layer);
         return delegate = FULL;
     }
@@ -428,7 +430,8 @@ public class CharFilterBlock extends ChunkFilterBlock {
         return getExtent().setBiome(x, y, z, biome);
     }
 
-    private interface SetDelegate {
+    @ApiStatus.Internal
+    protected interface SetDelegate {
 
         void set(@Nonnull CharFilterBlock block, char value);
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/SimdSupport.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/SimdSupport.java
@@ -1,0 +1,99 @@
+package com.fastasyncworldedit.core.internal.simd;
+
+import com.fastasyncworldedit.core.configuration.Settings;
+import com.fastasyncworldedit.core.extent.filter.block.DelegateFilter;
+import com.fastasyncworldedit.core.function.mask.SingleBlockStateMask;
+import com.fastasyncworldedit.core.queue.Filter;
+import com.sk89q.worldedit.function.mask.InverseSingleBlockStateMask;
+import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.function.pattern.Pattern;
+import com.sk89q.worldedit.internal.util.LogManagerCompat;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorOperators;
+
+import javax.annotation.Nullable;
+
+public class SimdSupport {
+
+    private static final boolean VECTOR_API_PRESENT;
+
+    static {
+        boolean vectorApiPresent = false;
+        try {
+            Class.forName("jdk.incubator.vector.Vector");
+            vectorApiPresent = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        VECTOR_API_PRESENT = vectorApiPresent;
+        if (!VECTOR_API_PRESENT && Settings.settings().EXPERIMENTAL.USE_VECTOR_API) {
+            LogManagerCompat.getLogger()
+                    .warn("FAWE use-vector-api is enabled but --add-modules=jdk.incubator.vector is not set.");
+        }
+    }
+
+    public static boolean useVectorApi() {
+        return VECTOR_API_PRESENT && Settings.settings().EXPERIMENTAL.USE_VECTOR_API;
+    }
+
+    public static @Nullable VectorizedMask vectorizedTargetMask(Mask mask) {
+        if (!useVectorApi()) {
+            return null;
+        }
+        return switch (mask) {
+            case SingleBlockStateMask single -> vectorizedTargetMask(single.getBlockState().getOrdinalChar());
+            case InverseSingleBlockStateMask inverse -> vectorizedTargetMaskInverse(inverse.getBlockState().getOrdinalChar());
+            default -> null;
+        };
+    }
+
+    private static VectorizedMask vectorizedTargetMask(char ordinal) {
+        return (set, get) -> get.compare(VectorOperators.EQ, (short) ordinal);
+    }
+
+    private static VectorizedMask vectorizedTargetMaskInverse(char ordinal) {
+        return (set, get) -> get.compare(VectorOperators.NE, (short) ordinal);
+    }
+
+    public static @Nullable VectorizedFilter vectorizedPattern(Pattern pattern) {
+        if (!useVectorApi()) {
+            return null;
+        }
+        return switch (pattern) {
+            case BaseBlock block -> {
+                if (block.getNbtReference() == null) {
+                    yield new VectorizedPattern<>(block, block.getOrdinalChar());
+                }
+                yield null;
+            }
+            case BlockStateHolder<?> blockStateHolder -> new VectorizedPattern<>(
+                    blockStateHolder,
+                    blockStateHolder.getOrdinalChar()
+            );
+            default -> null;
+        };
+    }
+
+    private static final class VectorizedPattern<T extends Filter> extends DelegateFilter<T> implements VectorizedFilter {
+
+        private final char ordinal;
+
+        public VectorizedPattern(final T parent, char ordinal) {
+            super(parent);
+            this.ordinal = ordinal;
+        }
+
+        @Override
+        public ShortVector applyVector(final ShortVector get, final ShortVector set) {
+            return ShortVector.broadcast(ShortVector.SPECIES_PREFERRED, ordinal);
+        }
+
+        @Override
+        public Filter newInstance(final Filter other) {
+            return new VectorizedPattern<>(other, ordinal);
+        }
+
+    }
+
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedCharFilterBlock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedCharFilterBlock.java
@@ -22,6 +22,7 @@ public class VectorizedCharFilterBlock extends CharFilterBlock {
         char[] setArr = this.setArr;
         assert setArr != null;
         char[] getArr = this.getArr;
+        // assume setArr.length == getArr.length == 4096
         for (int i = 0; i < 4096; i += species.length()) {
             ShortVector set = ShortVector.fromCharArray(species, setArr, i);
             ShortVector get = ShortVector.fromCharArray(species, getArr, i);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedCharFilterBlock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedCharFilterBlock.java
@@ -1,0 +1,32 @@
+package com.fastasyncworldedit.core.internal.simd;
+
+import com.fastasyncworldedit.core.extent.filter.block.CharFilterBlock;
+import com.fastasyncworldedit.core.queue.Filter;
+import com.sk89q.worldedit.extent.Extent;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorSpecies;
+
+public class VectorizedCharFilterBlock extends CharFilterBlock {
+
+    public VectorizedCharFilterBlock(final Extent extent) {
+        super(extent);
+    }
+
+    @Override
+    public synchronized void filter(final Filter filter) {
+        if (!(filter instanceof VectorizedFilter vecFilter)) {
+            throw new IllegalStateException("Unexpected VectorizedCharFilterBlock " + filter);
+        }
+        final VectorSpecies<Short> species = ShortVector.SPECIES_PREFERRED;
+        initSet(); // set array is null before
+        char[] setArr = this.setArr;
+        assert setArr != null;
+        char[] getArr = this.getArr;
+        for (int i = 0; i < 4096; i += species.length()) {
+            ShortVector set = ShortVector.fromCharArray(species, setArr, i);
+            ShortVector get = ShortVector.fromCharArray(species, getArr, i);
+            ShortVector res = vecFilter.applyVector(get, set);
+            res.intoCharArray(setArr, i);
+        }
+    }
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedFilter.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedFilter.java
@@ -1,0 +1,8 @@
+package com.fastasyncworldedit.core.internal.simd;
+
+import com.fastasyncworldedit.core.queue.Filter;
+import jdk.incubator.vector.ShortVector;
+
+public interface VectorizedFilter extends Filter {
+    ShortVector applyVector(ShortVector get, ShortVector set);
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedMask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedMask.java
@@ -1,0 +1,39 @@
+package com.fastasyncworldedit.core.internal.simd;
+
+import com.fastasyncworldedit.core.queue.IChunk;
+import com.fastasyncworldedit.core.queue.IChunkGet;
+import com.fastasyncworldedit.core.queue.IChunkSet;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+public interface VectorizedMask {
+
+    default void processChunks(IChunk chunk, IChunkGet get, IChunkSet set) {
+        for (int layer = get.getMinSectionPosition(); layer <= get.getMaxSectionPosition(); layer++) {
+            final char[] sectionSet = set.loadIfPresent(layer);
+            if (sectionSet == null) {
+                continue;
+            }
+            final char[] sectionGet = get.load(layer);
+            processSection(layer, sectionSet, sectionGet);
+        }
+    }
+
+    default void processSection(int layer, char[] set, char[] get) {
+        final VectorSpecies<Short> species = ShortVector.SPECIES_PREFERRED;
+        for (int i = 0; i < set.length; i += species.length()) {
+            ShortVector vectorSet = ShortVector.fromCharArray(species, set, i);
+            ShortVector vectorGet = ShortVector.fromCharArray(species, get, i);
+            vectorSet = processVector(vectorSet, vectorGet);
+            vectorSet.intoCharArray(set, i);
+        }
+    }
+
+    default ShortVector processVector(ShortVector set, ShortVector get) {
+        return set.blend(0, compareVector(set, get).not());
+    }
+
+    VectorMask<Short> compareVector(ShortVector set, ShortVector get);
+
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedMask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedMask.java
@@ -22,6 +22,7 @@ public interface VectorizedMask {
 
     default void processSection(int layer, char[] set, char[] get) {
         final VectorSpecies<Short> species = ShortVector.SPECIES_PREFERRED;
+        // assume that set.length % species.elementSize() == 0
         for (int i = 0; i < set.length; i += species.length()) {
             ShortVector vectorSet = ShortVector.fromCharArray(species, set, i);
             ShortVector vectorGet = ShortVector.fromCharArray(species, get, i);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IQueueExtent.java
@@ -2,6 +2,9 @@ package com.fastasyncworldedit.core.queue;
 
 import com.fastasyncworldedit.core.extent.filter.block.ChunkFilterBlock;
 import com.fastasyncworldedit.core.extent.processor.IBatchProcessorHolder;
+import com.fastasyncworldedit.core.internal.simd.SimdSupport;
+import com.fastasyncworldedit.core.internal.simd.VectorizedCharFilterBlock;
+import com.fastasyncworldedit.core.internal.simd.VectorizedFilter;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.operation.Operation;
 import com.sk89q.worldedit.math.BlockVector2;
@@ -146,7 +149,11 @@ public interface IQueueExtent<T extends IChunk> extends Flushable, Trimable, ICh
         if (newChunk != null) {
             chunk = newChunk;
             if (block == null) {
-                block = this.createFilterBlock();
+                if (SimdSupport.useVectorApi() && filter instanceof VectorizedFilter) {
+                    block = new VectorizedCharFilterBlock(this);
+                } else {
+                    block = this.createFilterBlock();
+                }
             }
             block.initChunk(chunkX, chunkZ);
             chunk.filterBlocks(filter, block, region, full);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
@@ -14,6 +14,8 @@ import com.fastasyncworldedit.core.extent.processor.BatchProcessorHolder;
 import com.fastasyncworldedit.core.extent.processor.MultiBatchProcessor;
 import com.fastasyncworldedit.core.function.mask.BlockMaskBuilder;
 import com.fastasyncworldedit.core.internal.exception.FaweException;
+import com.fastasyncworldedit.core.internal.simd.SimdSupport;
+import com.fastasyncworldedit.core.internal.simd.VectorizedFilter;
 import com.fastasyncworldedit.core.queue.Filter;
 import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
@@ -223,7 +225,9 @@ public class ParallelQueueExtent extends PassthroughExtent {
 
     @Override
     public int setBlocks(Region region, Pattern pattern) throws MaxChangedBlocksException {
-        return this.changes = apply(region, new LinkedFilter<>(pattern, new CountFilter()), true).getChild().getTotal();
+        VectorizedFilter vectorizedPattern = SimdSupport.vectorizedPattern(pattern);
+        var filter = LinkedFilter.of(vectorizedPattern == null ? pattern : vectorizedPattern, new CountFilter());
+        return this.changes = apply(region, filter, true).getChild().getTotal();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/MaskingExtent.java
@@ -24,6 +24,8 @@ import com.fastasyncworldedit.core.extent.filter.block.CharFilterBlock;
 import com.fastasyncworldedit.core.extent.filter.block.ChunkFilterBlock;
 import com.fastasyncworldedit.core.extent.filter.block.FilterBlock;
 import com.fastasyncworldedit.core.extent.processor.ProcessorScope;
+import com.fastasyncworldedit.core.internal.simd.SimdSupport;
+import com.fastasyncworldedit.core.internal.simd.VectorizedMask;
 import com.fastasyncworldedit.core.queue.Filter;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunk;
@@ -35,6 +37,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 
+import javax.annotation.Nullable;
 import java.util.function.LongFunction;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -47,6 +50,7 @@ public class MaskingExtent extends AbstractDelegateExtent implements IBatchProce
     //FAWE start
     private final LongFunction<ChunkFilterBlock> getOrCreateFilterBlock;
     private Mask mask;
+    private @Nullable VectorizedMask vectorizedMask;
     //FAWE end
 
     /**
@@ -59,16 +63,23 @@ public class MaskingExtent extends AbstractDelegateExtent implements IBatchProce
         super(extent);
         checkNotNull(mask);
         this.mask = mask;
+        this.vectorizedMask = SimdSupport.vectorizedTargetMask(mask);
         //FAWE start
         this.getOrCreateFilterBlock = FaweCache.INSTANCE.createMainThreadSafeCache(() -> new CharFilterBlock(getExtent()));
         //FAWE end
     }
 
     //FAWE start
-    private MaskingExtent(Extent extent, Mask mask, LongFunction<ChunkFilterBlock> getOrCreateFilterBlock) {
+    private MaskingExtent(
+            Extent extent,
+            Mask mask,
+            LongFunction<ChunkFilterBlock> getOrCreateFilterBlock,
+            @Nullable VectorizedMask vectorizedMask
+    ) {
         super(extent);
         checkNotNull(mask);
         this.mask = mask;
+        this.vectorizedMask = vectorizedMask;
         this.getOrCreateFilterBlock = getOrCreateFilterBlock;
     }
     //FAWE end
@@ -90,6 +101,7 @@ public class MaskingExtent extends AbstractDelegateExtent implements IBatchProce
     public void setMask(Mask mask) {
         checkNotNull(mask);
         this.mask = mask;
+        this.vectorizedMask = SimdSupport.vectorizedTargetMask(mask);
     }
 
     //FAWE start
@@ -105,6 +117,10 @@ public class MaskingExtent extends AbstractDelegateExtent implements IBatchProce
 
     @Override
     public IChunkSet processSet(final IChunk chunk, final IChunkGet get, final IChunkSet set) {
+        if (this.vectorizedMask != null) {
+            this.vectorizedMask.processChunks(chunk, get, set);
+            return set;
+        }
         final ChunkFilterBlock filter = getOrCreateFilterBlock.apply(Thread.currentThread().getId());
         filter.initChunk(chunk.getX(), chunk.getZ());
         return filter.filter(chunk, get, set, this);
@@ -122,12 +138,12 @@ public class MaskingExtent extends AbstractDelegateExtent implements IBatchProce
         if (child == getExtent()) {
             return this;
         }
-        return new MaskingExtent(child, this.mask.copy(), this.getOrCreateFilterBlock);
+        return new MaskingExtent(child, this.mask.copy(), this.getOrCreateFilterBlock, this.vectorizedMask);
     }
 
     @Override
     public Filter fork() {
-        return new MaskingExtent(getExtent(), this.mask.copy(), this.getOrCreateFilterBlock);
+        return new MaskingExtent(getExtent(), this.mask.copy(), this.getOrCreateFilterBlock, this.vectorizedMask);
     }
 
     @Override


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

This is an experimental, internal feature to use the Vector API when enabled. The current implementation is designed to cover basic use cases (i.e. `//gmask` with single blocks, `//set` with single blocks, `//replace` with single blocks). This could be expanded, but as that needs to be done rather careful to not make performance worse, I left it to the very basics for now.

A quick example of running `//replace dirt diamond_block` on a selection of 2048x320x2048:

Before:
![before](https://github.com/user-attachments/assets/b2171874-3bac-4811-8a3e-1b1ea7f90cf5)

![after](https://github.com/user-attachments/assets/aad6461e-fd8a-41b1-b953-9f819e5df7f4)

Note that the `hasSection` calls take up the same time in both profiles, same for `initLayer`. The difference is in the `filter` call, which results in many additional calls in the none-specialized variant vs pretty much only memory access and vector instructions in the specialized variant. (There might be ways to optimize without the Vector API here I guess, but the existing abstraction doesn't work well in either cases)

A few more notes on the benchmark:
- I limited FAWE to use 4 threads only, because that's what many people actually have (and FAWE is just comically fast otherwise)
- It might make sense to set the number of threads to the half of the actual hardware threads, as some platforms are known to not perform well with vector instructions otherwise - I don't know how much that might skew the result
- I'm running a machine with AVX2 (256 bit vectors) only, machines with AVX3/AVX512 might perform even better
- The difference is not really relevant on small edits


```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
