### PR TITLE
Deduplicate adapter fields into superclass

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -117,18 +117,10 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
     }
 
-    private final com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R2.PaperweightAdapter parent;
-    // ------------------------------------------------------------------------
-    // Code that may break between versions of Minecraft
-    // ------------------------------------------------------------------------
     private final PaperweightMapChunkUtil mapUtil = new PaperweightMapChunkUtil();
-    private char[] ibdToStateOrdinal = null;
-    private int[] ordinalToIbdID = null;
-    private boolean initialised = false;
-    private Map<String, List<Property<?>>> allBlockProperties = null;
 
     public PaperweightFaweAdapter() throws NoSuchFieldException, NoSuchMethodException {
-        this.parent = new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R2.PaperweightAdapter();
+        super(new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R2.PaperweightAdapter());
     }
 
     public Function<BlockEntity, FaweCompoundTag> blockEntityToCompoundTag() {

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
@@ -117,18 +117,10 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
     }
 
-    private final com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R3.PaperweightAdapter parent;
-    // ------------------------------------------------------------------------
-    // Code that may break between versions of Minecraft
-    // ------------------------------------------------------------------------
     private final PaperweightMapChunkUtil mapUtil = new PaperweightMapChunkUtil();
-    private char[] ibdToStateOrdinal = null;
-    private int[] ordinalToIbdID = null;
-    private boolean initialised = false;
-    private Map<String, List<Property<?>>> allBlockProperties = null;
 
     public PaperweightFaweAdapter() throws NoSuchFieldException, NoSuchMethodException {
-        this.parent = new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R3.PaperweightAdapter();
+        super(new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R3.PaperweightAdapter());
     }
 
     public Function<BlockEntity, FaweCompoundTag> blockEntityToCompoundTag() {

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
@@ -126,18 +126,10 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
     }
 
-    private final com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R4.PaperweightAdapter parent;
-    // ------------------------------------------------------------------------
-    // Code that may break between versions of Minecraft
-    // ------------------------------------------------------------------------
     private final PaperweightMapChunkUtil mapUtil = new PaperweightMapChunkUtil();
-    private char[] ibdToStateOrdinal = null;
-    private int[] ordinalToIbdID = null;
-    private boolean initialised = false;
-    private Map<String, List<Property<?>>> allBlockProperties = null;
 
     public PaperweightFaweAdapter() throws NoSuchFieldException, NoSuchMethodException {
-        this.parent = new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R4.PaperweightAdapter();
+        super(new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_20_R4.PaperweightAdapter());
     }
 
     public Function<BlockEntity, FaweCompoundTag> blockEntityToCompoundTag() {

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -126,18 +126,10 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
     }
 
-    private final com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_21_R1.PaperweightAdapter parent;
-    // ------------------------------------------------------------------------
-    // Code that may break between versions of Minecraft
-    // ------------------------------------------------------------------------
     private final PaperweightMapChunkUtil mapUtil = new PaperweightMapChunkUtil();
-    private char[] ibdToStateOrdinal = null;
-    private int[] ordinalToIbdID = null;
-    private boolean initialised = false;
-    private Map<String, List<Property<?>>> allBlockProperties = null;
 
     public PaperweightFaweAdapter() throws NoSuchFieldException, NoSuchMethodException {
-        this.parent = new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_21_R1.PaperweightAdapter();
+        super(new com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_21_R1.PaperweightAdapter());
     }
 
     public Function<BlockEntity, FaweCompoundTag> blockEntityToCompoundTag() {

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
@@ -4,7 +4,9 @@ import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
+import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.TreeGenerator;
 import org.bukkit.Material;
 import org.bukkit.TreeType;
@@ -12,6 +14,7 @@ import org.bukkit.World;
 import org.bukkit.block.BlockState;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * A base class for version-specific implementations of the BukkitImplAdapter
@@ -20,6 +23,16 @@ import java.util.List;
  * @param <SERVER_LEVEL> the version-specific ServerLevel type
  */
 public abstract class FaweAdapter<TAG, SERVER_LEVEL> extends CachedBukkitAdapter implements IDelegateBukkitImplAdapter<TAG> {
+
+    protected final BukkitImplAdapter<TAG> parent;
+    protected char[] ibdToStateOrdinal = null;
+    protected int[] ordinalToIbdID = null;
+    protected boolean initialised = false;
+    protected Map<String, List<Property<?>>> allBlockProperties = null;
+
+    protected FaweAdapter(final BukkitImplAdapter<TAG> parent) {
+        this.parent = parent;
+    }
 
     @Override
     public boolean generateTree(


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

We can reduce some code duplication by moving the fields that don't require a version-dependent type to the superclass.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
