### PR TITLE
feat: Using Block Registry to Replace Iterating Over the Material Enum

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -51,6 +51,7 @@ import io.papermc.lib.PaperLib;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.WritableRegistry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.resources.ResourceLocation;
@@ -92,6 +93,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -217,6 +219,15 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
         initialised = true;
         return true;
+    }
+
+    @Override
+    public Collection<String> getRegisteredDefaultBlockStates() {
+        ArrayList<String> states = new ArrayList<>();
+        for (final Block block : BuiltInRegistries.BLOCK) {
+            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+        }
+        return states;
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
@@ -50,6 +50,7 @@ import io.papermc.lib.PaperLib;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.WritableRegistry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.resources.ResourceLocation;
@@ -91,6 +92,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -216,6 +218,15 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
         initialised = true;
         return true;
+    }
+
+    @Override
+    public Collection<String> getRegisteredDefaultBlockStates() {
+        ArrayList<String> states = new ArrayList<>();
+        for (final Block block : BuiltInRegistries.BLOCK) {
+            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+        }
+        return states;
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
@@ -55,6 +55,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.WritableRegistry;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
@@ -98,6 +99,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -226,6 +228,15 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
         initialised = true;
         return true;
+    }
+
+    @Override
+    public Collection<String> getRegisteredDefaultBlockStates() {
+        ArrayList<String> states = new ArrayList<>();
+        for (final Block block : BuiltInRegistries.BLOCK) {
+            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+        }
+        return states;
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -55,6 +55,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.WritableRegistry;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
@@ -98,6 +99,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -226,6 +228,15 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
         initialised = true;
         return true;
+    }
+
+    @Override
+    public Collection<String> getRegisteredDefaultBlockStates() {
+        ArrayList<String> states = new ArrayList<>();
+        for (final Block block : BuiltInRegistries.BLOCK) {
+            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+        }
+        return states;
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
@@ -55,6 +55,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.WritableRegistry;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
@@ -97,6 +98,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -212,6 +214,15 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
         initialised = true;
         return true;
+    }
+
+    @Override
+    public Collection<String> getRegisteredDefaultBlockStates() {
+        ArrayList<String> states = new ArrayList<>();
+        for (final Block block : BuiltInRegistries.BLOCK) {
+            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+        }
+        return states;
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
@@ -55,6 +55,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.WritableRegistry;
 import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
@@ -97,6 +98,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -212,6 +214,15 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
         }
         initialised = true;
         return true;
+    }
+
+    @Override
+    public Collection<String> getRegisteredDefaultBlockStates() {
+        ArrayList<String> states = new ArrayList<>();
+        for (final Block block : BuiltInRegistries.BLOCK) {
+            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+        }
+        return states;
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/FaweAdapter.java
@@ -13,6 +13,7 @@ import org.bukkit.TreeType;
 import org.bukkit.World;
 import org.bukkit.block.BlockState;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/IDelegateBukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/IDelegateBukkitImplAdapter.java
@@ -35,6 +35,7 @@ import org.enginehub.linbus.tree.LinCompoundTag;
 import org.enginehub.linbus.tree.LinTag;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Map;
 import java.util.OptionalInt;
 
@@ -133,6 +134,11 @@ public interface IDelegateBukkitImplAdapter<T> extends BukkitImplAdapter<T> {
     @Override
     default void sendBiomeUpdates(World world, Iterable<BlockVector2> chunks) {
         getParent().sendBiomeUpdates(world, chunks);
+    }
+
+    @Override
+    default Collection<String> getRegisteredDefaultBlockStates() {
+        return getParent().getRegisteredDefaultBlockStates();
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
@@ -150,7 +150,7 @@ public class BukkitBlockRegistry extends BundledBlockRegistry {
 
     //FAWE start
     @Override
-    public Collection<String> getAllDefaultBlockStates() {
+    public Collection<String> values() {
         BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         return adapter.getRegisteredDefaultBlockStates();
     }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
@@ -152,7 +152,10 @@ public class BukkitBlockRegistry extends BundledBlockRegistry {
     @Override
     public Collection<String> values() {
         BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
-        return adapter.getRegisteredDefaultBlockStates();
+        if (adapter != null) {
+            return adapter.getRegisteredDefaultBlockStates();
+        }
+        return super.values();
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockRegistry.java
@@ -150,15 +150,9 @@ public class BukkitBlockRegistry extends BundledBlockRegistry {
 
     //FAWE start
     @Override
-    public Collection<String> values() {
-        ArrayList<String> blocks = new ArrayList<>();
-        for (Material m : Material.values()) {
-            if (!m.isLegacy() && m.isBlock()) {
-                BlockData blockData = m.createBlockData();
-                blocks.add(blockData.getAsString());
-            }
-        }
-        return blocks;
+    public Collection<String> getAllDefaultBlockStates() {
+        BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
+        return adapter.getRegisteredDefaultBlockStates();
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/adapter/BukkitImplAdapter.java
@@ -54,6 +54,7 @@ import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import org.bukkit.Keyed;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
@@ -66,7 +67,9 @@ import org.enginehub.linbus.tree.LinCompoundTag;
 import org.enginehub.linbus.tree.LinTag;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -330,6 +333,22 @@ public interface BukkitImplAdapter<T> extends IBukkitAdapter {
 
     default BlockMaterial getMaterial(BlockState blockState) {
         return null;
+    }
+
+    /**
+     * Returns an iterable of all blocks in their default state as string representations known to the server.
+     *
+     * @return an iterable containing the default state strings of all valid blocks
+     */
+    default Collection<String> getRegisteredDefaultBlockStates() {
+        ArrayList<String> blocks = new ArrayList<>();
+        for (Material m : Material.values()) {
+            if (!m.isLegacy() && m.isBlock()) {
+                BlockData blockData = m.createBlockData();
+                blocks.add(blockData.getAsString());
+            }
+        }
+        return blocks;
     }
 
     @Deprecated

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypesCache.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypesCache.java
@@ -214,7 +214,7 @@ public class BlockTypesCache {
             Platform platform = WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS);
             Registries registries = platform.getRegistries();
             BlockRegistry blockReg = registries.getBlockRegistry();
-            Collection<String> blocks = blockReg.getAllDefaultBlockStates();
+            Collection<String> blocks = blockReg.values();
             Map<String, String> blockMap = blocks.stream().collect(Collectors.toMap(item -> item.charAt(item.length() - 1) == ']'
                     ? item.substring(0, item.indexOf('['))
                     : item, item -> item));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypesCache.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypesCache.java
@@ -214,7 +214,7 @@ public class BlockTypesCache {
             Platform platform = WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.GAME_HOOKS);
             Registries registries = platform.getRegistries();
             BlockRegistry blockReg = registries.getBlockRegistry();
-            Collection<String> blocks = blockReg.values();
+            Collection<String> blocks = blockReg.getAllDefaultBlockStates();
             Map<String, String> blockMap = blocks.stream().collect(Collectors.toMap(item -> item.charAt(item.length() - 1) == ']'
                     ? item.substring(0, item.indexOf('['))
                     : item, item -> item));

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
@@ -94,7 +94,7 @@ public interface BlockRegistry {
     /**
      * Register all blocks.
      */
-    default Collection<String> values() {
+    default Collection<String> getAllDefaultBlockStates() {
         return Collections.emptyList();
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
@@ -94,7 +94,7 @@ public interface BlockRegistry {
     /**
      * Register all blocks.
      */
-    default Collection<String> getAllDefaultBlockStates() {
+    default Collection<String> values() {
         return Collections.emptyList();
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/registry/BlockRegistry.java
@@ -92,7 +92,7 @@ public interface BlockRegistry {
     //FAWE start
 
     /**
-     * Register all blocks.
+     * Get a collection of all blocks in their default state as string representations.
      */
     default Collection<String> values() {
         return Collections.emptyList();


### PR DESCRIPTION
The Material in Bukkit is an enum, which is not very flexible. This PR replaces it with Minecraft's built-in block registry to reduce unnecessary checks. Additionally, it changes values() to getAllDefaultBlockStates() to improve readability.