### PR TITLE
Make property changes more robust

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/registry/state/PropertyKey.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/registry/state/PropertyKey.java
@@ -137,4 +137,9 @@ public class PropertyKey implements Comparable<PropertyKey> {
         return Integer.compare(this.id, o.id);
     }
 
+    @Override
+    public String toString() {
+        return "PropertyKey[" + getName() + "]";
+    }
+
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockState.java
@@ -351,7 +351,7 @@ public class BlockState implements BlockStateHolder<BlockState>, Pattern {
         BlockState newState = this;
         for (Property<?> prop : ot.getProperties()) {
             PropertyKey key = prop.getKey();
-            if (blockType.hasProperty(key)) {
+            if (blockType.hasPropertyOfType(key, prop.getClass())) {
                 newState = newState.with(key, other.getState(key));
             }
         }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockType.java
@@ -247,6 +247,21 @@ public class BlockType implements Keyed, Pattern {
         return this.settings.propertiesMapArr.length > ordinal && this.settings.propertiesMapArr[ordinal] != null;
     }
 
+    /**
+     * {@return whether this block type has a property with given key of the given type}
+     *
+     * @param key          the key identifying the property
+     * @param propertyType the expected type of the property
+     * @since TODO
+     */
+    public boolean hasPropertyOfType(PropertyKey key, Class<?> propertyType) {
+        int ordinal = key.getId();
+        Property<?> property;
+        return this.settings.propertiesMapArr.length > ordinal
+                && (property = this.settings.propertiesMapArr[ordinal]) != null
+                && property.getClass() == propertyType;
+    }
+
     public <V> Property<V> getProperty(PropertyKey key) {
         try {
             return (Property<V>) this.settings.propertiesMapArr[key.getId()];


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2961

## Description
<!-- Please describe what this pull request does. -->

Different block types can share a property with the same name but with different types. In such case, we shouldn't try to apply the property with invalid values.

We could probably also remove the `IllegalArgumentException` and just return the current block state instead in `BlockState#with(PropertyKey,V)`, but that might hide other problems. Thoughts?

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
