### PR TITLE
Fix mutability issue leading to wrong behavior in //ascend and //descend

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/AbstractPlayerActor.java
@@ -280,14 +280,8 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         int yPlusSearchHeight = y + WorldEdit.getInstance().getConfiguration().defaultVerticalHeight;
         int maxY = Math.min(world.getMaxY(), yPlusSearchHeight) + 2;
 
-        //FAWE start - mutable
-        MutableBlockVector3 mutable = new MutableBlockVector3(x, y, z);
-        //FAWE end
-
         while (y <= maxY) {
-            //FAWE start - mutable
-            if (isLocationGoodForStanding(mutable.mutY(y))
-                    //FAWE end
+            if (isLocationGoodForStanding(BlockVector3.at(x, y, z))
                     && trySetPosition(Vector3.at(x + 0.5, y, z + 0.5))) {
                 return true;
             }
@@ -308,14 +302,8 @@ public abstract class AbstractPlayerActor implements Actor, Player, Cloneable {
         int yLessSearchHeight = y - WorldEdit.getInstance().getConfiguration().defaultVerticalHeight;
         int minY = Math.min(world.getMinY() + 1, yLessSearchHeight);
 
-        //FAWE start - mutable
-        MutableBlockVector3 mutable = new MutableBlockVector3(x, y, z);
-        //FAWE end
-
         while (y >= minY) {
-            //FAWE start - mutable
-            if (isLocationGoodForStanding(mutable.mutY(y))
-                    //FAWE end
+            if (isLocationGoodForStanding(BlockVector3.at(x, y, z))
                     && trySetPosition(Vector3.at(x + 0.5, y, z + 0.5))) {
                 return true;
             }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`//ascend` and `//descend` functionality used a mutable vector, but the vector got modified in another method. This caused the commands to misbehave. Simply reverting to the original WE code fixes that. As this isn't performance critical, using immutable vectors seems to be fine.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
