### PR TITLE
Simplify and deduplicate PaperweightGetBlocks#update logic

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -146,6 +146,11 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         return parent;
     }
 
+    @Override
+    protected void ensureInit() {
+        init();
+    }
+
     private synchronized boolean init() {
         if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -148,7 +148,9 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void ensureInit() {
-        init();
+        if (!this.initialised) {
+            init();
+        }
     }
 
     private synchronized boolean init() {

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -966,13 +966,8 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
             return data;
         }
-        if (data != null && data.length != 4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
-        }
-        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
+        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096 || data.length != 4096) {
+            data = new char[4096]; // new array, will be populated below
         }
         Semaphore lock = PaperweightPlatformAdapter.applyLock(section);
         synchronized (lock) {
@@ -1001,38 +996,24 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                     num_palette = palette.getSize();
                 } else {
                     // The section's palette is the global block palette.
-                    for (int i = 0; i < 4096; i++) {
-                        char paletteVal = data[i];
-                        char ordinal = adapter.ibdIDToOrdinal(paletteVal);
-                        data[i] = ordinal;
-                    }
+                    adapter.mapFromGlobalPalette(data);
                     return data;
                 }
 
                 char[] paletteToOrdinal = FaweCache.INSTANCE.PALETTE_TO_BLOCK_CHAR.get();
                 try {
-                    if (num_palette != 1) {
+                    if (num_palette == 1) {
+                        char ordinal = ordinal(palette.valueFor(0), adapter);
+                        Arrays.fill(data, ordinal);
+                    } else {
                         for (int i = 0; i < num_palette; i++) {
                             char ordinal = ordinal(palette.valueFor(i), adapter);
                             paletteToOrdinal[i] = ordinal;
                         }
-                        for (int i = 0; i < 4096; i++) {
-                            char paletteVal = data[i];
-                            char val = paletteToOrdinal[paletteVal];
-                            if (val == Character.MAX_VALUE) {
-                                val = ordinal(palette.valueFor(i), adapter);
-                                paletteToOrdinal[i] = val;
-                            }
-                            data[i] = val;
-                        }
-                    } else {
-                        char ordinal = ordinal(palette.valueFor(0), adapter);
-                        Arrays.fill(data, ordinal);
+                        adapter.mapWithPalette(data, paletteToOrdinal);
                     }
                 } finally {
-                    for (int i = 0; i < num_palette; i++) {
-                        paletteToOrdinal[i] = Character.MAX_VALUE;
-                    }
+                    Arrays.fill(paletteToOrdinal, 0, num_palette, Character.MAX_VALUE);
                 }
                 return data;
             } catch (IllegalAccessException | InterruptedException e) {

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
@@ -147,7 +147,9 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void ensureInit() {
-        init();
+        if (!this.initialised) {
+            init();
+        }
     }
 
     private synchronized boolean init() {

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
@@ -145,6 +145,11 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         return parent;
     }
 
+    @Override
+    protected void ensureInit() {
+        init();
+    }
+
     private synchronized boolean init() {
         if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
@@ -964,13 +964,8 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
             return data;
         }
-        if (data != null && data.length != 4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
-        }
-        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
+        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096 || data.length != 4096) {
+            data = new char[4096]; // new array, will be populated below
         }
         Semaphore lock = PaperweightPlatformAdapter.applyLock(section);
         synchronized (lock) {
@@ -999,38 +994,24 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                     num_palette = palette.getSize();
                 } else {
                     // The section's palette is the global block palette.
-                    for (int i = 0; i < 4096; i++) {
-                        char paletteVal = data[i];
-                        char ordinal = adapter.ibdIDToOrdinal(paletteVal);
-                        data[i] = ordinal;
-                    }
+                    adapter.mapFromGlobalPalette(data);
                     return data;
                 }
 
                 char[] paletteToOrdinal = FaweCache.INSTANCE.PALETTE_TO_BLOCK_CHAR.get();
                 try {
-                    if (num_palette != 1) {
+                    if (num_palette == 1) {
+                        char ordinal = ordinal(palette.valueFor(0), adapter);
+                        Arrays.fill(data, ordinal);
+                    } else {
                         for (int i = 0; i < num_palette; i++) {
                             char ordinal = ordinal(palette.valueFor(i), adapter);
                             paletteToOrdinal[i] = ordinal;
                         }
-                        for (int i = 0; i < 4096; i++) {
-                            char paletteVal = data[i];
-                            char val = paletteToOrdinal[paletteVal];
-                            if (val == Character.MAX_VALUE) {
-                                val = ordinal(palette.valueFor(i), adapter);
-                                paletteToOrdinal[i] = val;
-                            }
-                            data[i] = val;
-                        }
-                    } else {
-                        char ordinal = ordinal(palette.valueFor(0), adapter);
-                        Arrays.fill(data, ordinal);
+                        adapter.mapWithPalette(data, paletteToOrdinal);
                     }
                 } finally {
-                    for (int i = 0; i < num_palette; i++) {
-                        paletteToOrdinal[i] = Character.MAX_VALUE;
-                    }
+                    Arrays.fill(paletteToOrdinal, 0, num_palette, Character.MAX_VALUE);
                 }
                 return data;
             } catch (IllegalAccessException | InterruptedException e) {

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
@@ -155,6 +155,11 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         return parent;
     }
 
+    @Override
+    protected void ensureInit() {
+        init();
+    }
+
     private synchronized boolean init() {
         if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
@@ -157,7 +157,9 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void ensureInit() {
-        init();
+        if (!this.initialised) {
+            init();
+        }
     }
 
     private synchronized boolean init() {

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
@@ -967,13 +967,8 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
             return data;
         }
-        if (data != null && data.length != 4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
-        }
-        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
+        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096 || data.length != 4096) {
+            data = new char[4096]; // new array, will be populated below
         }
         Semaphore lock = PaperweightPlatformAdapter.applyLock(section);
         synchronized (lock) {
@@ -1002,38 +997,24 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                     num_palette = palette.getSize();
                 } else {
                     // The section's palette is the global block palette.
-                    for (int i = 0; i < 4096; i++) {
-                        char paletteVal = data[i];
-                        char ordinal = adapter.ibdIDToOrdinal(paletteVal);
-                        data[i] = ordinal;
-                    }
+                    adapter.mapFromGlobalPalette(data);
                     return data;
                 }
 
                 char[] paletteToOrdinal = FaweCache.INSTANCE.PALETTE_TO_BLOCK_CHAR.get();
                 try {
-                    if (num_palette != 1) {
+                    if (num_palette == 1) {
+                        char ordinal = ordinal(palette.valueFor(0), adapter);
+                        Arrays.fill(data, ordinal);
+                    } else {
                         for (int i = 0; i < num_palette; i++) {
                             char ordinal = ordinal(palette.valueFor(i), adapter);
                             paletteToOrdinal[i] = ordinal;
                         }
-                        for (int i = 0; i < 4096; i++) {
-                            char paletteVal = data[i];
-                            char val = paletteToOrdinal[paletteVal];
-                            if (val == Character.MAX_VALUE) {
-                                val = ordinal(palette.valueFor(i), adapter);
-                                paletteToOrdinal[i] = val;
-                            }
-                            data[i] = val;
-                        }
-                    } else {
-                        char ordinal = ordinal(palette.valueFor(0), adapter);
-                        Arrays.fill(data, ordinal);
+                        adapter.mapWithPalette(data, paletteToOrdinal);
                     }
                 } finally {
-                    for (int i = 0; i < num_palette; i++) {
-                        paletteToOrdinal[i] = Character.MAX_VALUE;
-                    }
+                    Arrays.fill(paletteToOrdinal, 0, num_palette, Character.MAX_VALUE);
                 }
                 return data;
             } catch (IllegalAccessException | InterruptedException e) {

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -155,6 +155,11 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         return parent;
     }
 
+    @Override
+    protected void ensureInit() {
+        init();
+    }
+
     private synchronized boolean init() {
         if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -157,7 +157,9 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void ensureInit() {
-        init();
+        if (!this.initialised) {
+            init();
+        }
     }
 
     private synchronized boolean init() {

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
@@ -962,13 +962,8 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
             return data;
         }
-        if (data != null && data.length != 4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
-        }
-        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
+        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096 || data.length != 4096) {
+            data = new char[4096]; // new array, will be populated below
         }
         Semaphore lock = PaperweightPlatformAdapter.applyLock(section);
         synchronized (lock) {
@@ -997,38 +992,24 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                     num_palette = palette.getSize();
                 } else {
                     // The section's palette is the global block palette.
-                    for (int i = 0; i < 4096; i++) {
-                        char paletteVal = data[i];
-                        char ordinal = adapter.ibdIDToOrdinal(paletteVal);
-                        data[i] = ordinal;
-                    }
+                    adapter.mapFromGlobalPalette(data);
                     return data;
                 }
 
                 char[] paletteToOrdinal = FaweCache.INSTANCE.PALETTE_TO_BLOCK_CHAR.get();
                 try {
-                    if (num_palette != 1) {
+                    if (num_palette == 1) {
+                        char ordinal = ordinal(palette.valueFor(0), adapter);
+                        Arrays.fill(data, ordinal);
+                    } else {
                         for (int i = 0; i < num_palette; i++) {
                             char ordinal = ordinal(palette.valueFor(i), adapter);
                             paletteToOrdinal[i] = ordinal;
                         }
-                        for (int i = 0; i < 4096; i++) {
-                            char paletteVal = data[i];
-                            char val = paletteToOrdinal[paletteVal];
-                            if (val == Character.MAX_VALUE) {
-                                val = ordinal(palette.valueFor(i), adapter);
-                                paletteToOrdinal[i] = val;
-                            }
-                            data[i] = val;
-                        }
-                    } else {
-                        char ordinal = ordinal(palette.valueFor(0), adapter);
-                        Arrays.fill(data, ordinal);
+                        adapter.mapWithPalette(data, paletteToOrdinal);
                     }
                 } finally {
-                    for (int i = 0; i < num_palette; i++) {
-                        paletteToOrdinal[i] = Character.MAX_VALUE;
-                    }
+                    Arrays.fill(paletteToOrdinal, 0, num_palette, Character.MAX_VALUE);
                 }
                 return data;
             } catch (IllegalAccessException | InterruptedException e) {

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
@@ -176,7 +176,9 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void ensureInit() {
-        init();
+        if (!this.initialised) {
+            init();
+        }
     }
 
     private synchronized boolean init() {

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
@@ -174,6 +174,11 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         return parent;
     }
 
+    @Override
+    protected void ensureInit() {
+        init();
+    }
+
     private synchronized boolean init() {
         if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightGetBlocks.java
@@ -963,13 +963,8 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
             Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
             return data;
         }
-        if (data != null && data.length != 4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
-        }
-        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096) {
-            data = new char[4096];
-            Arrays.fill(data, (char) BlockTypesCache.ReservedIDs.AIR);
+        if (data == null || data == FaweCache.INSTANCE.EMPTY_CHAR_4096 || data.length != 4096) {
+            data = new char[4096]; // new array, will be populated below
         }
         Semaphore lock = PaperweightPlatformAdapter.applyLock(section);
         synchronized (lock) {
@@ -998,38 +993,24 @@ public class PaperweightGetBlocks extends CharGetBlocks implements BukkitGetBloc
                     num_palette = palette.getSize();
                 } else {
                     // The section's palette is the global block palette.
-                    for (int i = 0; i < 4096; i++) {
-                        char paletteVal = data[i];
-                        char ordinal = adapter.ibdIDToOrdinal(paletteVal);
-                        data[i] = ordinal;
-                    }
+                    adapter.mapFromGlobalPalette(data);
                     return data;
                 }
 
                 char[] paletteToOrdinal = FaweCache.INSTANCE.PALETTE_TO_BLOCK_CHAR.get();
                 try {
-                    if (num_palette != 1) {
+                    if (num_palette == 1) {
+                        char ordinal = ordinal(palette.valueFor(0), adapter);
+                        Arrays.fill(data, ordinal);
+                    } else {
                         for (int i = 0; i < num_palette; i++) {
                             char ordinal = ordinal(palette.valueFor(i), adapter);
                             paletteToOrdinal[i] = ordinal;
                         }
-                        for (int i = 0; i < 4096; i++) {
-                            char paletteVal = data[i];
-                            char val = paletteToOrdinal[paletteVal];
-                            if (val == Character.MAX_VALUE) {
-                                val = ordinal(palette.valueFor(i), adapter);
-                                paletteToOrdinal[i] = val;
-                            }
-                            data[i] = val;
-                        }
-                    } else {
-                        char ordinal = ordinal(palette.valueFor(0), adapter);
-                        Arrays.fill(data, ordinal);
+                        adapter.mapWithPalette(data, paletteToOrdinal);
                     }
                 } finally {
-                    for (int i = 0; i < num_palette; i++) {
-                        paletteToOrdinal[i] = Character.MAX_VALUE;
-                    }
+                    Arrays.fill(paletteToOrdinal, 0, num_palette, Character.MAX_VALUE);
                 }
                 return data;
             } catch (IllegalAccessException | InterruptedException e) {

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
@@ -176,7 +176,9 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void ensureInit() {
-        init();
+        if (!this.initialised) {
+            init();
+        }
     }
 
     private synchronized boolean init() {

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
@@ -174,6 +174,11 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         return parent;
     }
 
+    @Override
+    protected void ensureInit() {
+        init();
+    }
+
     private synchronized boolean init() {
         if (ibdToOrdinal != null && ibdToOrdinal[1] != 0) {
             return false;

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
@@ -74,6 +74,25 @@ public abstract class FaweAdapter<TAG, SERVER_LEVEL> extends CachedBukkitAdapter
         return true;
     }
 
+    public void mapFromGlobalPalette(char[] data) {
+        assert data.length == 4096;
+        ensureInit();
+        for (int i = 0; i < 4096; i++) {
+            data[i] = (char) this.ibdToOrdinal[data[i]];
+        }
+    }
+
+    public void mapWithPalette(char[] data, char[] paletteToOrdinal) {
+        for (int i = 0; i < 4096; i++) {
+            char paletteVal = data[i];
+            char val = paletteToOrdinal[paletteVal];
+            assert val != Character.MAX_VALUE; // paletteToOrdinal should prevent that
+            data[i] = val;
+        }
+    }
+
+    protected abstract void ensureInit();
+
     protected abstract void preCaptureStates(SERVER_LEVEL serverLevel);
 
     protected abstract List<BlockState> getCapturedBlockStatesCopy(SERVER_LEVEL serverLevel);


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

We can simplify the logic in the update method:
- Avoid filling the array if all of its content is written later anyway
- Move version-independent loops to common supertype
- Use Arrays.fill instead of manual loops where possible

This also helps avoiding going through hard-to-optimize initialization check code every iteration instead of only once before

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
