### PR TITLE
fix: use a holder to allow "upgrading" LocalBV3Set to a full fat one

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ScatterBrush.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ScatterBrush.java
@@ -121,7 +121,7 @@ public class ScatterBrush implements Brush {
     @Deprecated(forRemoval = true, since = "2.9.2")
     public void apply(EditSession editSession, LocalBlockVectorSet placed, BlockVector3 pt, Pattern p, double size) throws
             MaxChangedBlocksException {
-        apply(editSession, (BlockVector3Set) placed, pt, p, size);
+        apply(editSession, LocalBlockVectorSet.wrap(placed), pt, p, size);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ScatterCommand.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ScatterCommand.java
@@ -3,6 +3,7 @@ package com.fastasyncworldedit.core.command.tool.brush;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.math.LocalBlockVectorSet;
 import com.fastasyncworldedit.core.util.StringMan;
+import com.fastasyncworldedit.core.util.collection.BlockVector3Set;
 import com.fastasyncworldedit.core.wrappers.AsyncPlayer;
 import com.fastasyncworldedit.core.wrappers.LocationMaskedPlayerWrapper;
 import com.fastasyncworldedit.core.wrappers.SilentPlayerWrapper;
@@ -31,9 +32,21 @@ public class ScatterCommand extends ScatterBrush {
     }
 
     @Override
+    @Deprecated(forRemoval = true, since = "TODO")
     public void apply(
             EditSession editSession,
             LocalBlockVectorSet placed,
+            BlockVector3 position,
+            Pattern p,
+            double size
+    ) throws MaxChangedBlocksException {
+        apply(editSession, LocalBlockVectorSet.wrap(placed), position, p, size);
+    }
+
+    @Override
+    public void apply(
+            EditSession editSession,
+            BlockVector3Set placed,
             BlockVector3 position,
             Pattern pattern,
             double size

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ScatterOverlayBrush.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ScatterOverlayBrush.java
@@ -2,6 +2,7 @@ package com.fastasyncworldedit.core.command.tool.brush;
 
 import com.fastasyncworldedit.core.math.LocalBlockVectorSet;
 import com.fastasyncworldedit.core.math.MutableBlockVector3;
+import com.fastasyncworldedit.core.util.collection.BlockVector3Set;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.function.pattern.Pattern;
@@ -14,7 +15,25 @@ public class ScatterOverlayBrush extends ScatterBrush {
     }
 
     @Override
-    public void apply(EditSession editSession, LocalBlockVectorSet placed, BlockVector3 pt, Pattern p, double size) throws
+    @Deprecated(forRemoval = true, since = "TODO")
+    public void apply(
+            EditSession editSession,
+            LocalBlockVectorSet placed,
+            BlockVector3 position,
+            Pattern p,
+            double size
+    ) throws MaxChangedBlocksException {
+        apply(editSession, LocalBlockVectorSet.wrap(placed), position, p, size);
+    }
+
+    @Override
+    public void apply(
+            EditSession editSession,
+            BlockVector3Set placed,
+            BlockVector3 pt,
+            Pattern p,
+            double size
+    ) throws
             MaxChangedBlocksException {
         final int x = pt.x();
         final int y = pt.y();

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ShatterBrush.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/ShatterBrush.java
@@ -23,6 +23,7 @@ public class ShatterBrush extends ScatterBrush {
     }
 
     @Override
+    @Deprecated(forRemoval = true, since = "TODO")
     public void apply(
             final EditSession editSession,
             final BlockVector3Set placed,
@@ -51,7 +52,7 @@ public class ShatterBrush extends ScatterBrush {
             LocalBlockVectorSet set = new LocalBlockVectorSet();
             set.add(pos);
             frontiers[i] = set;
-            frontiersVisited[i] = set.clone();
+            frontiersVisited[i] = set.copy();
             i++;
         }
         // Mask

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/SplatterBrush.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/SplatterBrush.java
@@ -3,6 +3,7 @@ package com.fastasyncworldedit.core.command.tool.brush;
 import com.fastasyncworldedit.core.function.mask.SplatterBrushMask;
 import com.fastasyncworldedit.core.function.mask.SurfaceMask;
 import com.fastasyncworldedit.core.math.LocalBlockVectorSet;
+import com.fastasyncworldedit.core.util.collection.BlockVector3Set;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.function.operation.Operations;
@@ -25,9 +26,21 @@ public class SplatterBrush extends ScatterBrush {
     }
 
     @Override
+    @Deprecated(forRemoval = true, since = "TODO")
     public void apply(
             final EditSession editSession,
             final LocalBlockVectorSet placed,
+            final BlockVector3 position,
+            Pattern p,
+            double size
+    ) throws MaxChangedBlocksException {
+        apply(editSession, LocalBlockVectorSet.wrap(placed), position, p, size);
+    }
+
+    @Override
+    public void apply(
+            final EditSession editSession,
+            final BlockVector3Set placed,
             final BlockVector3 position,
             Pattern p,
             double size

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/SurfaceSpline.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/brush/SurfaceSpline.java
@@ -4,6 +4,7 @@ import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.math.LocalBlockVectorSet;
 import com.fastasyncworldedit.core.math.MutableBlockVector3;
 import com.fastasyncworldedit.core.util.MathMan;
+import com.fastasyncworldedit.core.util.collection.BlockVector3Set;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.command.tool.brush.Brush;
@@ -66,7 +67,7 @@ public class SurfaceSpline implements Brush {
         MutableBlockVector3 mutable = MutableBlockVector3.at(0, 0, 0);
         interpol.setNodes(nodes);
         final double splinelength = interpol.arcLength(0, 1);
-        LocalBlockVectorSet vset = new LocalBlockVectorSet();
+        BlockVector3Set vset = LocalBlockVectorSet.wrapped();
         for (double loop = 0; loop <= 1; loop += 1D / splinelength / quality) {
             final Vector3 tipv = interpol.getPosition(loop);
             final int tipx = MathMan.roundInt(tipv.x());
@@ -85,7 +86,7 @@ public class SurfaceSpline implements Brush {
         }
         if (radius != 0) {
             double radius2 = radius * radius;
-            LocalBlockVectorSet newSet = new LocalBlockVectorSet();
+            BlockVector3Set newSet = LocalBlockVectorSet.wrapped();
             final int ceilrad = (int) Math.ceil(radius);
             for (BlockVector3 v : vset) {
                 final int tipx = v.x();

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/sweep/ClipboardSpline.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/command/tool/sweep/ClipboardSpline.java
@@ -2,6 +2,7 @@ package com.fastasyncworldedit.core.command.tool.sweep;
 
 import com.fastasyncworldedit.core.math.LocalBlockVectorSet;
 import com.fastasyncworldedit.core.math.transform.RoundedTransform;
+import com.fastasyncworldedit.core.util.collection.BlockVector3Set;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
@@ -28,7 +29,7 @@ public class ClipboardSpline extends Spline {
 
     private BlockVector3 center;
     private final BlockVector3 centerOffset;
-    private final LocalBlockVectorSet buffer;
+    private final BlockVector3Set buffer;
 
     /**
      * Constructor without position-correction. Use this constructor for an interpolation
@@ -87,7 +88,7 @@ public class ClipboardSpline extends Spline {
         this.centerOffset = center.subtract(center.round());
         this.center = center.subtract(centerOffset);
         this.transform = transform;
-        this.buffer = new LocalBlockVectorSet();
+        this.buffer = LocalBlockVectorSet.wrapped();
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/CachedMask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/CachedMask.java
@@ -27,12 +27,13 @@ public class CachedMask extends AbstractDelegateMask implements ResettableMask {
      * @param local If the area will be small
      * @since 2.4.0
      */
+    @Deprecated(forRemoval = true, since = "TODO")
     public CachedMask(Mask mask, boolean local) {
         super(mask);
         hasExtent = mask instanceof AbstractExtentMask;
         if (local) {
-            cache_checked = new LocalBlockVectorSet();
-            cache_results = new LocalBlockVectorSet();
+            cache_checked = LocalBlockVectorSet.wrapped();
+            cache_results = LocalBlockVectorSet.wrapped();
         } else {
             cache_checked = new BlockVectorSet();
             cache_results = new BlockVectorSet();

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/CachedMask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/CachedMask.java
@@ -64,25 +64,15 @@ public class CachedMask extends AbstractDelegateMask implements ResettableMask {
         int x = vector.x();
         int y = vector.y();
         int z = vector.z();
-        try {
-            boolean check = cache_checked.add(x, y, z);
-            if (!check) {
-                return cache_results.contains(x, y, z);
-            }
-            boolean result = getMask().test(vector);
-            if (result) {
-                cache_results.add(x, y, z);
-            }
-            return result;
-        } catch (UnsupportedOperationException ignored) {
-            boolean result = getMask().test(vector);
-            resetCache();
-            cache_checked.add(x, y, z);
-            if (result) {
-                cache_results.add(x, y, z);
-            }
-            return result;
+        boolean check = cache_checked.add(x, y, z);
+        if (!check) {
+            return cache_results.contains(x, y, z);
         }
+        boolean result = getMask().test(vector);
+        if (result) {
+            cache_results.add(x, y, z);
+        }
+        return result;
     }
 
     public boolean test(@Nullable Extent extent, BlockVector3 vector) {
@@ -93,25 +83,15 @@ public class CachedMask extends AbstractDelegateMask implements ResettableMask {
         int y = vector.y();
         int z = vector.z();
         AbstractExtentMask mask = (AbstractExtentMask) getMask();
-        try {
-            boolean check = cache_checked.add(x, y, z);
-            if (!check) {
-                return cache_results.contains(x, y, z);
-            }
-            boolean result = mask.test(extent, vector);
-            if (result) {
-                cache_results.add(x, y, z);
-            }
-            return result;
-        } catch (UnsupportedOperationException ignored) {
-            boolean result = mask.test(extent, vector);
-            resetCache();
-            cache_checked.add(x, y, z);
-            if (result) {
-                cache_results.add(x, y, z);
-            }
-            return result;
+        boolean check = cache_checked.add(x, y, z);
+        if (!check) {
+            return cache_results.contains(x, y, z);
         }
+        boolean result = mask.test(extent, vector);
+        if (result) {
+            cache_results.add(x, y, z);
+        }
+        return result;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/SplatterBrushMask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/SplatterBrushMask.java
@@ -1,6 +1,7 @@
 package com.fastasyncworldedit.core.function.mask;
 
 import com.fastasyncworldedit.core.math.LocalBlockVectorSet;
+import com.fastasyncworldedit.core.util.collection.BlockVector3Set;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.function.mask.AbstractExtentMask;
@@ -14,14 +15,38 @@ public class SplatterBrushMask extends AbstractExtentMask {
     private final BlockVector3 position;
     private final int size2;
     private final Mask surface;
-    private final LocalBlockVectorSet placed;
+    private final BlockVector3Set placed;
 
+    /**
+     * @deprecated in favour of {@link SplatterBrushMask#SplatterBrushMask(EditSession, BlockVector3, int, Mask, BlockVector3Set)}
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
     public SplatterBrushMask(
             EditSession editSession,
             BlockVector3 position,
             int size2,
             Mask surface,
             LocalBlockVectorSet placed
+    ) {
+        this(editSession, position, size2, surface, LocalBlockVectorSet.wrap(placed));
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param editSession Editsession to use
+     * @param position    position applied to
+     * @param size2       radius squared
+     * @param surface     surface mask
+     * @param placed      {@link BlockVector3Set} of placed blocks
+     * @since TODO
+     */
+    public SplatterBrushMask(
+            EditSession editSession,
+            BlockVector3 position,
+            int size2,
+            Mask surface,
+            BlockVector3Set placed
     ) {
         super(editSession);
         this.position = position;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/BufferedPattern.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/BufferedPattern.java
@@ -50,7 +50,9 @@ public class BufferedPattern extends AbstractPattern implements ResettablePatter
         this.pattern = parent;
         this.timer = Fawe.instance().getTimer();
         // Assume brush is used if no region provided, i.e. unlikely to required BlockVectorSet
-        set = region == null ? new LocalBlockVectorSet() : BlockVector3Set.getAppropriateVectorSet(region);
+        set = region == null
+            ? LocalBlockVectorSet.wrapped()
+            : BlockVector3Set.getAppropriateVectorSet(region);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/BlockVectorSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/BlockVectorSet.java
@@ -37,7 +37,7 @@ public class BlockVectorSet extends AbstractCollection<BlockVector3> implements 
             int offsetX = localSet.offsetX();
             int offsetY = localSet.offsetY();
             int offsetZ = localSet.offsetZ();
-            if ((offsetX & 2048) != 0 && (offsetY & 512) != 0 && (offsetZ & 2048) != 0) { // Can plug and play
+            if ((offsetX & 2047) == 0 && (offsetY & 511) == 0 && (offsetZ & 2047) == 0) { // Can plug and play
                 localSets.put(MathMan.tripleWorldCoord(offsetX >> 11, offsetY >> 9, offsetZ >> 11), localSet);
             } else {
                 localSet.forEach((x, y, z, index) -> this.add(x, y, z));

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/BlockVectorSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/BlockVectorSet.java
@@ -45,7 +45,7 @@ public class BlockVectorSet extends AbstractCollection<BlockVector3> implements 
         }
     }
 
-    private BlockVectorSet(Map<Long, LocalBlockVectorSet> sets) {
+    private BlockVectorSet(Map<Long, ? extends LocalBlockVectorSet> sets) {
         localSets.putAll(sets);
     }
 
@@ -289,7 +289,7 @@ public class BlockVectorSet extends AbstractCollection<BlockVector3> implements 
         return new BlockVectorSet(localSets
                 .long2ObjectEntrySet()
                 .stream()
-                .collect(Collectors.toMap(Long2ObjectMap.Entry::getLongKey, e -> (LocalBlockVectorSet) e.getValue().clone())));
+                .collect(Collectors.toMap(Long2ObjectMap.Entry::getLongKey, e -> e.getValue().copy())));
     }
 
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
@@ -85,7 +85,7 @@ public class LocalBlockVectorSet implements BlockVector3Set {
      * @since TODO
      */
     public static BlockVector3Set wrapped(int x, int z) {
-        return new BlockVector3SetHolder(new LocalBlockVectorSet());
+        return new BlockVector3SetHolder(new LocalBlockVectorSet(x, z));
     }
 
     /**
@@ -97,7 +97,7 @@ public class LocalBlockVectorSet implements BlockVector3Set {
      * @since TODO
      */
     public static BlockVector3Set wrapped(int x, int y, int z) {
-        return new BlockVector3SetHolder(new LocalBlockVectorSet());
+        return new BlockVector3SetHolder(new LocalBlockVectorSet(x, y, z));
     }
 
     private LocalBlockVectorSet(int x, int y, int z, SparseBitSet set) {
@@ -502,11 +502,11 @@ public class LocalBlockVectorSet implements BlockVector3Set {
 
     }
 
-    static class BlockVector3SetHolder implements BlockVector3Set {
+    private static class BlockVector3SetHolder implements BlockVector3Set {
 
         BlockVector3Set set;
 
-        public BlockVector3SetHolder(BlockVector3Set set) {
+        private BlockVector3SetHolder(BlockVector3Set set) {
             this.set = set;
         }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
@@ -58,6 +58,48 @@ public class LocalBlockVectorSet implements BlockVector3Set {
         this.set = new SparseBitSet();
     }
 
+    /**
+     * New wrapped LocalBlockVectorSet allowing "upgrading" to a {@link BlockVectorSet} as necessary
+     *
+     * @param set existing {@link LocalBlockVectorSet} to wrap
+     * @since TODO
+     */
+    public static BlockVector3Set wrap(LocalBlockVectorSet set) {
+        return new BlockVector3SetHolder(set);
+    }
+
+    /**
+     * New wrapped LocalBlockVectorSet allowing "upgrading" to a {@link BlockVectorSet} as necessary
+     *
+     * @since TODO
+     */
+    public static BlockVector3Set wrapped() {
+        return new BlockVector3SetHolder(new LocalBlockVectorSet());
+    }
+
+    /**
+     * New wrapped LocalBlockVectorSet with initial offset allowing "upgrading" to a {@link BlockVectorSet} as necessary
+     *
+     * @param x x offset
+     * @param z z offset
+     * @since TODO
+     */
+    public static BlockVector3Set wrapped(int x, int z) {
+        return new BlockVector3SetHolder(new LocalBlockVectorSet());
+    }
+
+    /**
+     * New wrapped LocalBlockVectorSet with initial offset allowing "upgrading" to a {@link BlockVectorSet} as necessary
+     *
+     * @param x x offset
+     * @param y y offset
+     * @param z z offset
+     * @since TODO
+     */
+    public static BlockVector3Set wrapped(int x, int y, int z) {
+        return new BlockVector3SetHolder(new LocalBlockVectorSet());
+    }
+
     private LocalBlockVectorSet(int x, int y, int z, SparseBitSet set) {
         this.offsetX = x;
         this.offsetY = y;
@@ -73,6 +115,18 @@ public class LocalBlockVectorSet implements BlockVector3Set {
     @Override
     public boolean isEmpty() {
         return set.isEmpty();
+    }
+
+    public int offsetX() {
+        return offsetX;
+    }
+
+    public int offsetY() {
+        return offsetY;
+    }
+
+    public int offsetZ() {
+        return offsetZ;
     }
 
     /**
@@ -95,8 +149,17 @@ public class LocalBlockVectorSet implements BlockVector3Set {
         return false;
     }
 
+    /**
+     * @deprecated use {@link LocalBlockVectorSet#copy()}
+     */
     @Override
+    @Deprecated(forRemoval = true, since = "TODO")
     public LocalBlockVectorSet clone() {
+        return copy();
+    }
+
+    @Override
+    public LocalBlockVectorSet copy() {
         return new LocalBlockVectorSet(offsetX, offsetY, offsetZ, set.clone());
     }
 
@@ -281,7 +344,7 @@ public class LocalBlockVectorSet implements BlockVector3Set {
         int relZ = z - offsetZ;
         int relY = y - offsetY;
         if (relX > 1023 || relX < -1024 || relZ > 1023 || relZ < -1024 || relY < -256 || relY > 255) {
-            throw new UnsupportedOperationException(
+            throw new IndexOutOfBoundsException(
                     "LocalVectorSet can only contain vectors within 1024 blocks (cuboid) of the first entry. Attempted to set " +
                             "block at " + x + ", " + y + ", " + z + ". With origin " + offsetX + " " + offsetY + " " + offsetZ);
         }
@@ -429,9 +492,128 @@ public class LocalBlockVectorSet implements BlockVector3Set {
         set.clear();
     }
 
+    public boolean isInitialised() {
+        return offsetX != Integer.MAX_VALUE && offsetZ != Integer.MAX_VALUE;
+    }
+
     public interface BlockVectorSetVisitor {
 
         void run(int x, int y, int z, int index);
+
+    }
+
+    static class BlockVector3SetHolder implements BlockVector3Set {
+
+        BlockVector3Set set;
+
+        public BlockVector3SetHolder(BlockVector3Set set) {
+            this.set = set;
+        }
+
+        @Override
+        public boolean add(int x, int y, int z) {
+            try {
+                return set.add(x, y, z);
+            } catch (IndexOutOfBoundsException e) {
+                if (set instanceof LocalBlockVectorSet localBlockVectorSet) {
+                    set = new BlockVectorSet(localBlockVectorSet);
+                    return set.add(x, y, z);
+                } else {
+                    throw e;
+                }
+            }
+        }
+
+        @Override
+        public boolean contains(int x, int y, int z) {
+            return set.contains(x, y, z);
+        }
+
+        @Override
+        public void setOffset(int x, int z) {
+            set.setOffset(x, z);
+        }
+
+        @Override
+        public void setOffset(int x, int y, int z) {
+            set.setOffset(x, y, z);
+        }
+
+        @Override
+        public boolean containsRadius(int x, int y, int z, int radius) {
+            return set.containsRadius(x, y, z, radius);
+        }
+
+        @Override
+        public int size() {
+            return set.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return set.isEmpty();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return set.contains(o);
+        }
+
+        @Override
+        public @Nonnull Iterator<BlockVector3> iterator() {
+            return set.iterator();
+        }
+
+        @Override
+        public @Nonnull Object[] toArray() {
+            return set.toArray();
+        }
+
+        @Override
+        public @Nonnull <T> T[] toArray(@Nonnull T[] a) {
+            return set.toArray(a);
+        }
+
+        @Override
+        public boolean add(BlockVector3 blockVector3) {
+            return set.add(blockVector3);
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            return set.remove(o);
+        }
+
+        @Override
+        public boolean containsAll(@Nonnull Collection<?> c) {
+            return set.containsAll(c);
+        }
+
+        @Override
+        public boolean addAll(@Nonnull Collection<? extends BlockVector3> c) {
+            return set.addAll(c);
+        }
+
+        @Override
+        public boolean retainAll(@Nonnull Collection<?> c) {
+            return set.retainAll(c);
+        }
+
+        @Override
+        public boolean removeAll(@Nonnull Collection<?> c) {
+            return set.removeAll(c);
+        }
+
+        @Override
+        public void clear() {
+            set.clear();
+        }
+
+        @Override
+        public BlockVector3SetHolder copy() {
+            BlockVector3Set copied = set.copy();
+            return new BlockVector3SetHolder(copied);
+        }
 
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/collection/BlockVector3Set.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/collection/BlockVector3Set.java
@@ -7,7 +7,7 @@ import com.sk89q.worldedit.regions.Region;
 
 import java.util.Set;
 
-public interface BlockVector3Set extends Set<BlockVector3>, Cloneable {
+public interface BlockVector3Set extends Set<BlockVector3> {
 
     /**
      * Get the appropriate {@link BlockVector3Set} implementation for the given region. Either {@link LocalBlockVectorSet} or
@@ -89,7 +89,7 @@ public interface BlockVector3Set extends Set<BlockVector3>, Cloneable {
     /**
      * Copy this {@link BlockVector3Set} instance
      *
-     * @return cloned instance
+     * @return copied instance
      * @since TODO
      */
     BlockVector3Set copy();

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/collection/BlockVector3Set.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/collection/BlockVector3Set.java
@@ -7,7 +7,7 @@ import com.sk89q.worldedit.regions.Region;
 
 import java.util.Set;
 
-public interface BlockVector3Set extends Set<BlockVector3> {
+public interface BlockVector3Set extends Set<BlockVector3>, Cloneable {
 
     /**
      * Get the appropriate {@link BlockVector3Set} implementation for the given region. Either {@link LocalBlockVectorSet} or
@@ -49,6 +49,7 @@ public interface BlockVector3Set extends Set<BlockVector3> {
             return new LocalBlockVectorSet();
         }
     }
+
     boolean add(int x, int y, int z);
 
     boolean contains(int x, int y, int z);
@@ -77,12 +78,20 @@ public interface BlockVector3Set extends Set<BlockVector3> {
     /**
      * If a radius is contained by the set
      *
-     * @param x      x radius center
-     * @param y      y radius center
-     * @param z      z radius center
+     * @param x x radius center
+     * @param y y radius center
+     * @param z z radius center
      * @return if radius is contained by the set
      * @since 2.9.2
      */
     boolean containsRadius(int x, int y, int z, int radius);
+
+    /**
+     * Copy this {@link BlockVector3Set} instance
+     *
+     * @return cloned instance
+     * @since TODO
+     */
+    BlockVector3Set copy();
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -3522,7 +3522,7 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
     )
             throws MaxChangedBlocksException {
 
-        LocalBlockVectorSet vset = new LocalBlockVectorSet();
+        BlockVector3Set vset = LocalBlockVectorSet.wrapped();
         List<Node> nodes = new ArrayList<>(nodevectors.size());
 
         Interpolation interpol = new KochanekBartelsInterpolation();
@@ -3561,7 +3561,7 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
         if (radius < 1) {
             return vset;
         }
-        LocalBlockVectorSet returnset = new LocalBlockVectorSet();
+        BlockVector3Set returnset = LocalBlockVectorSet.wrapped();
         int ceilrad = (int) Math.ceil(radius);
 
         for (BlockVector3 v : vset) {
@@ -3587,7 +3587,7 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
         if (radius < 1) {
             return vset;
         }
-        final LocalBlockVectorSet returnset = new LocalBlockVectorSet();
+        final BlockVector3Set returnset = LocalBlockVectorSet.wrapped();
         final int ceilrad = (int) Math.ceil(radius);
         for (BlockVector3 v : vset) {
             final int tipx = v.x();
@@ -3605,8 +3605,8 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
     }
 
     public Set<BlockVector3> getOutline(Set<BlockVector3> vset) {
-        final LocalBlockVectorSet returnset = new LocalBlockVectorSet();
-        final LocalBlockVectorSet newset = new LocalBlockVectorSet();
+        final BlockVector3Set returnset = LocalBlockVectorSet.wrapped();
+        final BlockVector3Set newset = LocalBlockVectorSet.wrapped();
         newset.addAll(vset);
         for (BlockVector3 v : newset) {
             final int x = v.x();
@@ -3624,8 +3624,8 @@ public class EditSession extends PassthroughExtent implements AutoCloseable {
     //FAWE end
 
     public Set<BlockVector3> getHollowed(Set<BlockVector3> vset) {
-        final Set<BlockVector3> returnset = new LocalBlockVectorSet();
-        final LocalBlockVectorSet newset = new LocalBlockVectorSet();
+        final BlockVector3Set returnset = LocalBlockVectorSet.wrapped();
+        final BlockVector3Set newset = LocalBlockVectorSet.wrapped();
         newset.addAll(vset);
         for (BlockVector3 v : newset) {
             final int x = v.x();


### PR DESCRIPTION
There was a/some issue(s) that were due to a local set being used assumptively. The only instances of the local sets being explicitly used should now only be when using chunk coords, or for the floating tree remover