### PR TITLE
Avoid map lookup in `isMovementBlocker` calls

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightBlockMaterial.java
@@ -135,9 +135,10 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return block.isRandomlyTicking(blockState);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean isMovementBlocker() {
-        return craftMaterial.isSolid();
+        return blockState.blocksMotion();
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightBlockMaterial.java
@@ -125,9 +125,10 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return block.isRandomlyTicking(blockState);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean isMovementBlocker() {
-        return craftMaterial.isSolid();
+        return blockState.blocksMotion();
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightBlockMaterial.java
@@ -126,9 +126,10 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return blockState.isRandomlyTicking();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean isMovementBlocker() {
-        return craftMaterial.isSolid();
+        return blockState.blocksMotion();
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightBlockMaterial.java
@@ -126,9 +126,10 @@ public class PaperweightBlockMaterial implements BlockMaterial {
         return blockState.isRandomlyTicking();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean isMovementBlocker() {
-        return craftMaterial.isSolid();
+        return blockState.blocksMotion();
     }
 
     @Override


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`isMovementBlocker` is called in the `HeightmapProcessor` for every edited column at least once, so it's kind of a hot method. On newer Spigot versions, the call `Material#isSolid()` however requires a map lookup as it goes through the registry, slowing down the method call unnecessarily. As we already have the NMS block state available, we can just take the shortcut and call the method that is used by Spigot (and by the NMS heightmap calculation) directly.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
