### PR TITLE
Allow lazy-loading chunk section data when using Vector API

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/CountFilter.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/CountFilter.java
@@ -1,8 +1,8 @@
 package com.fastasyncworldedit.core.extent.filter;
 
 import com.fastasyncworldedit.core.extent.filter.block.FilterBlock;
+import com.fastasyncworldedit.core.internal.simd.VectorFacade;
 import com.fastasyncworldedit.core.internal.simd.VectorizedFilter;
-import jdk.incubator.vector.ShortVector;
 import jdk.incubator.vector.VectorMask;
 
 public class CountFilter extends ForkedFilter<CountFilter> implements VectorizedFilter {
@@ -37,9 +37,8 @@ public class CountFilter extends ForkedFilter<CountFilter> implements Vectorized
     }
 
     @Override
-    public ShortVector applyVector(final ShortVector get, final ShortVector set, VectorMask<Short> mask) {
+    public void applyVector(final VectorFacade get, final VectorFacade set, final VectorMask<Short> mask) {
         total += mask.trueCount();
-        return set;
     }
 
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/LinkedFilter.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/LinkedFilter.java
@@ -1,11 +1,11 @@
 package com.fastasyncworldedit.core.extent.filter;
 
 import com.fastasyncworldedit.core.extent.filter.block.FilterBlock;
+import com.fastasyncworldedit.core.internal.simd.VectorFacade;
 import com.fastasyncworldedit.core.internal.simd.VectorizedFilter;
 import com.fastasyncworldedit.core.queue.Filter;
 import com.fastasyncworldedit.core.queue.IChunk;
 import com.sk89q.worldedit.regions.Region;
-import jdk.incubator.vector.ShortVector;
 import jdk.incubator.vector.VectorMask;
 import org.jetbrains.annotations.Nullable;
 
@@ -78,9 +78,9 @@ public sealed class LinkedFilter<L extends Filter, R extends Filter> implements 
         }
 
         @Override
-        public ShortVector applyVector(final ShortVector get, final ShortVector set, VectorMask<Short> mask) {
-            ShortVector res = getLeft().applyVector(get, set, mask);
-            return getRight().applyVector(get, res, mask);
+        public void applyVector(final VectorFacade get, final VectorFacade set, final VectorMask<Short> mask) {
+            getLeft().applyVector(get, set, mask);
+            getRight().applyVector(get, set, mask);
         }
 
         @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/block/CharFilterBlock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/filter/block/CharFilterBlock.java
@@ -37,14 +37,14 @@ public class CharFilterBlock extends ChunkFilterBlock {
 
     private int maxLayer;
     private int minLayer;
-    private CharGetBlocks get;
-    private IChunkSet set;
+    protected CharGetBlocks get;
+    protected IChunkSet set;
     protected char[] getArr;
     @Nullable
     protected char[] setArr;
     protected SetDelegate delegate;
     // local
-    private int layer;
+    protected int layer;
     private int index;
     private int x;
     private int y;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorFacade.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorFacade.java
@@ -1,0 +1,61 @@
+package com.fastasyncworldedit.core.internal.simd;
+
+import com.fastasyncworldedit.core.queue.IBlocks;
+import com.sk89q.worldedit.world.block.BlockTypesCache;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorSpecies;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public class VectorFacade {
+    private final IBlocks blocks;
+    private int layer;
+    private int index;
+    private char[] data;
+
+    VectorFacade(final IBlocks blocks) {
+        this.blocks = blocks;
+    }
+
+    public ShortVector get(VectorSpecies<Short> species) {
+        if (this.data == null) {
+            load();
+        }
+        return ShortVector.fromCharArray(species, this.data, this.index);
+    }
+
+    public ShortVector getOrZero(VectorSpecies<Short> species) {
+        if (this.data == null) {
+            return species.zero().reinterpretAsShorts();
+        }
+        return ShortVector.fromCharArray(species, this.data, this.index);
+    }
+
+    public void setOrIgnore(ShortVector vector) {
+        if (this.data == null) {
+            if (vector.eq((short) BlockTypesCache.ReservedIDs.__RESERVED__).allTrue()) {
+                return;
+            }
+            load();
+        }
+        vector.intoCharArray(this.data, this.index);
+    }
+
+    private void load() {
+        this.data = this.blocks.load(this.layer);
+    }
+
+    public void setLayer(int layer) {
+        this.layer = layer;
+        this.data = null;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public void setData(char[] data) {
+        this.data = data;
+    }
+
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedCharFilterBlock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedCharFilterBlock.java
@@ -19,18 +19,17 @@ public class VectorizedCharFilterBlock extends CharFilterBlock {
             throw new IllegalStateException("Unexpected VectorizedCharFilterBlock " + filter);
         }
         final VectorSpecies<Short> species = ShortVector.SPECIES_PREFERRED;
-        // TODO can we avoid eager initSet?
-        initSet(); // set array is null before
-        char[] setArr = this.setArr;
-        assert setArr != null;
-        char[] getArr = this.getArr;
+        VectorFacade setFassade = new VectorFacade(this.set);
+        setFassade.setLayer(this.layer);
+        VectorFacade getFassade = new VectorFacade(this.get);
+        getFassade.setLayer(this.layer);
+        getFassade.setData(this.getArr);
         // assume setArr.length == getArr.length == 4096
         VectorMask<Short> affectAll = species.maskAll(true);
         for (int i = 0; i < 4096; i += species.length()) {
-            ShortVector set = ShortVector.fromCharArray(species, setArr, i);
-            ShortVector get = ShortVector.fromCharArray(species, getArr, i);
-            ShortVector res = vecFilter.applyVector(get, set, affectAll);
-            res.intoCharArray(setArr, i);
+            setFassade.setIndex(i);
+            getFassade.setIndex(i);
+            vecFilter.applyVector(getFassade, setFassade, affectAll);
         }
     }
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedFilter.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedFilter.java
@@ -1,7 +1,6 @@
 package com.fastasyncworldedit.core.internal.simd;
 
 import com.fastasyncworldedit.core.queue.Filter;
-import jdk.incubator.vector.ShortVector;
 import jdk.incubator.vector.VectorMask;
 
 public interface VectorizedFilter extends Filter {
@@ -12,8 +11,7 @@ public interface VectorizedFilter extends Filter {
      * @param get  the get vector
      * @param set  the set vector
      * @param mask the mask with the lanes set to true which should be affected by the filter
-     * @return the resulting set vector.
      */
-    ShortVector applyVector(ShortVector get, ShortVector set, VectorMask<Short> mask);
+    void applyVector(VectorFacade get, VectorFacade set, VectorMask<Short> mask);
 
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

Previously, the use of the vector api forced us to load get and set arrays eagerly. This also caused some overhead in e.g. heightmap recalculation because a set array was present even if no changes were applied to a chunk section.

By using a thin wrapper, we can delay loading the data (or load dummy data) to when it is actually needed. This reduces the mentioned overhead.

Performance difference isn't really noticeable from a user's perspective, as the overhead ran pretty much in parallel to the edit itself. Manually inspecting profiles shows that there is less work done though (especially visible when using `//count`). This might be more noticeable on busy servers or servers with only 2-4 cores.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
