### PR TITLE
fix: don't process out of bound section while trimming Y sections

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
@@ -62,7 +62,7 @@ public interface IBatchProcessor {
      * @return false if chunk is empty of blocks
      */
     default boolean trimY(IChunkSet set, int minY, int maxY, final boolean keepInsideRange) {
-        int minLayer = (minY - 1) >> 4;
+        int minLayer = minY >> 4;
         int maxLayer = (maxY + 1) >> 4;
         if (keepInsideRange) {
             for (int layer = set.getMinSectionPosition(); layer <= minLayer; layer++) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
@@ -86,7 +86,15 @@ public interface IBatchProcessor {
                     if (layer == maxLayer) {
                         char[] arr = set.loadIfPresent(layer);
                         if (arr != null) {
-                            int index = ((maxY + 1) & 15) << 8;
+                            /*
+                              If maxY is the last coordinate in a chunk section (`2^n-1`), it bleeds into
+                              the next higher section and represents the 0th block on the y-axis on that section. This results
+                              in the index being 0 (so the whole section is wiped) - even though only the last slice should be
+                              overwritten.
+                              If maxY is any other coordinate (0 - 14) `((maxY + 1) & 15) << 8` is evaluated, resulting in
+                              getting the index for the next (upper) slice of this section (as this one should be overwritten)
+                             */
+                            int index = (maxY + 1) % 16 == 0 ? arr.length : ((maxY + 1) & 15) << 8;
                             for (int i = index; i < arr.length; i++) {
                                 arr[i] = BlockTypesCache.ReservedIDs.__RESERVED__;
                             }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
@@ -63,7 +63,7 @@ public interface IBatchProcessor {
      */
     default boolean trimY(IChunkSet set, int minY, int maxY, final boolean keepInsideRange) {
         int minLayer = minY >> 4;
-        int maxLayer = (maxY + 1) >> 4;
+        int maxLayer = maxY >> 4;
         if (keepInsideRange) {
             for (int layer = set.getMinSectionPosition(); layer <= minLayer; layer++) {
                 if (set.hasSection(layer)) {

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
@@ -22,77 +22,98 @@ class IBatchProcessorTest {
     class trimY {
 
         private static final char[] CHUNK_DATA = new char[16 * 16 * 16];
+        private static final char[] SLICE_AIR = new char[16 * 16];
+        private static final char[] SLICE_RESERVED = new char[16 * 16];
         private final IBatchProcessor processor = new NoopBatchProcessor();
 
         static {
             Arrays.fill(CHUNK_DATA, (char) BlockTypesCache.ReservedIDs.AIR);
+            Arrays.fill(SLICE_AIR, (char) BlockTypesCache.ReservedIDs.AIR);
+            Arrays.fill(SLICE_RESERVED, (char) BlockTypesCache.ReservedIDs.__RESERVED__);
         }
 
         @ParameterizedTest
         @MethodSource("provideTrimYInBoundsParameters")
-        void testFullChunkSelectedInBoundedRegion(int minY, int maxY) {
-            final int minYSection = minY >> 4;
-            final int maxYSection = maxY >> 4;
+        void testFullChunkSelectedInBoundedRegion(int minY, int maxY, int minSection, int maxSection) {
             final IChunkSet set = mock();
 
+            char[][] sections = new char[(320 + 64) >> 4][CHUNK_DATA.length];
+            for (final char[] chars : sections) {
+                System.arraycopy(CHUNK_DATA, 0, chars, 0, CHUNK_DATA.length);
+            }
+
             when(set.getMinSectionPosition()).thenReturn(-64 >> 4);
-            when(set.getMaxSectionPosition()).thenReturn(320 >> 4);
+            when(set.getMaxSectionPosition()).thenReturn(319 >> 4);
             when(set.hasSection(anyInt())).thenReturn(true);
-            when(set.loadIfPresent(anyInt())).thenReturn(CHUNK_DATA); // Return fully populated chunk (AIR)
+            when(set.loadIfPresent(anyInt())).thenAnswer(invocationOnMock -> sections[invocationOnMock.<Integer>getArgument(0) + 4]);
             doAnswer(invocationOnMock -> {
-                int layer = invocationOnMock.getArgument(0);
-                char[] blocks = invocationOnMock.getArgument(1);
-                // when totally out of range (layer mismatch) no blocks should be set
-                if (layer < minYSection || layer > maxYSection) {
-                    if (blocks != null) {
-                        fail("Expected null-array for out of range access at layer %d where minYLayer=%d and maxYLayer=%d"
-                                .formatted(layer, minYSection, maxYSection)
-                        );
-                    }
-                    return null;
-                }
-                assertNotNull(blocks, "expected non-null palette for in bound chunk section");
-                assertEquals(blocks.length, CHUNK_DATA.length, "chunk section palette size diffs from returned get palette");
-
-                // when working on the lowest layer, only blocks above minY should be set - otherwise __RESERVED__
-                if (layer == minYSection) {
-                    char[] expected = Arrays.copyOf(CHUNK_DATA, CHUNK_DATA.length);
-                    Arrays.fill(expected, 0, (minY & 15) << 8, (char) BlockTypesCache.ReservedIDs.__RESERVED__);
-                    assertArrayEquals(
-                            expected, blocks,
-                            "expected in-range blocks at layer=%d to be AIR - out-of-range __RESERVED__"
-                                    .formatted(layer)
-                    );
-                    return null;
-                }
-
-                // kinda the same for the highest layer - just the other way around
-                if (layer == maxYSection) {
-                    char[] expected = Arrays.copyOf(CHUNK_DATA, CHUNK_DATA.length);
-                    Arrays.fill(expected, ((maxY + 1) & 15) << 8, expected.length, (char) BlockTypesCache.ReservedIDs.__RESERVED__);
-                    assertArrayEquals(
-                            expected, blocks,
-                            "expected in-range blocks at layer=%d to be AIR - out-of-range __RESERVED__"
-                                    .formatted(layer)
-                    );
-                    return null;
-                }
-                assertArrayEquals(blocks, CHUNK_DATA, "full chunk should contain full data");
+                sections[invocationOnMock.<Integer>getArgument(0) + 4] = invocationOnMock.getArgument(1);
                 return null;
             }).when(set).setBlocks(anyInt(), any());
 
             processor.trimY(set, minY, maxY, true);
+
+
+            for (int section = -64 >> 4; section < 320 >> 4; section++) {
+                int sectionIndex = section + 4;
+                char[] palette = sections[sectionIndex];
+                if (section < minSection) {
+                    assertNull(palette, "expected section below minimum section to be null");
+                    continue;
+                }
+                if (section > maxSection) {
+                    assertNull(palette, "expected section above maximum section to be null");
+                    continue;
+                }
+                if (section == minSection) {
+                    for (int slice = 0; slice < 16; slice++) {
+                        boolean shouldContainBlocks = slice >= (minY % 16);
+                        // If boundaries only span one section, the upper constraints have to be checked explicitly
+                        if (section == maxSection) {
+                            shouldContainBlocks &= slice <= (maxY % 16);
+                        }
+                        assertArrayEquals(
+                                shouldContainBlocks ? SLICE_AIR : SLICE_RESERVED,
+                                Arrays.copyOfRange(palette, slice << 8, (slice + 1) << 8),
+                                ("[lower] slice %d (y=%d) expected to contain " + (shouldContainBlocks ? "air" : "nothing"))
+                                        .formatted(slice, ((section << 4) + slice))
+                        );
+                    }
+                    continue;
+                }
+                if (section == maxSection) {
+                    for (int slice = 0; slice < 16; slice++) {
+                        boolean shouldContainBlocks = slice <= (maxY % 16);
+                        assertArrayEquals(
+                                shouldContainBlocks ? SLICE_AIR : SLICE_RESERVED,
+                                Arrays.copyOfRange(palette, slice << 8, (slice + 1) << 8),
+                                ("[upper] slice %d (y=%d) expected to contain " + (shouldContainBlocks ? "air" : "nothing"))
+                                        .formatted(slice, ((section << 4) + slice))
+                        );
+                    }
+                    continue;
+                }
+                assertArrayEquals(CHUNK_DATA, palette, "full captured chunk @ %d should contain full data".formatted(section));
+            }
+
         }
 
+        /**
+         * Arguments explained:
+         * 1. minimum y coordinate (inclusive)
+         * 2. maximum y coordinate (inclusive)
+         * 3. chunk section which contains minimum y coordinate
+         * 4. chunk section which contains maximum y coordinate
+         */
         private static Stream<Arguments> provideTrimYInBoundsParameters() {
             return Stream.of(
-                    Arguments.of(64, 72),
-                    Arguments.of(-64, 0),
-                    Arguments.of(0, 128),
-                    Arguments.of(16, 132),
-                    Arguments.of(4, 144),
-                    Arguments.of(12, 255),
-                    Arguments.of(24, 103)
+                    Arguments.of(64, 72, 4, 4),
+                    Arguments.of(-64, 0, -4, 0),
+                    Arguments.of(0, 128, 0, 8),
+                    Arguments.of(16, 132, 1, 8),
+                    Arguments.of(4, 144, 0, 9),
+                    Arguments.of(12, 255, 0, 15),
+                    Arguments.of(24, 103, 1, 6)
             );
         }
 

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
@@ -1,0 +1,104 @@
+package com.fastasyncworldedit.core.queue;
+
+import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.world.block.BlockTypesCache;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class IBatchProcessorTest {
+
+    @Nested
+    class trimY {
+
+        private static final char[] CHUNK_DATA = new char[16 * 16 * 16];
+        private final IBatchProcessor processor = new NoopBatchProcessor();
+
+        static {
+            Arrays.fill(CHUNK_DATA, (char) BlockTypesCache.ReservedIDs.AIR);
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideTrimYInBoundsParameters")
+        void testFullChunkSelectedInBoundedRegion(int minY, int maxY) {
+            final int minYSection = minY >> 4;
+            final int maxYSection = maxY >> 4;
+            final IChunkSet set = mock();
+
+            when(set.getMinSectionPosition()).thenReturn(-64 >> 4);
+            when(set.getMaxSectionPosition()).thenReturn(320 >> 4);
+            when(set.hasSection(anyInt())).thenReturn(true);
+            when(set.loadIfPresent(anyInt())).thenReturn(CHUNK_DATA); // Return fully populated chunk (AIR)
+            doAnswer(invocationOnMock -> {
+                int layer = invocationOnMock.getArgument(0);
+                char[] blocks = invocationOnMock.getArgument(1);
+                // when totally out of range (layer mismatch) no blocks should be set
+                if ((layer < minYSection || layer > maxYSection)) {
+                    if (blocks != null) {
+                        fail("Expected null-array for out of range access at layer %d where minYLayer=%d and maxYLayer=%d"
+                                .formatted(layer, minYSection, maxYSection)
+                        );
+                    }
+                    return null;
+                }
+                assertNotNull(blocks, "expected non-null palette for in bound chunk section");
+                assertEquals(blocks.length, CHUNK_DATA.length, "chunk section palette size diffs from returned get palette");
+
+                // when working on the lowest layer, only blocks above minY should be set - otherwise __RESERVED__
+                if (layer == minYSection) {
+                    char[] expected = Arrays.copyOf(CHUNK_DATA, CHUNK_DATA.length);
+                    Arrays.fill(expected, 0, (minY & 15) << 8, (char) BlockTypesCache.ReservedIDs.__RESERVED__);
+                    assertArrayEquals(expected, blocks, "expected in-range blocks to be AIR - out-of-range __RESERVED__");
+                    return null;
+                }
+
+                // kinda the same for the highest layer - just the other way around
+                if (layer == maxYSection) {
+                    char[] expected = Arrays.copyOf(CHUNK_DATA, CHUNK_DATA.length);
+                    Arrays.fill(expected, (maxY & 15) << 8, expected.length, (char) BlockTypesCache.ReservedIDs.__RESERVED__);
+                    assertArrayEquals(expected, blocks, "expected in-range blocks to be AIR - out-of-range __RESERVED__");
+                    return null;
+                }
+                assertArrayEquals(blocks, CHUNK_DATA, "full chunk should contain full data");
+                return null;
+            }).when(set).setBlocks(anyInt(), any());
+
+            processor.trimY(set, minY, maxY, true);
+        }
+
+        private static Stream<Arguments> provideTrimYInBoundsParameters() {
+            return Stream.of(
+                    Arguments.of(64, 72),
+                    Arguments.of(-64, 0),
+                    Arguments.of(0, 128),
+                    Arguments.of(4, 144),
+                    Arguments.of(12, 256),
+                    Arguments.of(24, 103)
+            );
+        }
+
+    }
+
+    private static final class NoopBatchProcessor implements IBatchProcessor {
+
+        @Override
+        public IChunkSet processSet(final IChunk chunk, final IChunkGet get, final IChunkSet set) {
+            return set;
+        }
+
+        @Override
+        public @Nullable Extent construct(final Extent child) {
+            return null;
+        }
+
+    }
+
+}

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
@@ -41,7 +41,7 @@ class IBatchProcessorTest {
                 int layer = invocationOnMock.getArgument(0);
                 char[] blocks = invocationOnMock.getArgument(1);
                 // when totally out of range (layer mismatch) no blocks should be set
-                if ((layer < minYSection || layer > maxYSection)) {
+                if (layer < minYSection || layer > maxYSection) {
                     if (blocks != null) {
                         fail("Expected null-array for out of range access at layer %d where minYLayer=%d and maxYLayer=%d"
                                 .formatted(layer, minYSection, maxYSection)
@@ -56,7 +56,11 @@ class IBatchProcessorTest {
                 if (layer == minYSection) {
                     char[] expected = Arrays.copyOf(CHUNK_DATA, CHUNK_DATA.length);
                     Arrays.fill(expected, 0, (minY & 15) << 8, (char) BlockTypesCache.ReservedIDs.__RESERVED__);
-                    assertArrayEquals(expected, blocks, "expected in-range blocks to be AIR - out-of-range __RESERVED__");
+                    assertArrayEquals(
+                            expected, blocks,
+                            "expected in-range blocks at layer=%d to be AIR - out-of-range __RESERVED__"
+                                    .formatted(layer)
+                    );
                     return null;
                 }
 
@@ -64,7 +68,11 @@ class IBatchProcessorTest {
                 if (layer == maxYSection) {
                     char[] expected = Arrays.copyOf(CHUNK_DATA, CHUNK_DATA.length);
                     Arrays.fill(expected, (maxY & 15) << 8, expected.length, (char) BlockTypesCache.ReservedIDs.__RESERVED__);
-                    assertArrayEquals(expected, blocks, "expected in-range blocks to be AIR - out-of-range __RESERVED__");
+                    assertArrayEquals(
+                            expected, blocks,
+                            "expected in-range blocks at layer=%d to be AIR - out-of-range __RESERVED__"
+                                    .formatted(layer)
+                    );
                     return null;
                 }
                 assertArrayEquals(blocks, CHUNK_DATA, "full chunk should contain full data");
@@ -80,7 +88,7 @@ class IBatchProcessorTest {
                     Arguments.of(-64, 0),
                     Arguments.of(0, 128),
                     Arguments.of(4, 144),
-                    Arguments.of(12, 256),
+                    Arguments.of(12, 255),
                     Arguments.of(24, 103)
             );
         }

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
@@ -4,14 +4,11 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import java.util.Arrays;
 import java.util.stream.Stream;
 

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/queue/IBatchProcessorTest.java
@@ -4,10 +4,14 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -17,6 +21,7 @@ import static org.mockito.Mockito.*;
 class IBatchProcessorTest {
 
     @Nested
+    @Isolated
     class trimY {
 
         private static final char[] CHUNK_DATA = new char[16 * 16 * 16];
@@ -67,7 +72,7 @@ class IBatchProcessorTest {
                 // kinda the same for the highest layer - just the other way around
                 if (layer == maxYSection) {
                     char[] expected = Arrays.copyOf(CHUNK_DATA, CHUNK_DATA.length);
-                    Arrays.fill(expected, (maxY & 15) << 8, expected.length, (char) BlockTypesCache.ReservedIDs.__RESERVED__);
+                    Arrays.fill(expected, ((maxY + 1) & 15) << 8, expected.length, (char) BlockTypesCache.ReservedIDs.__RESERVED__);
                     assertArrayEquals(
                             expected, blocks,
                             "expected in-range blocks at layer=%d to be AIR - out-of-range __RESERVED__"
@@ -87,6 +92,7 @@ class IBatchProcessorTest {
                     Arguments.of(64, 72),
                     Arguments.of(-64, 0),
                     Arguments.of(0, 128),
+                    Arguments.of(16, 132),
                     Arguments.of(4, 144),
                     Arguments.of(12, 255),
                     Arguments.of(24, 103)


### PR DESCRIPTION
## Overview
Fixes #2894

## Description
trimY now doesn't overflow into unrelated sections anymore, allowing out of bounds editing. Seems to work for me so far - tests are passing. I couldn't find any edge cases or how that might break other existing behavior. 

I'd highly appreciate additional tests by others.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
