### PR TITLE
fix: make RegionMaskingFilter upstream compatible again

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BiomeCommands.java
@@ -206,7 +206,7 @@ public class BiomeCommands {
 
         RegionFunction replace = new BiomeReplace(editSession, target);
         if (mask != null) {
-            replace = new RegionMaskingFilter(editSession, mask, replace);
+            replace = new RegionMaskingFilter(mask, replace);
         }
         RegionVisitor visitor = new RegionVisitor(region, replace);
         Operations.completeLegacy(visitor);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
@@ -818,7 +818,7 @@ public interface Extent extends InputExtent, OutputExtent {
         checkNotNull(pattern);
 
         BlockReplace replace = new BlockReplace(this, pattern);
-        RegionMaskingFilter filter = new RegionMaskingFilter(this, mask, replace);
+        RegionMaskingFilter filter = new RegionMaskingFilter(mask, replace);
         //FAWE start > add extent to RegionVisitor to allow chunk preloading
         RegionVisitor visitor = new RegionVisitor(region, filter, this);
         //FAWE end

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/RegionMaskingFilter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/RegionMaskingFilter.java
@@ -35,9 +35,19 @@ public class RegionMaskingFilter implements RegionFunction {
 
     private final RegionFunction function;
     private final Mask mask;
-    //FAWE start
-    private final Extent extent;
-    //FAWE end
+
+    /**
+     * Create a new masking filter.
+     *
+     * @param mask the mask
+     * @param function the function
+     */
+    public RegionMaskingFilter(Mask mask, RegionFunction function) {
+        checkNotNull(function);
+        checkNotNull(mask);
+        this.mask = mask;
+        this.function = function;
+    }
 
     /**
      * Create a new masking filter.
@@ -46,16 +56,11 @@ public class RegionMaskingFilter implements RegionFunction {
      * @param function the function
      */
     //FAWE start - Extent
-    public RegionMaskingFilter(Extent extent, Mask mask, RegionFunction function) {
-        checkNotNull(function);
-        checkNotNull(mask);
-        //FAWE start
-        checkNotNull(extent);
-        this.extent = extent;
-        //FAWE end
-        this.mask = mask;
-        this.function = function;
+    @Deprecated(since = "TODO")
+    public RegionMaskingFilter(@SuppressWarnings("unused") Extent extent, Mask mask, RegionFunction function) {
+        this(mask, function);
     }
+    //FAWE end - Extent
 
     @Override
     public boolean apply(BlockVector3 position) throws WorldEditException {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/operation/ForwardExtentCopy.java
@@ -330,7 +330,7 @@ public class ForwardExtentCopy implements Operation {
                 }
                 if (sourceMask != Masks.alwaysTrue()) {
                     new MaskTraverser(sourceMask).reset(transExt);
-                    copy = new RegionMaskingFilter(source, sourceMask, copy);
+                    copy = new RegionMaskingFilter(sourceMask, copy);
                 }
                 if (copyingBiomes && (source.isWorld() || region instanceof FlatRegion)) {
                     copy = CombinedRegionFunction.combine(copy, new BiomeCopy(source, finalDest));
@@ -394,7 +394,7 @@ public class ForwardExtentCopy implements Operation {
                 if (maskFunc != null) {
                     copy = new RegionMaskTestFunction(sourceMask, copy, maskFunc);
                 } else {
-                    copy = new RegionMaskingFilter(source, sourceMask, copy);
+                    copy = new RegionMaskingFilter(sourceMask, copy);
                 }
             }
             if (copyingBiomes && (source.isWorld() || region instanceof FlatRegion)) {


### PR DESCRIPTION
## Overview
Fixes #3006

## Description
Constructor (and class itself) now matches upstream again. The actual extent was never used, so I don't really see any reason diffing here.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
