### PR TITLE
Update workflows to use upload-artifact v4

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,6 +22,7 @@ jobs:
         run: ./gradlew build -s
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
+        if: matrix.os == 'ubuntu-latest' # only upload once, use linux builds
         with:
             name: FastAsyncWorldEdit-SNAPSHOT
             path: worldedit-bukkit/build/libs/FastAsyncWorldEdit-*.jar

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./gradlew build -s
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
-        if: matrix.os == 'ubuntu-latest' # only upload once, use linux builds
+        if: ${{ matrix.os == 'ubuntu-latest' }} # only upload once, use linux builds
         with:
             name: FastAsyncWorldEdit-SNAPSHOT
             path: worldedit-bukkit/build/libs/FastAsyncWorldEdit-*.jar

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build on ${{ matrix.os }}
         run: ./gradlew build -s
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: FastAsyncWorldEdit-SNAPSHOT
             path: worldedit-bukkit/build/libs/FastAsyncWorldEdit-*.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           target-branch: main
           target-directory: worldedit-bukkit
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: FastAsyncWorldEdit-Bukkit-SNAPSHOT
           path: worldedit-bukkit/build/libs/FastAsyncWorldEdit-*.jar


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`upload-artifact` v3 is deprecated and makes jobs fail now. So it's time to update it.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
