### PR TITLE
Replace usages and overrides of deprecated getSuggestions method

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/AdjacentMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/AdjacentMaskParser.java
@@ -19,9 +19,9 @@ public class AdjacentMaskParser extends RichParser<Mask> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return worldEdit.getMaskFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getMaskFactory().getSuggestions(argumentInput, context).stream();
         } else if (index == 1 || index == 2) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput);
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/AngleMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/AngleMaskParser.java
@@ -22,7 +22,7 @@ public class AngleMaskParser extends RichParser<Mask> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0 || index == 1) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput).flatMap(s -> Stream.of(s, s + "d"));
         } else if (index > 1 && index <= 1 + flags.length) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/BesideMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/BesideMaskParser.java
@@ -18,9 +18,9 @@ public class BesideMaskParser extends RichParser<Mask> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(final String argumentInput, final int index) {
+    protected Stream<String> getSuggestions(final String argumentInput, final int index, ParserContext context) {
         if (index == 0) {
-            return worldEdit.getMaskFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getMaskFactory().getSuggestions(argumentInput, context).stream();
         } else if (index == 1 || index == 2) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput);
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/ExtremaMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/ExtremaMaskParser.java
@@ -22,7 +22,7 @@ public class ExtremaMaskParser extends RichParser<Mask> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0 || index == 1) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput).flatMap(s -> Stream.of(s, s + "d"));
         } else if (index > 1 && index <= 1 + flags.length) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/ROCAngleMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/ROCAngleMaskParser.java
@@ -22,7 +22,7 @@ public class ROCAngleMaskParser extends RichParser<Mask> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0 || index == 1) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput).flatMap(s -> Stream.of(s, s + "d"));
         } else if (index > 1 && index <= 1 + flags.length) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/RadiusMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/RadiusMaskParser.java
@@ -18,7 +18,7 @@ public class RadiusMaskParser extends RichParser<Mask> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0 || index == 1) {
             return SuggestionHelper.suggestPositiveIntegers(argumentInput);
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/RichOffsetMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/RichOffsetMaskParser.java
@@ -24,12 +24,12 @@ public class RichOffsetMaskParser extends RichParser<Mask> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index < 3) {
             return SuggestionHelper.suggestPositiveIntegers(argumentInput);
         }
         if (index == 3) {
-            return worldEdit.getMaskFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getMaskFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/SimplexMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/SimplexMaskParser.java
@@ -20,7 +20,7 @@ public class SimplexMaskParser extends RichParser<Mask> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index < 3) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput);
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/SurfaceAngleMaskParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/mask/SurfaceAngleMaskParser.java
@@ -23,7 +23,7 @@ public class SurfaceAngleMaskParser extends RichParser<Mask> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index <= 2) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput);
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/AngleColorPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/AngleColorPatternParser.java
@@ -25,7 +25,7 @@ public class AngleColorPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index != 0) {
             return Stream.empty();
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/AverageColorPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/AverageColorPatternParser.java
@@ -25,7 +25,7 @@ public class AverageColorPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index > 4) {
             return Stream.empty();
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/BiomePatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/BiomePatternParser.java
@@ -54,7 +54,7 @@ public class BiomePatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
             return BiomeType.REGISTRY.getSuggestions(argumentInput);
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/BufferedPattern2DParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/BufferedPattern2DParser.java
@@ -26,9 +26,9 @@ public class BufferedPattern2DParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/BufferedPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/BufferedPatternParser.java
@@ -26,9 +26,9 @@ public class BufferedPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/ColorPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/ColorPatternParser.java
@@ -26,7 +26,7 @@ public class ColorPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index > 4) {
             return Stream.empty();
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/DesaturatePatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/DesaturatePatternParser.java
@@ -25,7 +25,7 @@ public class DesaturatePatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput);
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/Linear2DPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/Linear2DPatternParser.java
@@ -28,9 +28,9 @@ public class Linear2DPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         return switch (index) {
-            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
             case 1, 2 -> SuggestionHelper.suggestPositiveIntegers(argumentInput);
             default -> Stream.empty();
         };

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/Linear3DPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/Linear3DPatternParser.java
@@ -28,9 +28,9 @@ public class Linear3DPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         return switch (index) {
-            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
             case 1, 2, 3 -> SuggestionHelper.suggestPositiveIntegers(argumentInput);
             default -> Stream.empty();
         };

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/LinearPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/LinearPatternParser.java
@@ -28,9 +28,9 @@ public class LinearPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         return switch (index) {
-            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
             case 1, 2, 3 -> SuggestionHelper.suggestPositiveIntegers(argumentInput);
             default -> Stream.empty();
         };

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/MaskedPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/MaskedPatternParser.java
@@ -25,10 +25,10 @@ public class MaskedPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         return switch (index) {
-            case 0 -> this.worldEdit.getMaskFactory().getSuggestions(argumentInput).stream();
-            case 1, 2 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            case 0 -> this.worldEdit.getMaskFactory().getSuggestions(argumentInput, context).stream();
+            case 1, 2 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
             default -> Stream.empty();
         };
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/NoXPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/NoXPatternParser.java
@@ -24,9 +24,9 @@ public class NoXPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/NoYPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/NoYPatternParser.java
@@ -24,9 +24,9 @@ public class NoYPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/NoZPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/NoZPatternParser.java
@@ -24,9 +24,9 @@ public class NoZPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/NoisePatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/NoisePatternParser.java
@@ -36,12 +36,12 @@ public abstract class NoisePatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput);
         }
         if (index == 1) {
-            return worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/OffsetPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/OffsetPatternParser.java
@@ -25,9 +25,9 @@ public class OffsetPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         return switch (index) {
-            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
             case 1, 2, 3 -> SuggestionHelper.suggestPositiveIntegers(argumentInput);
             default -> Stream.empty();
         };

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/RandomFullClipboardPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/RandomFullClipboardPatternParser.java
@@ -4,6 +4,7 @@ import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.extension.factory.parser.RichParser;
 import com.fastasyncworldedit.core.extent.clipboard.MultiClipboardHolder;
 import com.fastasyncworldedit.core.function.pattern.RandomFullClipboardPattern;
+import com.google.common.base.Function;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.command.util.SuggestionHelper;
 import com.sk89q.worldedit.extension.input.InputParseException;
@@ -33,7 +34,7 @@ public class RandomFullClipboardPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         switch (index) {
             case 0:
                 if (argumentInput.equals("#") || argumentInput.equals("#c")) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/RandomOffsetPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/RandomOffsetPatternParser.java
@@ -25,9 +25,9 @@ public class RandomOffsetPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         return switch (index) {
-            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
             case 1, 2, 3 -> SuggestionHelper.suggestPositiveIntegers(argumentInput);
             default -> Stream.empty();
         };

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/RelativePatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/RelativePatternParser.java
@@ -24,9 +24,9 @@ public class RelativePatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            return this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/SaturatePatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/SaturatePatternParser.java
@@ -25,7 +25,7 @@ public class SaturatePatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index > 3) {
             return Stream.empty();
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/SolidRandomOffsetPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/SolidRandomOffsetPatternParser.java
@@ -25,9 +25,9 @@ public class SolidRandomOffsetPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         return switch (index) {
-            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
             case 1, 2, 3 -> SuggestionHelper.suggestPositiveIntegers(argumentInput);
             default -> Stream.empty();
         };

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/SurfaceRandomOffsetPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/SurfaceRandomOffsetPatternParser.java
@@ -25,9 +25,9 @@ public class SurfaceRandomOffsetPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         return switch (index) {
-            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            case 0 -> this.worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
             case 1 -> SuggestionHelper.suggestPositiveIntegers(argumentInput);
             default -> Stream.empty();
         };

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/TypeSwapPatternParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/pattern/TypeSwapPatternParser.java
@@ -28,7 +28,7 @@ public class TypeSwapPatternParser extends RichParser<Pattern> {
     }
 
     @Override
-    public Stream<String> getSuggestions(String argumentInput, int index) {
+    public Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index > 2) {
             return Stream.empty();
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/Linear3DTransformParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/Linear3DTransformParser.java
@@ -23,9 +23,9 @@ public class Linear3DTransformParser extends RichParser<ResettableExtent> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return worldEdit.getTransformFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getTransformFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/LinearTransformParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/LinearTransformParser.java
@@ -23,9 +23,9 @@ public class LinearTransformParser extends RichParser<ResettableExtent> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return worldEdit.getTransformFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getTransformFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/OffsetTransformParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/OffsetTransformParser.java
@@ -26,11 +26,11 @@ public class OffsetTransformParser extends RichParser<ResettableExtent> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index < 3) {
             return SuggestionHelper.suggestPositiveIntegers(argumentInput);
         } else if (index == 3) {
-            return worldEdit.getTransformFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getTransformFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/PatternTransformParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/PatternTransformParser.java
@@ -24,11 +24,11 @@ public class PatternTransformParser extends RichParser<ResettableExtent> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index == 0) {
-            return worldEdit.getPatternFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getPatternFactory().getSuggestions(argumentInput, context).stream();
         } else if (index == 1) {
-            return worldEdit.getTransformFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getTransformFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/RotateTransformParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/RotateTransformParser.java
@@ -25,12 +25,12 @@ public class RotateTransformParser extends RichParser<ResettableExtent> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index < 3) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput);
         }
         if (index == 3) {
-            return worldEdit.getTransformFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getTransformFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/ScaleTransformParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/ScaleTransformParser.java
@@ -24,11 +24,11 @@ public class ScaleTransformParser extends RichParser<ResettableExtent> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index < 3) {
             return SuggestionHelper.suggestPositiveDoubles(argumentInput);
         } else if (index == 3) {
-            return worldEdit.getTransformFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getTransformFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/SpreadTransformParser.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/factory/parser/transform/SpreadTransformParser.java
@@ -24,11 +24,11 @@ public class SpreadTransformParser extends RichParser<ResettableExtent> {
     }
 
     @Override
-    protected Stream<String> getSuggestions(String argumentInput, int index) {
+    protected Stream<String> getSuggestions(String argumentInput, int index, ParserContext context) {
         if (index < 3) {
             return SuggestionHelper.suggestPositiveIntegers(argumentInput);
         } else if (index == 3) {
-            return worldEdit.getTransformFactory().getSuggestions(argumentInput).stream();
+            return worldEdit.getTransformFactory().getSuggestions(argumentInput, context).stream();
         }
         return Stream.empty();
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

As a follow up of #2613, we can replace the usages and overrides in FAWE code of the deprecated method. This should help to also make all the context-sensitive suggestions work better when nested in other constructs.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
