### PR TITLE
Simplify heightmap calculation and avoid loading empty sections

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -1155,6 +1155,13 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
+    public boolean hasNonEmptySection(int layer) {
+        layer -= getMinSectionPosition();
+        LevelChunkSection section = getSections(false)[layer];
+        return section != null && !section.hasOnlyAir();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public synchronized boolean trim(boolean aggressive) {
         skyLight = new DataLayer[getSectionCount()];

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
@@ -1153,6 +1153,13 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
+    public boolean hasNonEmptySection(int layer) {
+        layer -= getMinSectionPosition();
+        LevelChunkSection section = getSections(false)[layer];
+        return section != null && !section.hasOnlyAir();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public synchronized boolean trim(boolean aggressive) {
         skyLight = new DataLayer[getSectionCount()];

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
@@ -1156,6 +1156,13 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
+    public boolean hasNonEmptySection(int layer) {
+        layer -= getMinSectionPosition();
+        LevelChunkSection section = getSections(false)[layer];
+        return section != null && !section.hasOnlyAir();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public synchronized boolean trim(boolean aggressive) {
         skyLight = new DataLayer[getSectionCount()];

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
@@ -1151,6 +1151,13 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
+    public boolean hasNonEmptySection(int layer) {
+        layer -= getMinSectionPosition();
+        LevelChunkSection section = getSections(false)[layer];
+        return section != null && !section.hasOnlyAir();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public synchronized boolean trim(boolean aggressive) {
         skyLight = new DataLayer[getSectionCount()];

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightGetBlocks.java
@@ -1152,6 +1152,13 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
+    public boolean hasNonEmptySection(int layer) {
+        layer -= getMinSectionPosition();
+        LevelChunkSection section = getSections(false)[layer];
+        return section != null && !section.hasOnlyAir();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public synchronized boolean trim(boolean aggressive) {
         skyLight = new DataLayer[getSectionCount()];

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
@@ -1150,6 +1150,13 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
     }
 
     @Override
+    public boolean hasNonEmptySection(int layer) {
+        layer -= getMinSectionPosition();
+        LevelChunkSection section = getSections(false)[layer];
+        return section != null && !section.hasOnlyAir();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public synchronized boolean trim(boolean aggressive) {
         skyLight = new DataLayer[getSectionCount()];

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/heightmap/HeightmapProcessor.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/heightmap/HeightmapProcessor.java
@@ -18,11 +18,10 @@ public class HeightmapProcessor implements IBatchProcessor {
     private static final HeightMapType[] TYPES = HeightMapType.values();
     private static final int BLOCKS_PER_Y_SHIFT = 8; // log2(256)
     private static final int BLOCKS_PER_Y = 256; // 16 x 16
-    private static final boolean[] COMPLETE = new boolean[BLOCKS_PER_Y];
     private static final char[] AIR_LAYER = new char[4096];
+    private static final int NEEDED_UPDATES = TYPES.length * BLOCKS_PER_Y;
 
     static {
-        Arrays.fill(COMPLETE, true);
         Arrays.fill(AIR_LAYER, (char) BlockTypesCache.ReservedIDs.AIR);
     }
 
@@ -49,13 +48,12 @@ public class HeightmapProcessor implements IBatchProcessor {
     public IChunkSet processSet(IChunk chunk, IChunkGet get, IChunkSet set) {
         // each heightmap gets one 16*16 array
         int[][] heightmaps = new int[TYPES.length][BLOCKS_PER_Y];
-        boolean[][] updated = new boolean[TYPES.length][BLOCKS_PER_Y];
-        int skip = 0;
-        int allSkipped = (1 << TYPES.length) - 1; // lowest types.length bits are set
+        byte[] updated = new byte[BLOCKS_PER_Y];
+        int updateCount = 0; // count updates, this way we know when we're finished
         layer:
         for (int layer = maxY >> 4; layer >= minY >> 4; layer--) {
-            boolean hasSectionSet = set.hasSection(layer);
-            boolean hasSectionGet = get.hasSection(layer);
+            boolean hasSectionSet = set.hasNonEmptySection(layer);
+            boolean hasSectionGet = get.hasNonEmptySection(layer);
             if (!(hasSectionSet || hasSectionGet)) {
                 continue;
             }
@@ -103,30 +101,26 @@ public class HeightmapProcessor implements IBatchProcessor {
                     if (block == null) {
                         continue;
                     }
+                    byte updateStateAtJ = updated[j];
                     for (int i = 0; i < TYPES.length; i++) {
-                        if ((skip & (1 << i)) != 0) {
-                            continue; // skip finished height map
+                        int bitFlag = 1 << i;
+                        if ((updateStateAtJ & bitFlag) != 0) {
+                            continue; // skip finished height map at this column
                         }
                         HeightMapType type = TYPES[i];
                         // ignore if that position was already set
-                        if (!updated[i][j] && type.includes(block)) {
+                        if (type.includes(block)) {
                             // mc requires + 1, heightmaps are normalized internally, thus we need to "zero" them.
                             heightmaps[i][j] = ((layer - get.getMinSectionPosition()) << 4) + y + 1;
-                            updated[i][j] = true; // mark as updated
+                            updated[j] |= (byte) bitFlag; // mark as updated
+                            if (++updateCount == NEEDED_UPDATES) {
+                                break layer; // all heightmaps in all columns updated
+                            }
+
                         }
                     }
                 }
             }
-            for (int i = 0; i < updated.length; i++) {
-                if ((skip & (1 << i)) == 0 // if already true, skip array equality check
-                        && Arrays.equals(updated[i], COMPLETE)) {
-                    skip |= 1 << i;
-                }
-            }
-            if (skip != allSkipped) {
-                continue;
-            }
-            break; // all maps are processed
         }
         for (int i = 0; i < TYPES.length; i++) {
             set.setHeightMap(TYPES[i], heightmaps[i]);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/heightmap/HeightmapProcessor.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/heightmap/HeightmapProcessor.java
@@ -50,7 +50,7 @@ public class HeightmapProcessor implements IBatchProcessor {
         int[][] heightmaps = new int[TYPES.length][BLOCKS_PER_Y];
         byte[] updated = new byte[BLOCKS_PER_Y];
         int updateCount = 0; // count updates, this way we know when we're finished
-        layer:
+        layerIter:
         for (int layer = maxY >> 4; layer >= minY >> 4; layer--) {
             boolean hasSectionSet = set.hasNonEmptySection(layer);
             boolean hasSectionGet = get.hasNonEmptySection(layer);
@@ -76,7 +76,7 @@ public class HeightmapProcessor implements IBatchProcessor {
                     if (ordinal == BlockTypesCache.ReservedIDs.__RESERVED__) {
                         if (!hasSectionGet) {
                             if (!hasSectionSet) {
-                                continue layer;
+                                continue layerIter;
                             }
                             continue;
                         } else if (getSection == null) {
@@ -86,7 +86,7 @@ public class HeightmapProcessor implements IBatchProcessor {
                                     || Arrays.equals(getSection, AIR_LAYER)) {
                                 hasSectionGet = false;
                                 if (!hasSectionSet) {
-                                    continue layer;
+                                    continue layerIter;
                                 }
                                 continue;
                             }
@@ -114,7 +114,7 @@ public class HeightmapProcessor implements IBatchProcessor {
                             heightmaps[i][j] = ((layer - get.getMinSectionPosition()) << 4) + y + 1;
                             updated[j] |= (byte) bitFlag; // mark as updated
                             if (++updateCount == NEEDED_UPDATES) {
-                                break layer; // all heightmaps in all columns updated
+                                break layerIter; // all heightmaps in all columns updated
                             }
 
                         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IBlocks.java
@@ -38,6 +38,17 @@ public interface IBlocks extends Trimable {
     boolean hasSection(int layer);
 
     /**
+     * {@return whether the chunk has a section that has any non-air/reserved blocks}
+     * This method might be conservative and return {@code true} even if the section is empty.
+     *
+     * @param layer the section's layer
+     * @since TODO
+     */
+    default boolean hasNonEmptySection(int layer) {
+        return hasSection(layer);
+    }
+
+    /**
      * Obtain the specified chunk section stored as an array of ordinals. Uses normal minecraft chunk-section position indices
      * (length 4096). Operations synchronises on the section and will load the section into memory if not present. For chunk
      * GET operations, this will load the data from the world. For chunk SET, this will create a new empty array.

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -883,6 +883,11 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
     }
 
     @Override
+    public boolean hasNonEmptySection(final int layer) {
+        return chunkExisting != null && chunkExisting.hasNonEmptySection(layer);
+    }
+
+    @Override
     public synchronized void filterBlocks(Filter filter, ChunkFilterBlock block, @Nullable Region region, boolean full) {
         final IChunkGet get = getOrCreateGet();
         final IChunkSet set = getOrCreateSet();


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

There are two relevant changes:
1. Instead of a two-dimensional boolean array, we can use one byte array and mark specific bits per heightmap type. This reduces memory loads and simplifies the skip logic a bit. The skip bitset is also replaced by a simple counting variable, which also means we can avoid the array equals check.
2. Add a method `hasNonEmptySection` that can return false if the section is present but only contains air. As minecraft already tracks that information, we can use it and avoid unnecessary array comparisons.

In my tests, the time spent in the HeightmapProcessor was 8 times less than before.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
