### PR TITLE
Avoid ThreadLocal lookup in ParallelQueueExtent

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
@@ -84,7 +84,21 @@ public class ParallelQueueExtent extends PassthroughExtent {
         this.sideEffectSet = sideEffectSet == null ? SideEffectSet.defaults() : sideEffectSet;
     }
 
+    /**
+     * Removes the extent currently associated with the calling thread.
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
+    public static void clearCurrentExtent() {
+        FaweThread.clearCurrentExtent();
+    }
 
+    /**
+     * Sets the extent associated with the calling thread.
+     */
+    @Deprecated(forRemoval = true, since = "TODO")
+    public static void setCurrentExtent(Extent extent) {
+        FaweThread.setCurrentExtent(extent);
+    }
 
     private void enter(Extent extent) {
         FaweThread.setCurrentExtent(extent);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
@@ -19,6 +19,7 @@ import com.fastasyncworldedit.core.internal.simd.VectorizedFilter;
 import com.fastasyncworldedit.core.queue.Filter;
 import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
+import com.fastasyncworldedit.core.util.task.FaweThread;
 import com.sk89q.worldedit.MaxChangedBlocksException;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.extent.Extent;
@@ -53,7 +54,6 @@ import java.util.stream.IntStream;
 public class ParallelQueueExtent extends PassthroughExtent {
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
-    private static final ThreadLocal<Extent> extents = new ThreadLocal<>();
 
     private final World world;
     private final QueueHandler handler;
@@ -84,32 +84,20 @@ public class ParallelQueueExtent extends PassthroughExtent {
         this.sideEffectSet = sideEffectSet == null ? SideEffectSet.defaults() : sideEffectSet;
     }
 
-    /**
-     * Removes the extent currently associated with the calling thread.
-     */
-    public static void clearCurrentExtent() {
-        extents.remove();
-    }
 
-    /**
-     * Sets the extent associated with the calling thread.
-     */
-    public static void setCurrentExtent(Extent extent) {
-        extents.set(extent);
-    }
 
     private void enter(Extent extent) {
-        setCurrentExtent(extent);
+        FaweThread.setCurrentExtent(extent);
     }
 
     private void exit() {
-        clearCurrentExtent();
+        FaweThread.clearCurrentExtent();
     }
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     public IQueueExtent<IQueueChunk> getExtent() {
-        Extent extent = extents.get();
+        Extent extent = FaweThread.getCurrentExtent();
         if (extent == null) {
             extent = super.getExtent();
         }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/chunk/ChunkHolder.java
@@ -10,9 +10,9 @@ import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
-import com.fastasyncworldedit.core.queue.implementation.ParallelQueueExtent;
 import com.fastasyncworldedit.core.util.MemUtil;
 import com.sk89q.worldedit.entity.Entity;
+import com.fastasyncworldedit.core.util.task.FaweThread;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
@@ -1056,11 +1056,11 @@ public class ChunkHolder<T extends Future<T>> implements IQueueChunk<T> {
     // This way, locking is spread across multiple STQEs, allowing for better performance
 
     private void trackExtent() {
-            ParallelQueueExtent.setCurrentExtent(extent);
+        FaweThread.setCurrentExtent(extent);
     }
 
     private void untrackExtent() {
-        ParallelQueueExtent.clearCurrentExtent();
+        FaweThread.clearCurrentExtent();
     }
 
     /**

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/task/FaweForkJoinWorkerThreadFactory.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/task/FaweForkJoinWorkerThreadFactory.java
@@ -16,7 +16,7 @@ public class FaweForkJoinWorkerThreadFactory implements ForkJoinPool.ForkJoinWor
 
     @Override
     public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
-        final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+        final ForkJoinWorkerThread worker = new FaweThread(pool);
         worker.setName(String.format(nameFormat, idCounter.getAndIncrement()));
         return worker;
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/task/FaweThread.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/task/FaweThread.java
@@ -1,0 +1,51 @@
+package com.fastasyncworldedit.core.util.task;
+
+import com.sk89q.worldedit.extent.Extent;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+
+@ApiStatus.Internal
+public class FaweThread extends ForkJoinWorkerThread {
+
+    private static final ThreadLocal<Extent> EXTENTS = new ThreadLocal<>();
+
+    private Extent currentExtent;
+
+    protected FaweThread(final ForkJoinPool pool) {
+        super(null, pool, true);
+    }
+
+    /**
+     * Removes the extent currently associated with the calling thread.
+     */
+    public static void clearCurrentExtent() {
+        if (Thread.currentThread() instanceof FaweThread ft) {
+            ft.currentExtent = null;
+        } else {
+            EXTENTS.remove();
+        }
+    }
+
+    /**
+     * Sets the extent associated with the calling thread.
+     */
+    public static void setCurrentExtent(Extent extent) {
+        if (Thread.currentThread() instanceof FaweThread ft) {
+            ft.currentExtent = extent;
+        } else {
+            EXTENTS.set(extent);
+        }
+
+    }
+
+    public static Extent getCurrentExtent() {
+        if (Thread.currentThread() instanceof FaweThread ft) {
+            return ft.currentExtent;
+        } else {
+            return EXTENTS.get();
+        }
+    }
+
+}


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`ThreadLocal` has some overhead that can be avoided as we're controlling our thread pools ourselves. By just having specific thread types with direct access, we can improve performance of commands that go through the `ParallelQueueExtent#getExtent()` code a lot (i.e. `//copy`). As most time is spent loading chunks there, it's somewhat hard to measure, but the time spent in the `getExtent()` method is reduced by ~90%.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
