### PR TITLE
Fix direction changes for //undo

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
@@ -817,6 +817,7 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
             @Override
             protected void write(final MutableTileChange change, final CompoundTag tag) {
                 change.tag = tag;
+                change.create = create;
             }
 
             @Override
@@ -845,6 +846,7 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
             @Override
             protected void write(final MutableEntityChange change, final CompoundTag tag) {
                 change.tag = tag;
+                change.create = create;
             }
 
             @Override


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #2971 

## Description
<!-- Please describe what this pull request does. -->

With the coordinated undo, we now reuse `MutableTileChange` and `MutableEntityChange` across `create` and `remove` changes. This however requires us to also adjust the change in that regard. Unconditionally writing the currently expected value is most likely the simplest solution.

This is not a problem for other change types as we don't have the create/remove situation there.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
