### PR TITLE
Fix NBT stripping and trimming

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/LimitExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/LimitExtent.java
@@ -512,8 +512,8 @@ public class LimitExtent extends AbstractDelegateExtent implements IBatchProcess
         if (!processing) {
             return set;
         }
-        int tiles = set.getTiles().size();
-        int ents = set.getEntities().size() + set.getEntityRemoves().size();
+        int tiles = set.tiles().size();
+        int ents = set.entities().size() + set.getEntityRemoves().size();
         limit.THROW_MAX_CHANGES(tiles + ents);
         limit.THROW_MAX_BLOCKSTATES(tiles);
         limit.THROW_MAX_ENTITIES(ents);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBatchProcessor.java
@@ -3,15 +3,16 @@ package com.fastasyncworldedit.core.queue;
 import com.fastasyncworldedit.core.extent.processor.EmptyBatchProcessor;
 import com.fastasyncworldedit.core.extent.processor.MultiBatchProcessor;
 import com.fastasyncworldedit.core.extent.processor.ProcessorScope;
-import com.sk89q.jnbt.CompoundTag;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
+import com.fastasyncworldedit.core.util.NbtUtils;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.function.Function;
@@ -156,11 +157,11 @@ public interface IBatchProcessor {
      */
     @Deprecated(forRemoval = true, since = "2.8.4")
     default boolean trimNBT(IChunkSet set, Function<BlockVector3, Boolean> contains) {
-        Set<CompoundTag> ents = set.getEntities();
+        Collection<FaweCompoundTag> ents = set.entities();
         if (!ents.isEmpty()) {
-            ents.removeIf(ent -> !contains.apply(ent.getEntityPosition().toBlockPoint()));
+            ents.removeIf(ent -> !contains.apply(NbtUtils.entityPosition(ent).toBlockPoint()));
         }
-        Map<BlockVector3, CompoundTag> tiles = set.getTiles();
+        Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
         if (!tiles.isEmpty()) {
             tiles.entrySet().removeIf(blockVector3CompoundTagEntry -> !contains
                     .apply(blockVector3CompoundTagEntry.getKey()));
@@ -177,11 +178,11 @@ public interface IBatchProcessor {
     default boolean trimNBT(
             IChunkSet set, Function<BlockVector3, Boolean> containsEntity, Function<BlockVector3, Boolean> containsTile
     ) {
-        Set<CompoundTag> ents = set.getEntities();
+        Collection<FaweCompoundTag> ents = set.entities();
         if (!ents.isEmpty()) {
-            ents.removeIf(ent -> !containsEntity.apply(ent.getEntityPosition().toBlockPoint()));
+            ents.removeIf(ent -> !containsEntity.apply(NbtUtils.entityPosition(ent).toBlockPoint()));
         }
-        Map<BlockVector3, CompoundTag> tiles = set.getTiles();
+        Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
         if (!tiles.isEmpty()) {
             tiles.entrySet().removeIf(blockVector3CompoundTagEntry -> !containsTile.apply(blockVector3CompoundTagEntry.getKey()));
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBlocks.java
@@ -61,7 +61,7 @@ public interface IBlocks extends Trimable {
 
     @Deprecated(forRemoval = true, since = "2.11.2")
     default Map<BlockVector3, CompoundTag> getTiles() {
-        return AdaptedMap.immutable(tiles(), pos -> pos, IBlocks::toCompoundTag);
+        return AdaptedMap.values(tiles(), ct -> FaweCompoundTag.of(ct.toLinTag()), IBlocks::toCompoundTag);
     }
 
     Map<BlockVector3, FaweCompoundTag> tiles();

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/NbtUtils.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/NbtUtils.java
@@ -2,6 +2,7 @@ package com.fastasyncworldedit.core.util;
 
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.entity.Entity;
+import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.storage.InvalidFormatException;
 import org.enginehub.linbus.tree.LinByteTag;
@@ -209,6 +210,20 @@ public final class NbtUtils {
 
         map.put("PersistentIDMSB", LinLongTag.of(uuid.getMostSignificantBits()));
         map.put("PersistentIDLSB", LinLongTag.of(uuid.getLeastSignificantBits()));
+    }
+
+    /**
+     * {@return the position data of the given tag}
+     *
+     * @param compoundTag the tag to extract position information from
+     * @since TODO
+     */
+    public static Vector3 entityPosition(FaweCompoundTag compoundTag) {
+        LinListTag<LinDoubleTag> pos = compoundTag.linTag().getListTag("Pos", LinTagType.doubleTag());
+        double x = pos.get(0).valueAsDouble();
+        double y = pos.get(1).valueAsDouble();
+        double z = pos.get(2).valueAsDouble();
+        return Vector3.at(x, y, z);
     }
 
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2928

## Description
<!-- Please describe what this pull request does. -->

` IBlocks#getEntities()` and `IBlocks#getTiles()` returned mutable collections before #2883, which FAWE depends on when trimming or stripping NBT data. After the change, `getEntities()` still returns a mutable set which does *not* reflect changes to the original set, and `getTiles()` returns an immutable view of the backing map. This leads to exceptions and misbehavior as seen in #2928.

This change does two things:
- Avoid the usage of the deprecated methods in FAWE and use `tiles()` and `entities()` instead, this should also bring performance benefits
- Make `getTiles()` mutable again. This does not work as easy for `getEntities()`, so I just hope no one outside of FAWE uses this method while relying on mutability.

I also noticed that entity NBT stripping was broken, as we lowercase all keys to strip, but the code called toUpperCase when looking up if the key should be removed.

The `stripEntityNBT` and `stripBlockNBT` methods do not care about that at all, so I assume they won't work currently?

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
