### PR TITLE
Update feature/folia-v3, ensuring latest devbundle for 1.20.4 mappings - worldedit-bukkit 

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_4/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/build.gradle.kts
@@ -12,6 +12,6 @@ repositories {
 
 dependencies {
     // url=https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/1.20.4-R0.1-SNAPSHOT
-    the<PaperweightUserDependenciesExtension>().paperDevBundle("1.20.4-R0.1-20240325.123556-143")
+    the<PaperweightUserDependenciesExtension>().paperDevBundle("1.20.4-R0.1-SNAPSHOT")
     compileOnly(libs.paperlib)
 }


### PR DESCRIPTION
Update devbundle, with --refresh-dependencies will allow compilation

## Overview
Fixes: 

> `org.gradle.internal.operations.BuildOperationInvocationException: Failed to apply dev bundle patches. See the log file at 'C:\Users\User\source\repos\TailWindSea\FastAsyncWorldEdit\worldedit-bukkit\adapters\adapter-1_20_4\.gradle\caches\paperweight\setupCache\patchedSourcesJar.log' for more details. Usually, the issue is with the dev bundle itself, and not the userdev project.`

## Description
Sets to the release of devbundle to` -SNAPSHOT` , which does produce a valid build, and is a redirect to grab the latest dev-bundle

```[tasklist]
### Submitter Checklist
- [ ] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [ ] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [ ] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
