### PR TITLE
Make #clipboard in height brush work again

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -532,7 +532,7 @@ public class BrushCommands {
         int maxY = player.getWorld().getMaxY();
         try {
             brush = new StencilBrush(stream, rotation, yscale, onlyWhite,
-                    "#clipboard".equalsIgnoreCase(image)
+                    isClipboard(image)
                             ? session.getClipboard().getClipboard() : null, minY, maxY
             );
         } catch (EmptyClipboardException ignored) {
@@ -903,23 +903,15 @@ public class BrushCommands {
         int minY = player.getWorld().getMinY();
         int maxY = player.getWorld().getMaxY();
         if (flat) {
-            try {
-                brush = new FlattenBrush(stream, rotation, yscale, layers, smooth,
-                        "#clipboard".equalsIgnoreCase(image)
-                                ? session.getClipboard().getClipboard() : null, shape, minY, maxY
-                );
-            } catch (EmptyClipboardException ignored) {
-                brush = new FlattenBrush(stream, rotation, yscale, layers, smooth, null, shape, minY, maxY);
-            }
+            brush = new FlattenBrush(stream, rotation, yscale, layers, smooth,
+                    isClipboard(image)
+                            ? session.getClipboard().getClipboard() : null, shape, minY, maxY
+            );
         } else {
-            try {
-                brush = new HeightBrush(stream, rotation, yscale, layers, smooth,
-                        "#clipboard".equalsIgnoreCase(image)
-                                ? session.getClipboard().getClipboard() : null, minY, maxY
-                );
-            } catch (EmptyClipboardException ignored) {
-                brush = new HeightBrush(stream, rotation, yscale, layers, smooth, null, minY, maxY);
-            }
+            brush = new HeightBrush(stream, rotation, yscale, layers, smooth,
+                    isClipboard(image)
+                            ? session.getClipboard().getClipboard() : null, minY, maxY
+            );
         }
         if (randomRotate) {
             brush.setRandomRotate(true);
@@ -927,8 +919,12 @@ public class BrushCommands {
         set(context, brush, "worldedit.brush.height").setSize(radius);
     }
 
+    private static boolean isClipboard(String image) {
+        return "#clipboard".equalsIgnoreCase(image);
+    }
+
     private InputStream getHeightmapStream(String filename) throws FileNotFoundException {
-        if (filename == null || "none".equalsIgnoreCase(filename)) {
+        if (filename == null || "none".equalsIgnoreCase(filename) || isClipboard(filename)) {
             return null;
         }
         String filenamePng = filename.endsWith(".png") ? filename : filename + ".png";


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`#clipboard` didn't work in height brushes anymore, as the filename/url check didn't cover it properly. Additionally, using `#clipboard` previously silently went back to the default height map when no region was selected. Reporting the problem to the user is better.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
