### PR TITLE
Locality-aware chunk distribution

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ApplyTask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ApplyTask.java
@@ -1,16 +1,12 @@
 package com.fastasyncworldedit.core.queue.implementation;
 
 import com.fastasyncworldedit.core.Fawe;
-import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.filter.block.ChunkFilterBlock;
 import com.fastasyncworldedit.core.internal.exception.FaweException;
 import com.fastasyncworldedit.core.queue.Filter;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
-import jdk.jfr.Category;
-import jdk.jfr.Event;
-import jdk.jfr.Name;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ApplyTask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ApplyTask.java
@@ -111,6 +111,11 @@ class ApplyTask<F extends Filter> extends RecursiveAction implements Runnable {
                         processRegion(regionX, regionZ, this.shift);
                         continue;
                     }
+                    if (this.shift == 0 && !this.commonState.region.containsChunk(regionX, regionZ)) {
+                        // if shift == 0, region ccords are chunk coords
+                        continue; // chunks not intersecting with the region don't need a task
+                    }
+
                     // creating more tasks will likely help parallelism as other threads aren't *that* busy
                     subtask = new ApplyTask<>(
                             this.commonState,
@@ -152,7 +157,7 @@ class ApplyTask<F extends Filter> extends RecursiveAction implements Runnable {
             for (int chunkX = regionX << shift; chunkX <= ((regionX  + 1) << shift) - 1; chunkX++) {
                 for (int chunkZ = regionZ << shift; chunkZ <= ((regionZ  + 1) << shift) - 1; chunkZ++) {
                     if (!this.commonState.region.containsChunk(chunkX, chunkZ)) {
-                        continue; // chunks not intersecting with the region don't need a task
+                        continue; // chunks not intersecting with the region must not be processed
                     }
                     applyChunk(chunkX, chunkZ, state);
                 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ApplyTask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ApplyTask.java
@@ -117,7 +117,7 @@ class ApplyTask<F extends Filter> extends RecursiveAction implements Runnable {
             for (int regionX = minRegionX; regionX <= maxRegionX; regionX++) {
                 for (int regionZ = minRegionZ; regionZ <= maxRegionZ; regionZ++) {
                     if (ForkJoinTask.getSurplusQueuedTaskCount() > Settings.settings().QUEUE.PARALLEL_THREADS) {
-                        // assume we can do a bigger batch of work here - the other threads are busy for a while
+                        // assume we should do a bigger batch of work here - the other threads are busy for a while
                         processRegion(regionX, regionZ, this.shift);
                         continue;
                     }
@@ -218,7 +218,7 @@ class ApplyTask<F extends Filter> extends RecursiveAction implements Runnable {
     }
 
     private void onCompletion() {
-        for (ForkJoinTask<?> task : postProcess()) {
+        for (ForkJoinTask<?> task : flushQueues()) {
             if (task.tryUnfork()) {
                 task.invoke();
             } else {
@@ -227,7 +227,7 @@ class ApplyTask<F extends Filter> extends RecursiveAction implements Runnable {
         }
     }
 
-    private ForkJoinTask<?>[] postProcess() {
+    private ForkJoinTask<?>[] flushQueues() {
         final Collection<ThreadState<F>> values = this.commonState.stateCache.values();
         ForkJoinTask<?>[] tasks = new ForkJoinTask[values.size()];
         int i = values.size() - 1;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ApplyTask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ApplyTask.java
@@ -1,0 +1,204 @@
+package com.fastasyncworldedit.core.queue.implementation;
+
+import com.fastasyncworldedit.core.configuration.Settings;
+import com.fastasyncworldedit.core.extent.filter.block.ChunkFilterBlock;
+import com.fastasyncworldedit.core.queue.Filter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Region;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.RecursiveAction;
+
+class ApplyTask<F extends Filter> extends RecursiveAction implements Runnable {
+
+    private static final int INITIAL_REGION_SHIFT = 5;
+    private static final int SHIFT_REDUCTION = 2;
+
+    private final CommonState<F> commonState;
+    private final ApplyTask<F> before;
+    private final int minChunkX;
+    private final int minChunkZ;
+    private final int maxChunkX;
+    private final int maxChunkZ;
+    private final int shift;
+
+    @Override
+    public void run() {
+        compute();
+    }
+
+    private record CommonState<F extends Filter>(
+            F originalFilter,
+            Region region,
+            ParallelQueueExtent parallelQueueExtent,
+            ConcurrentMap<Thread, ThreadState<F>> stateCache,
+            boolean full
+    ) {
+
+    }
+
+    private static final class ThreadState<F extends Filter> {
+
+        private final SingleThreadQueueExtent queue;
+        private final F filter;
+        private ChunkFilterBlock block;
+
+        private ThreadState(SingleThreadQueueExtent queue, F filter) {
+            this.queue = queue;
+            this.filter = filter;
+        }
+
+    }
+
+    ApplyTask(
+            final Region region,
+            final F filter,
+            final ParallelQueueExtent parallelQueueExtent,
+            final boolean full
+    ) {
+        this.commonState = new CommonState<>(
+                filter,
+                region.clone(), // clone only once, assuming the filter doesn't modify that clone
+                parallelQueueExtent,
+                new ConcurrentHashMap<>(),
+                full
+        );
+        this.before = null;
+        final BlockVector3 minimumPoint = region.getMinimumPoint();
+        this.minChunkX = minimumPoint.x() >> 4;
+        this.minChunkZ = minimumPoint.z() >> 4;
+        final BlockVector3 maximumPoint = region.getMaximumPoint();
+        this.maxChunkX = maximumPoint.x() >> 4;
+        this.maxChunkZ = maximumPoint.z() >> 4;
+        this.shift = INITIAL_REGION_SHIFT;
+
+    }
+
+    private ApplyTask(
+            final CommonState<F> commonState,
+            final ApplyTask<F> before,
+            final int minChunkX,
+            final int maxChunkX,
+            final int minChunkZ,
+            final int maxChunkZ,
+            final int higherShift
+    ) {
+        this.commonState = commonState;
+        this.minChunkX = minChunkX;
+        this.maxChunkX = maxChunkX;
+        this.minChunkZ = minChunkZ;
+        this.maxChunkZ = maxChunkZ;
+        this.before = before;
+        this.shift = Math.max(0, higherShift - SHIFT_REDUCTION);
+    }
+
+    @Override
+    protected void compute() {
+        ApplyTask<F> subtask = null;
+        if (this.minChunkX != this.maxChunkX || this.minChunkZ != this.maxChunkZ) {
+            int minRegionX = this.minChunkX >> this.shift;
+            int minRegionZ = this.minChunkZ >> this.shift;
+            int maxRegionX = this.maxChunkX >> this.shift;
+            int maxRegionZ = this.maxChunkZ >> this.shift;
+            // This task covers multiple regions. Create one subtask per region
+            for (int regionX = minRegionX; regionX <= maxRegionX; regionX++) {
+                for (int regionZ = minRegionZ; regionZ <= maxRegionZ; regionZ++) {
+                    if (ForkJoinTask.getSurplusQueuedTaskCount() > Settings.settings().QUEUE.PARALLEL_THREADS) {
+                        // assume we can do a bigger batch of work here - the other threads are busy for a while
+                        processRegion(regionX, regionZ, this.shift);
+                        continue;
+                    }
+                    // creating more tasks will likely help parallelism as other threads aren't *that* busy
+                    subtask = new ApplyTask<>(
+                            this.commonState,
+                            subtask,
+                            regionX << this.shift,
+                            ((regionX + 1) << this.shift) - 1,
+                            regionZ << this.shift,
+                            ((regionZ + 1) << this.shift) - 1,
+                            this.shift
+                    );
+                    subtask.fork();
+                }
+            }
+        } else {
+            // we reached a task for a single chunk, let's process it
+            processChunk(this.minChunkX, this.minChunkZ);
+        }
+        // try processing tasks in reverse order if not processed already, otherwise "wait" for completion
+        while (subtask != null) {
+            if (subtask.tryUnfork()) {
+                subtask.compute();
+            } else {
+                subtask.quietlyJoin();
+            }
+            subtask = subtask.before;
+        }
+    }
+
+    private void processRegion(int regionX, int regionZ, int shift) {
+        final ThreadState<F> state = this.commonState.stateCache.computeIfAbsent(
+                Thread.currentThread(),
+                __ -> new ThreadState<>(
+                        (SingleThreadQueueExtent) this.commonState.parallelQueueExtent.getNewQueue(),
+                        (F) this.commonState.originalFilter.fork()
+                )
+        );
+        this.commonState.parallelQueueExtent.enter(state.queue);
+        try {
+            for (int chunkX = regionX << shift; chunkX <= ((regionX  + 1) << shift) - 1; chunkX++) {
+                for (int chunkZ = regionZ << shift; chunkZ <= ((regionZ  + 1) << shift) - 1; chunkZ++) {
+                    if (!this.commonState.region.containsChunk(chunkX, chunkZ)) {
+                        continue; // chunks not intersecting with the region don't need a task
+                    }
+                    applyChunk(chunkX, chunkZ, state);
+                }
+            }
+        } finally {
+            this.commonState.parallelQueueExtent.exit();
+        }
+
+    }
+
+    private void processChunk(int chunkX, int chunkZ) {
+        final ThreadState<F> state = this.commonState.stateCache.computeIfAbsent(
+                Thread.currentThread(),
+                __ -> new ThreadState<>(
+                        (SingleThreadQueueExtent) this.commonState.parallelQueueExtent.getNewQueue(),
+                        (F) this.commonState.originalFilter.fork()
+                )
+        );
+        this.commonState.parallelQueueExtent.enter(state.queue);
+        try {
+            applyChunk(chunkX, chunkZ, state);
+        } finally {
+            this.commonState.parallelQueueExtent.exit();
+        }
+    }
+
+    private void applyChunk(int chunkX, int chunkZ, ThreadState<F> state) {
+        state.block = state.queue.apply(
+                state.block,
+                state.filter,
+                this.commonState.region,
+                chunkX,
+                chunkZ,
+                this.commonState.full
+        );
+    }
+
+    ForkJoinTask<?>[] postProcess() {
+        final Collection<ThreadState<F>> values = this.commonState.stateCache.values();
+        ForkJoinTask<?>[] tasks = new ForkJoinTask[values.size()];
+        int i = 0;
+        for (final ThreadState<F> value : values) {
+            tasks[i] = ForkJoinTask.adapt(value.queue::flush).fork();
+            i++;
+        }
+        return tasks;
+    }
+
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
@@ -155,16 +155,7 @@ public class ParallelQueueExtent extends PassthroughExtent {
             getExtent().flush();
             filter.finish();
         } else {
-            ForkJoinTask<?> task = this.handler.submit(new ApplyTask<>(region, filter, ParallelQueueExtent.this, full) {
-                @Override
-                protected void compute() {
-                    super.compute();
-                    // the root task takes care of the post-process invocation
-                    for (ForkJoinTask<?> task1 : postProcess()) {
-                        task1.quietlyJoin();
-                    }
-                }
-            });
+            ForkJoinTask<?> task = this.handler.submit(new ApplyTask<>(region, filter, this, full));
             // wait for task to finish
             task.quietlyJoin();
             // Join filters

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/ParallelQueueExtent.java
@@ -1,6 +1,5 @@
 package com.fastasyncworldedit.core.queue.implementation;
 
-import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.NullExtent;
@@ -42,9 +41,6 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.world.block.BlockType;
-import jdk.jfr.Category;
-import jdk.jfr.Event;
-import jdk.jfr.Name;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
@@ -52,7 +48,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ForkJoinTask;
-import java.util.stream.IntStream;
 
 public class ParallelQueueExtent extends PassthroughExtent {
 
@@ -160,27 +155,14 @@ public class ParallelQueueExtent extends PassthroughExtent {
             getExtent().flush();
             filter.finish();
         } else {
-            @Category("FAWE")
-            @Name("ComputeEvent")
-            class ComputeEvent extends Event {
-                public String type;
-            }
-            final ComputeEvent rawCompute = new ComputeEvent();
-            rawCompute.type = "raw";
-            rawCompute.begin();
-            final ComputeEvent fullCompute = new ComputeEvent();
-            fullCompute.type = "full";
-            fullCompute.begin();
             ForkJoinTask<?> task = this.handler.submit(new ApplyTask<>(region, filter, ParallelQueueExtent.this, full) {
                 @Override
                 protected void compute() {
                     super.compute();
-                    rawCompute.commit();
                     // the root task takes care of the post-process invocation
                     for (ForkJoinTask<?> task1 : postProcess()) {
                         task1.quietlyJoin();
                     }
-                    fullCompute.commit();
                 }
             });
             // wait for task to finish

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
@@ -53,7 +53,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
             null,
             false,
             Settings.settings().QUEUE.PARALLEL_THREADS,
-            Settings.settings().QUEUE.PARALLEL_THREADS * 2,
+            Settings.settings().QUEUE.PARALLEL_THREADS,
             0,
             pool -> true,
             60,

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 /**
@@ -50,7 +51,13 @@ public abstract class QueueHandler implements Trimable, Runnable {
             Settings.settings().QUEUE.PARALLEL_THREADS,
             new FaweForkJoinWorkerThreadFactory("FAWE Fork Join Pool Primary - %s"),
             null,
-            false
+            false,
+            Settings.settings().QUEUE.PARALLEL_THREADS,
+            Settings.settings().QUEUE.PARALLEL_THREADS * 2,
+            0,
+            pool -> true,
+            60,
+            TimeUnit.SECONDS
     );
 
     /**

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/regions/Region.java
@@ -381,6 +381,9 @@ public interface Region extends Iterable<BlockVector3>, Cloneable, IBatchProcess
                 && contains(tx, ty, tz);
     }
 
+    /**
+     * {@return whether this region <b>intersects</b> with the AABB of the given chunk}
+     */
     default boolean containsChunk(int chunkX, int chunkZ) {
         int bx = chunkX << 4;
         int bz = chunkZ << 4;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

`ParallelQueueExtent` deals with distributing work onto multiple threads to speed up edits. In its current implementation, this is achieved by just using the `Region#getChunks().iterator()` as a queue and let all threads pull the next chunk to work on from there. This works well typically, but it has one downside: Different threads work on neighboring chunks. There are multiple reasons this isn't optimal:

- Filters accessing data of surrounding chunks will cause more cache misses in their `STQE`. As currently this also means that one `STQE` will trim the chunk cached/processed by another `STQE`, we do a lot of extra work in such cases.
- Due to how Minecraft generates chunks, processing neighboring chunks on different threads can be slower if both threads wait for the same resources.

By distributing work more location-aware, these downsides can be prevented, at the cost of a somewhat more complicated work-splitting logic. This means threads will process more tasks, but those tasks are smaller and faster to process. As an additional benefit, this allows better work distribution if multiple edits are done concurrently, as the threads don't have to finish one edit before they are free again for the next edit. Consequently, thread-local data needs to be cleared and re-set more often.

Exception handling is a bit of a question mark with this approach, I tried to get it near to the original handling, but I'm not sure if it makes sense the way it is right now.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
