### PR TITLE
Support single y level processing using Vector API

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorFacade.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorFacade.java
@@ -26,7 +26,7 @@ public class VectorFacade {
 
     public ShortVector getOrZero(VectorSpecies<Short> species) {
         if (this.data == null) {
-            return species.zero().reinterpretAsShorts();
+            return ShortVector.zero(species);
         }
         return ShortVector.fromCharArray(species, this.data, this.index);
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedCharFilterBlock.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/VectorizedCharFilterBlock.java
@@ -15,6 +15,11 @@ public class VectorizedCharFilterBlock extends CharFilterBlock {
 
     @Override
     public synchronized void filter(final Filter filter) {
+        filter(filter, 0, 15);
+    }
+
+    @Override
+    public synchronized void filter(final Filter filter, final int startY, final int endY) {
         if (!(filter instanceof VectorizedFilter vecFilter)) {
             throw new IllegalStateException("Unexpected VectorizedCharFilterBlock " + filter);
         }
@@ -24,9 +29,8 @@ public class VectorizedCharFilterBlock extends CharFilterBlock {
         VectorFacade getFassade = new VectorFacade(this.get);
         getFassade.setLayer(this.layer);
         getFassade.setData(this.getArr);
-        // assume setArr.length == getArr.length == 4096
         VectorMask<Short> affectAll = species.maskAll(true);
-        for (int i = 0; i < 4096; i += species.length()) {
+        for (int i = startY << 8; i < ((endY + 1) << 8) - 1; i += species.length()) {
             setFassade.setIndex(i);
             getFassade.setIndex(i);
             vecFilter.applyVector(getFassade, setFassade, affectAll);


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

If we only need to filter a range of y levels of a section rather than the full section, the vectorized filters can still be used. In fact, the code for both supported filter variants can be shared.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
