### PR TITLE
Simplify NMSAdapter#createPalette methods

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -147,17 +147,17 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     }
 
     private synchronized boolean init() {
-        if (ibdToStateOrdinal != null && ibdToStateOrdinal[1] != 0) {
+        if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;
         }
-        ibdToStateOrdinal = new char[BlockTypesCache.states.length]; // size
-        ordinalToIbdID = new int[ibdToStateOrdinal.length]; // size
-        for (int i = 0; i < ibdToStateOrdinal.length; i++) {
+        ibdToOrdinal = new int[BlockTypesCache.states.length]; // size
+        ordinalToIbdID = new int[ibdToOrdinal.length]; // size
+        for (int i = 0; i < ibdToOrdinal.length; i++) {
             BlockState blockState = BlockTypesCache.states[i];
             PaperweightBlockMaterial material = (PaperweightBlockMaterial) blockState.getMaterial();
             int id = Block.BLOCK_STATE_REGISTRY.getId(material.getState());
             char ordinal = blockState.getOrdinalChar();
-            ibdToStateOrdinal[id] = ordinal;
+            ibdToOrdinal[id] = ordinal;
             ordinalToIbdID[ordinal] = id;
         }
         Map<String, List<Property<?>>> properties = new HashMap<>();
@@ -365,18 +365,18 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public char adaptToChar(net.minecraft.world.level.block.state.BlockState blockState) {
         int id = Block.BLOCK_STATE_REGISTRY.getId(blockState);
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             try {
                 init();
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             } catch (ArrayIndexOutOfBoundsException e1) {
-                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToStateOrdinal length: {}. Defaulting to air!",
-                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToStateOrdinal.length, e1
+                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToOrdinal length: {}. Defaulting to air!",
+                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToOrdinal.length, e1
                 );
                 return BlockTypesCache.ReservedIDs.AIR;
             }
@@ -385,28 +385,28 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public char ibdIDToOrdinal(int id) {
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             init();
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
     }
 
     @Override
-    public char[] getIbdToStateOrdinal() {
+    protected int[] getIbdToOrdinal() {
         if (initialised) {
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal;
+                return ibdToOrdinal;
             }
             init();
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
@@ -82,7 +82,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static java.lang.invoke.MethodType.methodType;
 import static net.minecraft.core.registries.Registries.BIOME;
@@ -420,7 +420,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static LevelChunkSection newChunkSection(
             final int layer,
-            final Function<Integer, char[]> get,
+            final IntFunction<char[]> get,
             char[] set,
             CachedBukkitAdapter adapter,
             Registry<Biome> biomeRegistry,
@@ -436,9 +436,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         try {
             int num_palette;
             if (get == null) {
-                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter, null);
+                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter);
             } else {
-                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter, null);
+                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter);
             }
 
             int bitsPerEntry = MathMan.log2nlz(num_palette - 1);

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
@@ -146,17 +146,17 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     }
 
     private synchronized boolean init() {
-        if (ibdToStateOrdinal != null && ibdToStateOrdinal[1] != 0) {
+        if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;
         }
-        ibdToStateOrdinal = new char[BlockTypesCache.states.length]; // size
-        ordinalToIbdID = new int[ibdToStateOrdinal.length]; // size
-        for (int i = 0; i < ibdToStateOrdinal.length; i++) {
+        ibdToOrdinal = new int[BlockTypesCache.states.length]; // size
+        ordinalToIbdID = new int[ibdToOrdinal.length]; // size
+        for (int i = 0; i < ibdToOrdinal.length; i++) {
             BlockState blockState = BlockTypesCache.states[i];
             PaperweightBlockMaterial material = (PaperweightBlockMaterial) blockState.getMaterial();
             int id = Block.BLOCK_STATE_REGISTRY.getId(material.getState());
             char ordinal = blockState.getOrdinalChar();
-            ibdToStateOrdinal[id] = ordinal;
+            ibdToOrdinal[id] = ordinal;
             ordinalToIbdID[ordinal] = id;
         }
         Map<String, List<Property<?>>> properties = new HashMap<>();
@@ -364,18 +364,18 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public char adaptToChar(net.minecraft.world.level.block.state.BlockState blockState) {
         int id = Block.BLOCK_STATE_REGISTRY.getId(blockState);
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             try {
                 init();
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             } catch (ArrayIndexOutOfBoundsException e1) {
-                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToStateOrdinal length: {}. Defaulting to air!",
-                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToStateOrdinal.length, e1
+                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToOrdinal length: {}. Defaulting to air!",
+                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToOrdinal.length, e1
                 );
                 return BlockTypesCache.ReservedIDs.AIR;
             }
@@ -384,28 +384,28 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public char ibdIDToOrdinal(int id) {
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             init();
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
     }
 
     @Override
-    public char[] getIbdToStateOrdinal() {
+    public int[] getIbdToOrdinal() {
         if (initialised) {
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal;
+                return ibdToOrdinal;
             }
             init();
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
@@ -82,7 +82,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static java.lang.invoke.MethodType.methodType;
 import static net.minecraft.core.registries.Registries.BIOME;
@@ -420,7 +420,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static LevelChunkSection newChunkSection(
             final int layer,
-            final Function<Integer, char[]> get,
+            final IntFunction<char[]> get,
             char[] set,
             CachedBukkitAdapter adapter,
             Registry<Biome> biomeRegistry,
@@ -436,9 +436,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         try {
             int num_palette;
             if (get == null) {
-                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter, null);
+                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter);
             } else {
-                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter, null);
+                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter);
             }
 
             int bitsPerEntry = MathMan.log2nlz(num_palette - 1);

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
@@ -156,17 +156,17 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     }
 
     private synchronized boolean init() {
-        if (ibdToStateOrdinal != null && ibdToStateOrdinal[1] != 0) {
+        if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;
         }
-        ibdToStateOrdinal = new char[BlockTypesCache.states.length]; // size
-        ordinalToIbdID = new int[ibdToStateOrdinal.length]; // size
-        for (int i = 0; i < ibdToStateOrdinal.length; i++) {
+        ibdToOrdinal = new int[BlockTypesCache.states.length]; // size
+        ordinalToIbdID = new int[ibdToOrdinal.length]; // size
+        for (int i = 0; i < ibdToOrdinal.length; i++) {
             BlockState blockState = BlockTypesCache.states[i];
             PaperweightBlockMaterial material = (PaperweightBlockMaterial) blockState.getMaterial();
             int id = Block.BLOCK_STATE_REGISTRY.getId(material.getState());
             char ordinal = blockState.getOrdinalChar();
-            ibdToStateOrdinal[id] = ordinal;
+            ibdToOrdinal[id] = ordinal;
             ordinalToIbdID[ordinal] = id;
         }
         Map<String, List<Property<?>>> properties = new HashMap<>();
@@ -374,18 +374,18 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public char adaptToChar(net.minecraft.world.level.block.state.BlockState blockState) {
         int id = Block.BLOCK_STATE_REGISTRY.getId(blockState);
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             try {
                 init();
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             } catch (ArrayIndexOutOfBoundsException e1) {
-                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToStateOrdinal length: {}. Defaulting to air!",
-                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToStateOrdinal.length, e1
+                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToOrdinal length: {}. Defaulting to air!",
+                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToOrdinal.length, e1
                 );
                 return BlockTypesCache.ReservedIDs.AIR;
             }
@@ -394,28 +394,28 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public char ibdIDToOrdinal(int id) {
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             init();
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
     }
 
     @Override
-    public char[] getIbdToStateOrdinal() {
+    public int[] getIbdToOrdinal() {
         if (initialised) {
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal;
+                return ibdToOrdinal;
             }
             init();
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightPlatformAdapter.java
@@ -10,7 +10,6 @@ import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
-import com.mojang.datafixers.util.Either;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.Refraction;
@@ -77,12 +76,11 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static java.lang.invoke.MethodType.methodType;
 import static net.minecraft.core.registries.Registries.BIOME;
@@ -415,7 +413,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static LevelChunkSection newChunkSection(
             final int layer,
-            final Function<Integer, char[]> get,
+            final IntFunction<char[]> get,
             char[] set,
             CachedBukkitAdapter adapter,
             Registry<Biome> biomeRegistry,
@@ -431,9 +429,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         try {
             int num_palette;
             if (get == null) {
-                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter, null);
+                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter);
             } else {
-                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter, null);
+                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter);
             }
 
             int bitsPerEntry = MathMan.log2nlz(num_palette - 1);

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -156,17 +156,17 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     }
 
     private synchronized boolean init() {
-        if (ibdToStateOrdinal != null && ibdToStateOrdinal[1] != 0) {
+        if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;
         }
-        ibdToStateOrdinal = new char[BlockTypesCache.states.length]; // size
-        ordinalToIbdID = new int[ibdToStateOrdinal.length]; // size
-        for (int i = 0; i < ibdToStateOrdinal.length; i++) {
+        ibdToOrdinal = new int[BlockTypesCache.states.length]; // size
+        ordinalToIbdID = new int[ibdToOrdinal.length]; // size
+        for (int i = 0; i < ibdToOrdinal.length; i++) {
             BlockState blockState = BlockTypesCache.states[i];
             PaperweightBlockMaterial material = (PaperweightBlockMaterial) blockState.getMaterial();
             int id = Block.BLOCK_STATE_REGISTRY.getId(material.getState());
             char ordinal = blockState.getOrdinalChar();
-            ibdToStateOrdinal[id] = ordinal;
+            ibdToOrdinal[id] = ordinal;
             ordinalToIbdID[ordinal] = id;
         }
         Map<String, List<Property<?>>> properties = new HashMap<>();
@@ -374,18 +374,18 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public char adaptToChar(net.minecraft.world.level.block.state.BlockState blockState) {
         int id = Block.BLOCK_STATE_REGISTRY.getId(blockState);
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             try {
                 init();
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             } catch (ArrayIndexOutOfBoundsException e1) {
-                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToStateOrdinal length: {}. Defaulting to air!",
-                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToStateOrdinal.length, e1
+                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToOrdinal length: {}. Defaulting to air!",
+                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToOrdinal.length, e1
                 );
                 return BlockTypesCache.ReservedIDs.AIR;
             }
@@ -394,28 +394,28 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public char ibdIDToOrdinal(int id) {
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             init();
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
     }
 
     @Override
-    public char[] getIbdToStateOrdinal() {
+    public int[] getIbdToOrdinal() {
         if (initialised) {
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal;
+                return ibdToOrdinal;
             }
             init();
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
@@ -11,7 +11,6 @@ import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
-import com.mojang.datafixers.util.Either;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.Refraction;
@@ -76,12 +75,11 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static java.lang.invoke.MethodType.methodType;
 import static net.minecraft.core.registries.Registries.BIOME;
@@ -399,7 +397,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static LevelChunkSection newChunkSection(
             final int layer,
-            final Function<Integer, char[]> get,
+            final IntFunction<char[]> get,
             char[] set,
             CachedBukkitAdapter adapter,
             Registry<Biome> biomeRegistry,
@@ -415,9 +413,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         try {
             int num_palette;
             if (get == null) {
-                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter, null);
+                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter);
             } else {
-                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter, null);
+                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter);
             }
 
             int bitsPerEntry = MathMan.log2nlz(num_palette - 1);

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
@@ -175,17 +175,17 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     }
 
     private synchronized boolean init() {
-        if (ibdToStateOrdinal != null && ibdToStateOrdinal[1] != 0) {
+        if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;
         }
-        ibdToStateOrdinal = new char[BlockTypesCache.states.length]; // size
-        ordinalToIbdID = new int[ibdToStateOrdinal.length]; // size
-        for (int i = 0; i < ibdToStateOrdinal.length; i++) {
+        ibdToOrdinal = new int[BlockTypesCache.states.length]; // size
+        ordinalToIbdID = new int[ibdToOrdinal.length]; // size
+        for (int i = 0; i < ibdToOrdinal.length; i++) {
             BlockState blockState = BlockTypesCache.states[i];
             PaperweightBlockMaterial material = (PaperweightBlockMaterial) blockState.getMaterial();
             int id = Block.BLOCK_STATE_REGISTRY.getId(material.getState());
             char ordinal = blockState.getOrdinalChar();
-            ibdToStateOrdinal[id] = ordinal;
+            ibdToOrdinal[id] = ordinal;
             ordinalToIbdID[ordinal] = id;
         }
         Map<String, List<Property<?>>> properties = new HashMap<>();
@@ -356,18 +356,18 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public char adaptToChar(net.minecraft.world.level.block.state.BlockState blockState) {
         int id = Block.BLOCK_STATE_REGISTRY.getId(blockState);
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             try {
                 init();
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             } catch (ArrayIndexOutOfBoundsException e1) {
-                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToStateOrdinal length: {}. Defaulting to air!",
-                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToStateOrdinal.length, e1
+                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToOrdinal length: {}. Defaulting to air!",
+                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToOrdinal.length, e1
                 );
                 return BlockTypesCache.ReservedIDs.AIR;
             }
@@ -376,28 +376,28 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public char ibdIDToOrdinal(int id) {
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             init();
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
     }
 
     @Override
-    public char[] getIbdToStateOrdinal() {
+    public int[] getIbdToOrdinal() {
         if (initialised) {
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal;
+                return ibdToOrdinal;
             }
             init();
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightPlatformAdapter.java
@@ -80,7 +80,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static java.lang.invoke.MethodType.methodType;
 import static net.minecraft.core.registries.Registries.BIOME;
@@ -404,7 +404,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static LevelChunkSection newChunkSection(
             final int layer,
-            final Function<Integer, char[]> get,
+            final IntFunction<char[]> get,
             char[] set,
             CachedBukkitAdapter adapter,
             Registry<Biome> biomeRegistry,
@@ -420,9 +420,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         try {
             int num_palette;
             if (get == null) {
-                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter, null);
+                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter);
             } else {
-                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter, null);
+                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter);
             }
 
             int bitsPerEntry = MathMan.log2nlz(num_palette - 1);

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
@@ -176,17 +176,17 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     }
 
     private synchronized boolean init() {
-        if (ibdToStateOrdinal != null && ibdToStateOrdinal[1] != 0) {
+        if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;
         }
-        ibdToStateOrdinal = new char[BlockTypesCache.states.length]; // size
-        ordinalToIbdID = new int[ibdToStateOrdinal.length]; // size
-        for (int i = 0; i < ibdToStateOrdinal.length; i++) {
+        ibdToOrdinal = new int[BlockTypesCache.states.length]; // size
+        ordinalToIbdID = new int[ibdToOrdinal.length]; // size
+        for (int i = 0; i < ibdToOrdinal.length; i++) {
             BlockState blockState = BlockTypesCache.states[i];
             PaperweightBlockMaterial material = (PaperweightBlockMaterial) blockState.getMaterial();
             int id = Block.BLOCK_STATE_REGISTRY.getId(material.getState());
             char ordinal = blockState.getOrdinalChar();
-            ibdToStateOrdinal[id] = ordinal;
+            ibdToOrdinal[id] = ordinal;
             ordinalToIbdID[ordinal] = id;
         }
         Map<String, List<Property<?>>> properties = new HashMap<>();
@@ -357,18 +357,18 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public char adaptToChar(net.minecraft.world.level.block.state.BlockState blockState) {
         int id = Block.BLOCK_STATE_REGISTRY.getId(blockState);
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             try {
                 init();
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             } catch (ArrayIndexOutOfBoundsException e1) {
-                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToStateOrdinal length: {}. Defaulting to air!",
-                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToStateOrdinal.length, e1
+                LOGGER.error("Attempted to convert {} with ID {} to char. ibdToOrdinal length: {}. Defaulting to air!",
+                        blockState.getBlock(), Block.BLOCK_STATE_REGISTRY.getId(blockState), ibdToOrdinal.length, e1
                 );
                 return BlockTypesCache.ReservedIDs.AIR;
             }
@@ -377,28 +377,28 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     public char ibdIDToOrdinal(int id) {
         if (initialised) {
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal[id];
+                return (char) ibdToOrdinal[id];
             }
             init();
-            return ibdToStateOrdinal[id];
+            return (char) ibdToOrdinal[id];
         }
     }
 
     @Override
-    public char[] getIbdToStateOrdinal() {
+    public int[] getIbdToOrdinal() {
         if (initialised) {
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
         synchronized (this) {
             if (initialised) {
-                return ibdToStateOrdinal;
+                return ibdToOrdinal;
             }
             init();
-            return ibdToStateOrdinal;
+            return ibdToOrdinal;
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightPlatformAdapter.java
@@ -24,7 +24,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
-import net.minecraft.network.protocol.game.ClientboundForgetLevelChunkPacket;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -80,7 +79,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import static java.lang.invoke.MethodType.methodType;
 import static net.minecraft.core.registries.Registries.BIOME;
@@ -400,7 +399,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static LevelChunkSection newChunkSection(
             final int layer,
-            final Function<Integer, char[]> get,
+            final IntFunction<char[]> get,
             char[] set,
             CachedBukkitAdapter adapter,
             Registry<Biome> biomeRegistry,
@@ -416,9 +415,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         try {
             int num_palette;
             if (get == null) {
-                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter, null);
+                num_palette = createPalette(blockToPalette, paletteToBlock, blocksCopy, set, adapter);
             } else {
-                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter, null);
+                num_palette = createPalette(layer, blockToPalette, paletteToBlock, blocksCopy, get, set, adapter);
             }
 
             int bitsPerEntry = MathMan.log2nlz(num_palette - 1);

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/CachedBukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/CachedBukkitAdapter.java
@@ -100,7 +100,7 @@ public abstract class CachedBukkitAdapter implements IBukkitAdapter {
         }
     }
 
-    protected abstract char[] getIbdToStateOrdinal();
+    protected abstract int[] getIbdToOrdinal();
 
     protected abstract int[] getOrdinalToIbdID();
 

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public abstract class FaweAdapter<TAG, SERVER_LEVEL> extends CachedBukkitAdapter implements IDelegateBukkitImplAdapter<TAG> {
 
     protected final BukkitImplAdapter<TAG> parent;
-    protected char[] ibdToStateOrdinal = null;
+    protected int[] ibdToOrdinal = null;
     protected int[] ordinalToIbdID = null;
     protected boolean initialised = false;
     protected Map<String, List<Property<?>>> allBlockProperties = null;

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/SimpleBukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/SimpleBukkitAdapter.java
@@ -23,8 +23,8 @@ public class SimpleBukkitAdapter extends CachedBukkitAdapter {
     }
 
     @Override
-    protected char[] getIbdToStateOrdinal() {
-        return new char[Character.MAX_VALUE + 1];
+    protected int[] getIbdToOrdinal() {
+        return new int[Character.MAX_VALUE + 1];
     }
 
     @Override


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

There are a few things we can simplify here:
- The `short[] nonEmptyBlockCount` was always `null`, so we can remove it
- As a consequence, we don't need to calculate non-air block count anymore
- We can use `int[]` instead of `char[]` for the global palette mapping, and use `System.arraycopy` then
- We can extract duplicated code of the two variants into a common method

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
