### PR TITLE
API: New Clipboard helper methods

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
@@ -190,6 +190,25 @@ public interface Clipboard extends Extent, Iterable<BlockVector3>, Closeable, Fl
         return getDimensions().z();
     }
 
+    default BlockVector3 getCenter() {
+        return new BlockVector3() {
+            @Override
+            public int x() {
+                return getWidth() / 2;
+            }
+
+            @Override
+            public int y() {
+                return getHeight() / 2;
+            }
+
+            @Override
+            public int z() {
+                return getLength() / 2;
+            }
+        };
+    }
+
     default int getArea() {
         return getWidth() * getLength();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
@@ -217,6 +217,14 @@ public interface Clipboard extends Extent, Iterable<BlockVector3>, Closeable, Fl
         return getMinimumPoint().distanceSq(getMaximumPoint());
     }
 
+    default double getRadius() {
+        return getDiagonal() / 2;
+    }
+
+    default int getRadiusSq() {
+        return getDiagonalSq() / 4;
+    }
+
     default int getArea() {
         return getWidth() * getLength();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
@@ -213,7 +213,7 @@ public interface Clipboard extends Extent, Iterable<BlockVector3>, Closeable, Fl
         return getMinimumPoint().distance(getMaximumPoint());
     }
 
-    default double getDiagonalSq() {
+    default int getDiagonalSq() {
         return getMinimumPoint().distanceSq(getMaximumPoint());
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
@@ -209,6 +209,14 @@ public interface Clipboard extends Extent, Iterable<BlockVector3>, Closeable, Fl
         };
     }
 
+    default double getDiagonal() {
+        return getMinimumPoint().distance(getMaximumPoint());
+    }
+
+    default double getDiagonalSq() {
+        return getMinimumPoint().distanceSq(getMaximumPoint());
+    }
+
     default int getArea() {
         return getWidth() * getLength();
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->
Make Clipboards easier to use and less boilerplate.

## Description
<!-- Please describe what this pull request does. -->
Adds `getCenter()`, `getDiagonal()`, `getDiagonalSq()`, `getRadius()`, and `getRadiusSq()` methods to `com.sk89q.worldedit.extent.clipboard.Clipboard`.