### PR TITLE
Improve BiomeMask performance

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
@@ -652,11 +652,12 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static BiomeType adapt(Holder<Biome> biome, LevelAccessor levelAccessor) {
         final Registry<Biome> biomeRegistry = levelAccessor.registryAccess().registryOrThrow(BIOME);
-        if (biomeRegistry.getKey(biome.value()) == null) {
-            return biomeRegistry.asHolderIdMap().getId(biome) == -1 ? BiomeTypes.OCEAN
-                    : null;
+        final int id = biomeRegistry.getId(biome.value());
+        if (id < 0) {
+            // this shouldn't be the case, but other plugins can be weird
+            return BiomeTypes.OCEAN;
         }
-        return BiomeTypes.get(biome.unwrapKey().orElseThrow().location().toString());
+        return BiomeTypes.getLegacy(id);
     }
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
@@ -652,11 +652,12 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static BiomeType adapt(Holder<Biome> biome, LevelAccessor levelAccessor) {
         final Registry<Biome> biomeRegistry = levelAccessor.registryAccess().registryOrThrow(BIOME);
-        if (biomeRegistry.getKey(biome.value()) == null) {
-            return biomeRegistry.asHolderIdMap().getId(biome) == -1 ? BiomeTypes.OCEAN
-                    : null;
+        final int id = biomeRegistry.getId(biome.value());
+        if (id < 0) {
+            // this shouldn't be the case, but other plugins can be weird
+            return BiomeTypes.OCEAN;
         }
-        return BiomeTypes.get(biome.unwrapKey().orElseThrow().location().toString());
+        return BiomeTypes.getLegacy(id);
     }
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightPlatformAdapter.java
@@ -645,11 +645,12 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static BiomeType adapt(Holder<Biome> biome, LevelAccessor levelAccessor) {
         final Registry<Biome> biomeRegistry = levelAccessor.registryAccess().registryOrThrow(BIOME);
-        if (biomeRegistry.getKey(biome.value()) == null) {
-            return biomeRegistry.asHolderIdMap().getId(biome) == -1 ? BiomeTypes.OCEAN
-                    : null;
+        final int id = biomeRegistry.getId(biome.value());
+        if (id < 0) {
+            // this shouldn't be the case, but other plugins can be weird
+            return BiomeTypes.OCEAN;
         }
-        return BiomeTypes.get(biome.unwrapKey().orElseThrow().location().toString());
+        return BiomeTypes.getLegacy(id);
     }
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
@@ -629,11 +629,12 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static BiomeType adapt(Holder<Biome> biome, LevelAccessor levelAccessor) {
         final Registry<Biome> biomeRegistry = levelAccessor.registryAccess().registryOrThrow(BIOME);
-        if (biomeRegistry.getKey(biome.value()) == null) {
-            return biomeRegistry.asHolderIdMap().getId(biome) == -1 ? BiomeTypes.OCEAN
-                    : null;
+        final int id = biomeRegistry.getId(biome.value());
+        if (id < 0) {
+            // this shouldn't be the case, but other plugins can be weird
+            return BiomeTypes.OCEAN;
         }
-        return BiomeTypes.get(biome.unwrapKey().orElseThrow().location().toString());
+        return BiomeTypes.getLegacy(id);
     }
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightPlatformAdapter.java
@@ -636,11 +636,12 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static BiomeType adapt(Holder<Biome> biome, LevelAccessor levelAccessor) {
         final Registry<Biome> biomeRegistry = levelAccessor.registryAccess().lookupOrThrow(BIOME);
-        if (biomeRegistry.getKey(biome.value()) == null) {
-            return biomeRegistry.asHolderIdMap().getId(biome) == -1 ? BiomeTypes.OCEAN
-                    : null;
+        final int id = biomeRegistry.getId(biome.value());
+        if (id < 0) {
+            // this shouldn't be the case, but other plugins can be weird
+            return BiomeTypes.OCEAN;
         }
-        return BiomeTypes.get(biome.unwrapKey().orElseThrow().location().toString());
+        return BiomeTypes.getLegacy(id);
     }
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightPlatformAdapter.java
@@ -631,11 +631,12 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     public static BiomeType adapt(Holder<Biome> biome, LevelAccessor levelAccessor) {
         final Registry<Biome> biomeRegistry = levelAccessor.registryAccess().lookupOrThrow(BIOME);
-        if (biomeRegistry.getKey(biome.value()) == null) {
-            return biomeRegistry.asHolderIdMap().getId(biome) == -1 ? BiomeTypes.OCEAN
-                    : null;
+        final int id = biomeRegistry.getId(biome.value());
+        if (id < 0) {
+            // this shouldn't be the case, but other plugins can be weird
+            return BiomeTypes.OCEAN;
         }
-        return BiomeTypes.get(biome.unwrapKey().orElseThrow().location().toString());
+        return BiomeTypes.getLegacy(id);
     }
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BiomeMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BiomeMask.java
@@ -26,8 +26,6 @@ import com.sk89q.worldedit.world.biome.BiomeType;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -38,7 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class BiomeMask extends AbstractExtentMask {
 //FAWE end
 
-    private final Set<BiomeType> biomes = new HashSet<>();
+    private final boolean[] biomes;
 
     /**
      * Create a new biome mask.
@@ -51,7 +49,15 @@ public class BiomeMask extends AbstractExtentMask {
         super(extent);
         //FAWE end
         checkNotNull(biomes);
-        this.biomes.addAll(biomes);
+        this.biomes = new boolean[BiomeType.REGISTRY.size()];
+        for (final BiomeType biome : biomes) {
+            this.biomes[biome.getInternalId()] = true;
+        }
+    }
+
+    private BiomeMask(Extent extent, boolean[] biomes) {
+        super(extent);
+        this.biomes = biomes;
     }
 
     /**
@@ -71,7 +77,9 @@ public class BiomeMask extends AbstractExtentMask {
      */
     public void add(Collection<BiomeType> biomes) {
         checkNotNull(biomes);
-        this.biomes.addAll(biomes);
+        for (final BiomeType biome : biomes) {
+            this.biomes[biome.getInternalId()] = true;
+        }
     }
 
     /**
@@ -89,13 +97,13 @@ public class BiomeMask extends AbstractExtentMask {
      * @return a list of biomes
      */
     public Collection<BiomeType> getBiomes() {
-        return biomes;
+        return BiomeType.REGISTRY.values().stream().filter(type -> biomes[type.getInternalId()]).toList();
     }
 
     @Override
     public boolean test(BlockVector3 vector) {
         BiomeType biome = vector.getBiome(getExtent());
-        return biomes.contains(biome);
+        return biomes[biome.getInternalId()];
     }
 
     @Nullable
@@ -107,14 +115,14 @@ public class BiomeMask extends AbstractExtentMask {
     //FAWE start
     @Override
     public Mask copy() {
-        return new BiomeMask(getExtent(), new HashSet<>(biomes));
+        return new BiomeMask(getExtent(), this.biomes.clone());
     }
     //FAWE end
 
     @Override
     public boolean test(Extent extent, BlockVector3 position) {
         BiomeType biome = getExtent().getBiome(position);
-        return biomes.contains(biome);
+        return biomes[biome.getInternalId()];
     }
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BiomeMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/BiomeMask.java
@@ -36,7 +36,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class BiomeMask extends AbstractExtentMask {
 //FAWE end
 
+    //FAWE start - avoid HashSet usage
     private final boolean[] biomes;
+    //FAWE end
 
     /**
      * Create a new biome mask.
@@ -49,10 +51,12 @@ public class BiomeMask extends AbstractExtentMask {
         super(extent);
         //FAWE end
         checkNotNull(biomes);
+        //FAWE start - avoid HashSet usage
         this.biomes = new boolean[BiomeType.REGISTRY.size()];
         for (final BiomeType biome : biomes) {
             this.biomes[biome.getInternalId()] = true;
         }
+        //FAWE end
     }
 
     private BiomeMask(Extent extent, boolean[] biomes) {
@@ -77,9 +81,11 @@ public class BiomeMask extends AbstractExtentMask {
      */
     public void add(Collection<BiomeType> biomes) {
         checkNotNull(biomes);
+        //FAWE start - avoid HashSet usage
         for (final BiomeType biome : biomes) {
             this.biomes[biome.getInternalId()] = true;
         }
+        //FAWE end
     }
 
     /**
@@ -97,13 +103,17 @@ public class BiomeMask extends AbstractExtentMask {
      * @return a list of biomes
      */
     public Collection<BiomeType> getBiomes() {
+        //FAWE start - avoid HashSet usage
         return BiomeType.REGISTRY.values().stream().filter(type -> biomes[type.getInternalId()]).toList();
+        //FAWE end
     }
 
     @Override
     public boolean test(BlockVector3 vector) {
+        //FAWE start - avoid HashSet usage
         BiomeType biome = vector.getBiome(getExtent());
         return biomes[biome.getInternalId()];
+        //FAWE end
     }
 
     @Nullable
@@ -117,12 +127,12 @@ public class BiomeMask extends AbstractExtentMask {
     public Mask copy() {
         return new BiomeMask(getExtent(), this.biomes.clone());
     }
-    //FAWE end
 
     @Override
     public boolean test(Extent extent, BlockVector3 position) {
         BiomeType biome = getExtent().getBiome(position);
         return biomes[biome.getInternalId()];
     }
+    //FAWE end
 
 }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeTypes.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/biome/BiomeTypes.java
@@ -20,7 +20,10 @@
 package com.sk89q.worldedit.world.biome;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * Stores a list of common {@link BiomeType BiomeTypes}.
@@ -297,10 +300,18 @@ public final class BiomeTypes {
     }
 
     public static BiomeType getLegacy(int legacyId) {
-        for (BiomeType type : values()) {
-            if (type.getLegacyId() == legacyId) {
-                return type;
+        class BiomeTypeIdCache {
+            private static final List<BiomeType> byId = create();
+
+            private static List<BiomeType> create() {
+                BiomeType[] array = values().toArray(new BiomeType[0]);
+                Arrays.sort(array, Comparator.comparing(BiomeType::getLegacyId));
+                return List.of(array);
             }
+
+        }
+        if (legacyId >= 0 && legacyId < BiomeTypeIdCache.byId.size()) {
+            return BiomeTypeIdCache.byId.get(legacyId);
         }
         return null;
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->


BiomeMask and biome access generally are rather slow, and a lot of the slowness is caused by inefficient translation and slow contains checks. The adaption from NMS biomes to WE BiomeType can be simplified as we already set the legacy id (= NMS-internal id). The HashSet can be replaced by a boolean array, similar to how BlockMask works.


```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
