### PR TITLE
Fix BatchProcessor ordering in MultiBatchProcessor

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/MultiBatchProcessor.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/MultiBatchProcessor.java
@@ -19,7 +19,7 @@ import org.apache.logging.log4j.Logger;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,11 +77,11 @@ public class MultiBatchProcessor implements IBatchProcessor {
 
     @Override
     public IChunkSet processSet(IChunk chunk, IChunkGet get, IChunkSet set) {
-        Map<Integer, List<IBatchProcessor>> ordered = new HashMap<>();
+        Map<ProcessorScope, List<IBatchProcessor>> ordered = new EnumMap<>(ProcessorScope.class);
         IChunkSet chunkSet = set;
         for (IBatchProcessor processor : processors) {
             if (processor.getScope() != ProcessorScope.ADDING_BLOCKS) {
-                ordered.computeIfAbsent(processor.getScope().intValue(), k -> new ArrayList<>())
+                ordered.computeIfAbsent(processor.getScope(), k -> new ArrayList<>())
                         .add(processor);
                 continue;
             }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

I noticed that the order is based on HashMap, which does not make any guarantees about value iteration order. EnumMap is a better choice as it guarantees iteration order in the natural order of the enum values.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
