### PR TITLE
Fix //snow

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightBlockMaterial.java
@@ -70,7 +70,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        return craftMaterial.isOccluding();
+        return Block.isShapeFullBlock(blockState.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightBlockMaterial.java
@@ -61,7 +61,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        return craftMaterial.isOccluding();
+        return Block.isShapeFullBlock(blockState.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightBlockMaterial.java
@@ -61,7 +61,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        return craftMaterial.isOccluding();
+        return Block.isShapeFullBlock(blockState.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightBlockMaterial.java
@@ -61,7 +61,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        return craftMaterial.isOccluding();
+        return Block.isShapeFullBlock(blockState.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightBlockMaterial.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightBlockMaterial.java
@@ -61,7 +61,7 @@ public class PaperweightBlockMaterial implements BlockMaterial {
 
     @Override
     public boolean isFullCube() {
-        return craftMaterial.isOccluding();
+        return Block.isShapeFullBlock(blockState.getShape(EmptyBlockGetter.INSTANCE, BlockPos.ZERO));
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -170,7 +170,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.sk89q.worldedit.function.block.SnowSimulator.snowy;
+import static com.sk89q.worldedit.function.block.SnowSimulator.SNOWY;
 import static com.sk89q.worldedit.regions.Regions.asFlatRegion;
 import static com.sk89q.worldedit.regions.Regions.maximumBlockY;
 import static com.sk89q.worldedit.regions.Regions.minimumBlockY;
@@ -2788,8 +2788,8 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
                         if (setBlock(mutable, air)) {
                             if (y > getMinY()) {
                                 BlockState block = getBlock(mutable2);
-                                if (block.getBlockType().hasProperty(snowy)) {
-                                    if (setBlock(mutable2, block.with(snowy, false))) {
+                                if (block.getBlockType().hasProperty(SNOWY)) {
+                                    if (setBlock(mutable2, block.with(SNOWY, false))) {
                                         affected++;
                                     }
                                 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/SnowSimulator.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/block/SnowSimulator.java
@@ -39,9 +39,8 @@ public class SnowSimulator implements LayerFunction {
     public static final BooleanProperty SNOWY = (BooleanProperty) (Property<?>) BlockTypes.GRASS_BLOCK.getProperty("snowy");
     private static final EnumProperty PROPERTY_SLAB = (EnumProperty) (Property<?>) BlockTypes.OAK_SLAB.getProperty("type");
     private static final EnumProperty PROPERTY_STAIR = (EnumProperty) (Property<?>) BlockTypes.OAK_STAIRS.getProperty("half");
-    private static final EnumProperty TRAPDOOR = (EnumProperty) (Property<?>) BlockTypes.OAK_TRAPDOOR.getProperty("half");
-    private static final BooleanProperty TRAPDOOR_OPEN = (BooleanProperty) (Property<?>) BlockTypes.OAK_TRAPDOOR.getProperty(
-            "open");
+    private static final EnumProperty PROPERTY_TRAPDOOR = (EnumProperty) (Property<?>) BlockTypes.OAK_TRAPDOOR.getProperty("half");
+    private static final BooleanProperty PROPERTY_TRAPDOOR_OPEN = (BooleanProperty) (Property<?>) BlockTypes.OAK_TRAPDOOR.getProperty("open");
 
     private static final BlockState ICE = BlockTypes.ICE.getDefaultState();
     private static final BlockState SNOW = BlockTypes.SNOW.getDefaultState();
@@ -179,12 +178,12 @@ public class SnowSimulator implements LayerFunction {
             return PROPERTY_VALUE_TOP.equals(blockState.getState(PROPERTY_SLAB));
         }
         // if block is a trapdoor, the trapdoor must NOT be open
-        if (type.hasProperty(TRAPDOOR_OPEN) && blockState.getState(TRAPDOOR_OPEN)) {
+        if (type.hasProperty(PROPERTY_TRAPDOOR_OPEN) && blockState.getState(PROPERTY_TRAPDOOR_OPEN)) {
             return false;
         }
         // if block is a closed trapdoor, the trapdoor must be aligned at the top part of the block
-        if (type.hasProperty(TRAPDOOR)) {
-            return PROPERTY_VALUE_TOP.equals(blockState.getState(TRAPDOOR));
+        if (type.hasProperty(PROPERTY_TRAPDOOR)) {
+            return PROPERTY_VALUE_TOP.equals(blockState.getState(PROPERTY_TRAPDOOR));
         }
         // if block is a stair, it must be "bottom" (upside-down)
         if (type.hasProperty(PROPERTY_STAIR)) {


### PR DESCRIPTION
## Overview
https://github.com/IntellectualSites/FastAsyncWorldEdit/pull/2976 seems to have introduced a regression - which should be fixed now

## Description
- Updated #isFullBlock to actually check for the VoxelShape and not the occlusion of the block
- Updated SnowSimulator to make it more readable (hopefully?) and following Minecrafts snow / rain ticking logic closer

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
