### PR TITLE
Only compute solid blocks once

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/heightmap/HeightMapType.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/heightmap/HeightMapType.java
@@ -1,6 +1,7 @@
 package com.fastasyncworldedit.core.extent.processor.heightmap;
 
 import com.fastasyncworldedit.core.registry.state.PropertyKey;
+import com.sk89q.worldedit.function.mask.SolidBlockMask;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.world.block.BlockCategories;
 import com.sk89q.worldedit.world.block.BlockState;
@@ -17,19 +18,19 @@ public enum HeightMapType {
     MOTION_BLOCKING {
         @Override
         public boolean includes(BlockState state) {
-            return state.getMaterial().isMovementBlocker() || HeightMapType.hasFluid(state);
+            return isMovementBlocker(state) || HeightMapType.hasFluid(state);
         }
     },
     MOTION_BLOCKING_NO_LEAVES {
         @Override
         public boolean includes(BlockState state) {
-            return (state.getMaterial().isMovementBlocker() || HeightMapType.hasFluid(state)) && !HeightMapType.isLeaf(state);
+            return (isMovementBlocker(state) || HeightMapType.hasFluid(state)) && !HeightMapType.isLeaf(state);
         }
     },
     OCEAN_FLOOR {
         @Override
         public boolean includes(BlockState state) {
-            return state.getMaterial().isMovementBlocker();
+            return HeightMapType.isMovementBlocker(state);
         }
     },
     WORLD_SURFACE {
@@ -38,6 +39,10 @@ public enum HeightMapType {
             return !state.isAir();
         }
     };
+
+    private static boolean isMovementBlocker(BlockState state) {
+        return SolidBlockMask.isSolid(state);
+    }
 
     static {
         BlockCategories.LEAVES.getAll(); // make sure this category is initialized, otherwise isLeaf might fail

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/Extent.java
@@ -47,6 +47,7 @@ import com.sk89q.worldedit.function.block.BlockReplace;
 import com.sk89q.worldedit.function.mask.BlockMask;
 import com.sk89q.worldedit.function.mask.ExistingBlockMask;
 import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.function.mask.SolidBlockMask;
 import com.sk89q.worldedit.function.operation.Operation;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.function.pattern.BlockPattern;
@@ -456,17 +457,17 @@ public interface Extent extends InputExtent, OutputExtent {
         int clearanceBelow = y - minY;
         int clearance = Math.min(clearanceAbove, clearanceBelow);
         BlockState block = getBlock(x, y, z);
-        boolean state = !block.getBlockType().getMaterial().isMovementBlocker();
+        boolean state = !SolidBlockMask.isSolid(block);
         int offset = state ? 0 : 1;
         for (int d = 0; d <= clearance; d++) {
             int y1 = y + d;
             block = getBlock(x, y1, z);
-            if (block.getMaterial().isMovementBlocker() == state && block.getBlockType() != BlockTypes.__RESERVED__) {
+            if (matchesSolidState(block, state)) {
                 return y1 - offset;
             }
             int y2 = y - d;
             block = getBlock(x, y2, z);
-            if (block.getMaterial().isMovementBlocker() == state && block.getBlockType() != BlockTypes.__RESERVED__) {
+            if (matchesSolidState(block, state)) {
                 return y2 + offset;
             }
         }
@@ -474,14 +475,14 @@ public interface Extent extends InputExtent, OutputExtent {
             if (clearanceAbove < clearanceBelow) {
                 for (int layer = y - clearance - 1; layer >= minY; layer--) {
                     block = getBlock(x, layer, z);
-                    if (block.getMaterial().isMovementBlocker() == state && block.getBlockType() != BlockTypes.__RESERVED__) {
+                    if (matchesSolidState(block, state)) {
                         return layer + offset;
                     }
                 }
             } else {
                 for (int layer = y + clearance + 1; layer <= maxY; layer++) {
                     block = getBlock(x, layer, z);
-                    if (block.getMaterial().isMovementBlocker() == state && block.getBlockType() != BlockTypes.__RESERVED__) {
+                    if (matchesSolidState(block, state)) {
                         return layer - offset;
                     }
                 }
@@ -493,6 +494,10 @@ public interface Extent extends InputExtent, OutputExtent {
             return block.getBlockType().getMaterial().isAir() ? -1 : result;
         }
         return result;
+    }
+
+    private static boolean matchesSolidState(BlockState block, boolean state) {
+        return SolidBlockMask.isSolid(block) == state && block.getBlockType() != BlockTypes.__RESERVED__;
     }
 
     default void addCaves(Region region) throws WorldEditException {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/SolidBlockMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/SolidBlockMask.java
@@ -20,23 +20,38 @@
 package com.sk89q.worldedit.function.mask;
 
 import com.sk89q.worldedit.extent.Extent;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.block.BlockTypesCache;
 
-import javax.annotation.Nullable;
+public class SolidBlockMask extends AbstractExtentMask {
+    // FAWE start - precompute solid blocks
+    private static final boolean[] SOLID = initialize();
 
-public class SolidBlockMask extends BlockMask {
+    private static boolean[] initialize() {
+        final boolean[] solid = new boolean[BlockTypesCache.states.length];
+        for (int i = 0; i < solid.length; i++) {
+            solid[i] = BlockTypesCache.states[i].getBlockType().getMaterial().isMovementBlocker();
+        }
+        return solid;
+    }
+    // FAWE end
 
     public SolidBlockMask(Extent extent) {
         super(extent);
-        add(state -> state.getMaterial().isMovementBlocker());
     }
 
-    @Nullable
+    // FAWE start
     @Override
-    public Mask2D toMask2D() {
-        return null;
+    public boolean test(final Extent extent, final BlockVector3 position) {
+        final int ordinal = position.getOrdinal(extent);
+        return SOLID[ordinal];
     }
 
-    //FAWE start
+    @Override
+    public boolean test(final BlockVector3 vector) {
+        return test(getExtent(), vector);
+    }
+
     @Override
     public Mask copy() {
         return new SolidBlockMask(getExtent());

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/SolidBlockMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/SolidBlockMask.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.function.mask;
 
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 
 public class SolidBlockMask extends AbstractExtentMask {
@@ -51,6 +52,15 @@ public class SolidBlockMask extends AbstractExtentMask {
     public boolean test(final BlockVector3 vector) {
         return test(getExtent(), vector);
     }
+
+    /**
+     * {@return whether the given block state is considered solid by this mask}
+     * @since TODO
+     */
+    public static boolean isSolid(BlockState blockState) {
+        return SOLID[blockState.getOrdinal()];
+    }
+
 
     @Override
     public Mask copy() {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`SolidBlockMask` previously went through all block states on construction to find all movement-blocking block states. While that doesn't take much time, it adds up as the mask is used in other places, e.g. on every click with a brush. Precalculating the values only once additionally allows us to use the information in other places where we previously called into NMS code through multiple layers of abstraction to check whether a block blocks movement.
For example operations using an angle mask can benefit from that.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
