### PR TITLE
Fix: Copy-Paste-Brush with falsy mask

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/CopyPastaBrush.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/CopyPastaBrush.java
@@ -3,7 +3,6 @@ package com.fastasyncworldedit.core.command.tool.brush;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.command.tool.ResettableTool;
 import com.fastasyncworldedit.core.configuration.Caption;
-import com.fastasyncworldedit.core.extent.clipboard.EmptyClipboard;
 import com.fastasyncworldedit.core.extent.clipboard.ResizableClipboardBuilder;
 import com.fastasyncworldedit.core.function.NullRegionFunction;
 import com.fastasyncworldedit.core.function.mask.AbstractDelegateMask;
@@ -88,11 +87,11 @@ public class CopyPastaBrush implements Brush, ResettableTool {
             visitor.visit(position);
             Operations.completeBlindly(visitor);
             // Build the clipboard
-            long blocks = builder.longSize();
-            Clipboard newClipboard = blocks > 0 ? builder.build() : EmptyClipboard.getInstance();
+            Clipboard newClipboard = builder.build();
             newClipboard.setOrigin(position);
             ClipboardHolder holder = new ClipboardHolder(newClipboard);
             session.setClipboard(holder);
+            long blocks = builder.longSize();
             player.print(Caption.of("fawe.worldedit.copy.command.copy", blocks));
         } else {
             AffineTransform transform = null;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/CopyPastaBrush.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/CopyPastaBrush.java
@@ -3,6 +3,7 @@ package com.fastasyncworldedit.core.command.tool.brush;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.command.tool.ResettableTool;
 import com.fastasyncworldedit.core.configuration.Caption;
+import com.fastasyncworldedit.core.extent.clipboard.EmptyClipboard;
 import com.fastasyncworldedit.core.extent.clipboard.ResizableClipboardBuilder;
 import com.fastasyncworldedit.core.function.NullRegionFunction;
 import com.fastasyncworldedit.core.function.mask.AbstractDelegateMask;
@@ -87,11 +88,11 @@ public class CopyPastaBrush implements Brush, ResettableTool {
             visitor.visit(position);
             Operations.completeBlindly(visitor);
             // Build the clipboard
-            Clipboard newClipboard = builder.build();
+            long blocks = builder.longSize();
+            Clipboard newClipboard = blocks > 0 ? builder.build() : EmptyClipboard.getInstance();
             newClipboard.setOrigin(position);
             ClipboardHolder holder = new ClipboardHolder(newClipboard);
             session.setClipboard(holder);
-            long blocks = builder.longSize();
             player.print(Caption.of("fawe.worldedit.copy.command.copy", blocks));
         } else {
             AffineTransform transform = null;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ResizableClipboardBuilder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ResizableClipboardBuilder.java
@@ -58,6 +58,9 @@ public class ResizableClipboardBuilder extends MemoryOptimizedHistory {
     }
 
     public Clipboard build() {
+        if (longSize() == 0) {
+            return EmptyClipboard.getInstance();
+        }
         BlockVector3 pos1 = BlockVector3.at(minX, minY, minZ);
         BlockVector3 pos2 = BlockVector3.at(maxX, maxY, maxZ);
         CuboidRegion region = new CuboidRegion(pos1, pos2);


### PR DESCRIPTION
## Overview
Fixes a bug shared on discord. 

## Description
Use copypaste-brush (`//br copypaste`) with a falsy mask (e.g. `//gmask 0`) and select the area via the first click / interact. Output should state, that `0 blocks were copied.`. Attempting to paste with that brush, results in no future actions being possible (potentially depending on the queue type). 

That's due to the `ResizableClipboardBuilder`. As the mask did not match any blocks, no blocks were added to the builder. Therefor, on build the default dimensions are used, which results in the region spanning from XYZ Integer.MAX_VALUE to XYZ Integer.MIN_VALUE. The RegionVisitor - called by the ForwardExtentCopy - attempts to load all chunks in that range via the SingleThreadQueueExtent. 

The fix is simply using an `EmptyClipboard` if nothing was being written into the `ResizableClipboardBuilder`.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
