### PR TITLE
fix: allow webinterface schematic format to be detected

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/MainUtil.java
@@ -701,7 +701,7 @@ public class MainUtil {
 
     public static File resolve(File dir, String filename, @Nullable ClipboardFormat format, boolean allowDir) {
         if (format != null) {
-            if (!filename.matches(".*\\.[\\w].*")) {
+            if (!filename.matches(".*\\.\\w.*")) {
                 filename = filename + "." + format.getPrimaryFileExtension();
             }
             return MainUtil.resolveRelative(new File(dir, filename));
@@ -712,7 +712,7 @@ public class MainUtil {
                 return file;
             }
         }
-        if (filename.matches(".*\\.[\\w].*")) {
+        if (filename.matches(".*\\.\\w.*")) {
             File file = MainUtil.resolveRelative(new File(dir, filename));
             if (file.exists()) {
                 return file;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SchematicCommands.java
@@ -69,18 +69,21 @@ import org.enginehub.piston.exception.StopExecutionException;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -325,8 +328,9 @@ public class SchematicCommands {
         LocalConfiguration config = worldEdit.getConfiguration();
 
         //FAWE start
+        final Closer closer = Closer.create();
         ClipboardFormat format;
-        InputStream in = null;
+        InputStream in;
         // if format is set explicitly, do not look up by extension!
         boolean noExplicitFormat = formatName == null;
         if (noExplicitFormat) {
@@ -346,11 +350,32 @@ public class SchematicCommands {
                 }
                 UUID uuid = UUID.fromString(filename.substring(4));
                 URL webUrl = new URL(Settings.settings().WEB.URL);
-                format = ClipboardFormats.findByAlias(formatName);
+                if ((format = ClipboardFormats.findByAlias(formatName)) == null) {
+                    actor.print(Caption.of("worldedit.schematic.unknown-format", TextComponent.of(formatName)));
+                    return;
+                }
+                // The interface requires the correct schematic extension - otherwise it can't be downloaded
+                // So it basically only supports .schem files (sponge v2 + v3) - or the correct extensions is specified manually
+                // Sadly it's not really an API endpoint but spits out the HTML source of the uploader - so no real handling
+                // can happen
                 URL url = new URL(webUrl, "uploads/" + uuid + "." + format.getPrimaryFileExtension());
-                ReadableByteChannel byteChannel = Channels.newChannel(url.openStream());
-                in = Channels.newInputStream(byteChannel);
-                uri = url.toURI();
+                final Path temp = Files.createTempFile("faweremoteschem", null);
+                final File tempFile = temp.toFile();
+                // delete temporary file when we're done
+                closer.register((Closeable) () -> Files.deleteIfExists(temp));
+                // write schematic into temporary file
+                try (final ReadableByteChannel byteChannel = Channels.newChannel(url.openStream());
+                     final FileOutputStream out = new FileOutputStream(tempFile);
+                     final FileChannel outChannel = out.getChannel()) {
+                    outChannel.transferFrom(byteChannel, 0, Long.MAX_VALUE);
+                }
+                // No format is specified -> try or fail
+                if (noExplicitFormat && (format = ClipboardFormats.findByFile(tempFile)) == null) {
+                    actor.print(Caption.of("fawe.worldedit.schematic.schematic.load-failure", TextComponent.of(filename)));
+                    return;
+                }
+                in = new FileInputStream(tempFile);
+                uri = temp.toUri();
             } else {
                 File saveDir = worldEdit.getWorkingDirectoryPath(config.saveDir).toFile();
                 File dir = Settings.settings().PATHS.PER_PLAYER_SCHEMATICS ? new File(saveDir, actor.getUniqueId().toString()) : saveDir;
@@ -378,7 +403,7 @@ public class SchematicCommands {
                     }
                     if (!noExplicitFormat) {
                         format = ClipboardFormats.findByAlias(formatName);
-                    } else if (filename.matches(".*\\.[\\w].*")) {
+                    } else if (filename.matches(".*\\.\\w.*")) {
                         format = ClipboardFormats
                                 .findByExplicitExtension(filename.substring(filename.lastIndexOf('.') + 1));
                     } else {
@@ -412,6 +437,7 @@ public class SchematicCommands {
                 in = new FileInputStream(file);
                 uri = file.toURI();
             }
+            closer.register(in);
             format.hold(actor, uri, in);
             if (randomRotate) {
                 AffineTransform transform = new AffineTransform();
@@ -422,18 +448,23 @@ public class SchematicCommands {
             actor.print(Caption.of("fawe.worldedit.schematic.schematic.loaded", filename));
         } catch (IllegalArgumentException e) {
             actor.print(Caption.of("worldedit.schematic.unknown-filename", TextComponent.of(filename)));
-        } catch (URISyntaxException | IOException e) {
+        } catch (EOFException e) {
+            // EOFException is extending IOException - but the IOException error is too generic.
+            // EOF mostly occurs when there was unexpected content in the schematic - due to the wrong reader (= version)
+            actor.print(Caption.of("fawe.worldedit.schematic.schematic.load-failure",
+                    TextComponent.of(e.getMessage() != null ? e.getMessage() : "EOFException"))); // often null...
+            LOGGER.error("Error loading a schematic", e);
+        } catch (IOException e) {
             actor.print(Caption.of("worldedit.schematic.file-not-exist", TextComponent.of(Objects.toString(e.getMessage()))));
             LOGGER.warn("Failed to load a saved clipboard", e);
         } catch (Exception e) {
             actor.print(Caption.of("fawe.worldedit.schematic.schematic.load-failure", TextComponent.of(e.getMessage())));
             LOGGER.error("Error loading a schematic", e);
         } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException ignored) {
-                }
+            try {
+                closer.close();
+            } catch (IOException e) {
+                LOGGER.error("Failed to close schematic resources", e);
             }
         }
         //FAWE end


### PR DESCRIPTION
## Overview
Fixes #2892

## Description
Not completely happy with how it works - but that's just a limitation of the interface itself.
When not specifying the format, it'll be auto detected. Sadly, the interface outputs the command with the `schem` format specified (which now defaults to v3). But I've updated the exception handling to state that, if the schematic fails to load (the EOFException triggered, when loading a v2 schematic with the default `schem` was handled by the IOException block):
![image](https://github.com/user-attachments/assets/9b9977c4-4d39-4a25-86cd-917140f87bc6)

As I'd have to download the file either way when checking for the format, it's simply downloaded even if the format is specified. That way it can utilize the reset functionality of the underlying stream for the reader (v3 in particular). The Closer handles the deletion either way - so it shouldn't clog up anything nor be noticeable in any way.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
