### PR TITLE
fix: hollow on large areas fails

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -3611,7 +3611,8 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
     }
 
     private void recurseHollow(Region region, BlockVector3 origin, Set<BlockVector3> outside, Mask mask) {
-        final LocalBlockVectorSet queue = new LocalBlockVectorSet();
+        // FAWE start - use BlockVector3Set instead of LinkedList
+        final BlockVector3Set queue = BlockVector3Set.getAppropriateVectorSet(region);
         queue.add(origin);
 
         while (!queue.isEmpty()) {
@@ -3634,6 +3635,7 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
                 }
             }
         }
+        // FAWE end
     }
 
     public int makeBiomeShape(


### PR DESCRIPTION
## Overview
Fixes #2897

## Description
Determine the appropriate BlockVector3Set implementation by the region (or rather it's size).
Seems to work, as no error is thrown after 30ish seconds anymore (but I haven't waited for the hollow to complete on > 1bil blocks - chunk gen takes ages)

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
