### PR TITLE
Optimize layer iteration to prevent performance overhead.

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -403,7 +403,7 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
         if (tx >= min.x() && bx <= max.x() && tz >= min.z() && bz <= max.z()) {
             // contains some
             boolean processExtra = false;
-            for (int layer = getMinimumY() >> 4; layer <= getMaximumY() >> 4; layer++) {
+            for (int layer = Math.max(getMinimumY(), chunk.getMinY()) >> 4; layer <= Math.min(getMaximumY(), chunk.getMaxY()) >> 4; layer++) {
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -457,7 +457,7 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
         if (tx >= min.x() && bx <= max.x() && tz >= min.z() && bz <= max.z()) {
             // contains some
             boolean processExtra = false;
-            for (int layer = getMinimumY() >> 4; layer <= getMaximumY() >> 4; layer++) {
+            for (int layer = Math.max(getMinimumY(), chunk.getMinY()) >> 4; layer <= Math.min(getMaximumY(), chunk.getMaxY()) >> 4; layer++) {
                 int by = layer << 4;
                 int ty = by + 15;
                 if (containsEntireCuboid(bx, tx, by, ty, bz, tz)) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -403,9 +403,9 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
         if (tx >= min.x() && bx <= max.x() && tz >= min.z() && bz <= max.z()) {
             // contains some
             boolean processExtra = false;
-            final int max1 = Math.max(getMinimumY(), chunk.getMinY());
-            final int min1 = Math.min(getMaximumY(), chunk.getMaxY());
-            for (int layer = max1 >> 4; layer <= min1 >> 4; layer++) {
+            final int minLayer = Math.max(getMinimumY(), chunk.getMinY());
+            final int maxLayer = Math.min(getMaximumY(), chunk.getMaxY());
+            for (int layer = minLayer >> 4; layer <= maxLayer >> 4; layer++) {
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -459,9 +459,9 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
         if (tx >= min.x() && bx <= max.x() && tz >= min.z() && bz <= max.z()) {
             // contains some
             boolean processExtra = false;
-            final int max1 = Math.max(getMinimumY(), chunk.getMinY());
-            final int min1 = Math.min(getMaximumY(), chunk.getMaxY());
-            for (int layer = max1 >> 4; layer <= min1 >> 4; layer++) {
+            final int minLayer = Math.max(getMinimumY(), chunk.getMinY());
+            final int maxLayer = Math.min(getMaximumY(), chunk.getMaxY());
+            for (int layer = minLayer >> 4; layer <= maxLayer >> 4; layer++) {
                 int by = layer << 4;
                 int ty = by + 15;
                 if (containsEntireCuboid(bx, tx, by, ty, bz, tz)) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -403,9 +403,9 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
         if (tx >= min.x() && bx <= max.x() && tz >= min.z() && bz <= max.z()) {
             // contains some
             boolean processExtra = false;
-            final int minLayer = Math.max(getMinimumY(), chunk.getMinY());
-            final int maxLayer = Math.min(getMaximumY(), chunk.getMaxY());
-            for (int layer = minLayer >> 4; layer <= maxLayer >> 4; layer++) {
+            final int minLayer = Math.max(getMinimumY(), chunk.getMinY()) >> 4;
+            final int maxLayer = Math.min(getMaximumY(), chunk.getMaxY()) >> 4;
+            for (int layer = minLayer; layer <= maxLayer; layer++) {
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -459,9 +459,9 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
         if (tx >= min.x() && bx <= max.x() && tz >= min.z() && bz <= max.z()) {
             // contains some
             boolean processExtra = false;
-            final int minLayer = Math.max(getMinimumY(), chunk.getMinY());
-            final int maxLayer = Math.min(getMaximumY(), chunk.getMaxY());
-            for (int layer = minLayer >> 4; layer <= maxLayer >> 4; layer++) {
+            final int minLayer = Math.max(getMinimumY(), chunk.getMinY()) >> 4;
+            final int maxLayer = Math.min(getMaximumY(), chunk.getMaxY()) >> 4;
+            for (int layer = minLayer; layer <= maxLayer; layer++) {
                 int by = layer << 4;
                 int ty = by + 15;
                 if (containsEntireCuboid(bx, tx, by, ty, bz, tz)) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -403,7 +403,9 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
         if (tx >= min.x() && bx <= max.x() && tz >= min.z() && bz <= max.z()) {
             // contains some
             boolean processExtra = false;
-            for (int layer = Math.max(getMinimumY(), chunk.getMinY()) >> 4; layer <= Math.min(getMaximumY(), chunk.getMaxY()) >> 4; layer++) {
+            final int max1 = Math.max(getMinimumY(), chunk.getMinY());
+            final int min1 = Math.min(getMaximumY(), chunk.getMaxY());
+            for (int layer = max1 >> 4; layer <= min1 >> 4; layer++) {
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -457,7 +459,9 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
         if (tx >= min.x() && bx <= max.x() && tz >= min.z() && bz <= max.z()) {
             // contains some
             boolean processExtra = false;
-            for (int layer = Math.max(getMinimumY(), chunk.getMinY()) >> 4; layer <= Math.min(getMaximumY(), chunk.getMaxY()) >> 4; layer++) {
+            final int max1 = Math.max(getMinimumY(), chunk.getMinY());
+            final int min1 = Math.min(getMaximumY(), chunk.getMaxY());
+            for (int layer = max1 >> 4; layer <= min1 >> 4; layer++) {
                 int by = layer << 4;
                 int ty = by + 15;
                 if (containsEntireCuboid(bx, tx, by, ty, bz, tz)) {


### PR DESCRIPTION
## Overview

Clamp the min and max y values to the min and max values of the chunk

## Description

Adjusted the layer iteration logic in the Region class to use the minimum and maximum Y-values from the chunk. This prevents unnecessary iterations when getMinimumY or getMaximumY returns extreme values, improving performance efficiency.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
