### PR TITLE
Revert history writing using LinBinaryIO

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
@@ -22,12 +22,9 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockTypes;
-import org.enginehub.linbus.stream.LinBinaryIO;
-import org.enginehub.linbus.tree.LinRootEntry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.DataOutput;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -405,8 +402,8 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
     public void addTileCreate(final FaweCompoundTag tag) {
         blockSize++;
         try {
-            DataOutput nbtos = getTileCreateOS();
-            LinBinaryIO.write(nbtos, new LinRootEntry("tile-create", tag.linTag()));
+            NBTOutputStream nbtos = getTileCreateOS();
+            nbtos.writeTag(new CompoundTag(tag.linTag()));
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -416,8 +413,8 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
     public void addTileRemove(final FaweCompoundTag tag) {
         blockSize++;
         try {
-            DataOutput nbtos = getTileRemoveOS();
-            LinBinaryIO.write(nbtos, new LinRootEntry("tile-remove", tag.linTag()));
+            NBTOutputStream nbtos = getTileRemoveOS();
+            nbtos.writeTag(new CompoundTag(tag.linTag()));
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -427,8 +424,8 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
     public void addEntityRemove(final FaweCompoundTag tag) {
         blockSize++;
         try {
-            DataOutput nbtos = getEntityRemoveOS();
-            LinBinaryIO.write(nbtos, new LinRootEntry("entity-remove", tag.linTag()));
+            NBTOutputStream nbtos = getEntityRemoveOS();
+            nbtos.writeTag(new CompoundTag(tag.linTag()));
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -438,8 +435,8 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
     public void addEntityCreate(final FaweCompoundTag tag) {
         blockSize++;
         try {
-            DataOutput nbtos = getEntityCreateOS();
-            LinBinaryIO.write(nbtos, new LinRootEntry("entity-create", tag.linTag()));
+            NBTOutputStream nbtos = getEntityCreateOS();
+            nbtos.writeTag(new CompoundTag(tag.linTag()));
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

Writing using LinBinaryIO isn't what we want. It only allows writing named tags, but that's not what we want. As I also didn't change the reading accordingly, this results in reading arbitrary data.

Reverting this will (again) cause some additional computation/memory overhead but makes history work correctly again.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
