### PR TITLE
Restore Spigot compatibility

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -232,7 +232,7 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public Collection<String> getRegisteredDefaultBlockStates() {
         ArrayList<String> states = new ArrayList<>();
         for (final Block block : BuiltInRegistries.BLOCK) {
-            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+            states.add(CraftBlockData.fromData(block.defaultBlockState()).getAsString());
         }
         return states;
     }

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
@@ -231,7 +231,7 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public Collection<String> getRegisteredDefaultBlockStates() {
         ArrayList<String> states = new ArrayList<>();
         for (final Block block : BuiltInRegistries.BLOCK) {
-            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+            states.add(CraftBlockData.fromData(block.defaultBlockState()).getAsString());
         }
         return states;
     }

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
@@ -241,7 +241,7 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public Collection<String> getRegisteredDefaultBlockStates() {
         ArrayList<String> states = new ArrayList<>();
         for (final Block block : BuiltInRegistries.BLOCK) {
-            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+            states.add(CraftBlockData.fromData(block.defaultBlockState()).getAsString());
         }
         return states;
     }

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -241,7 +241,7 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public Collection<String> getRegisteredDefaultBlockStates() {
         ArrayList<String> states = new ArrayList<>();
         for (final Block block : BuiltInRegistries.BLOCK) {
-            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+            states.add(CraftBlockData.fromData(block.defaultBlockState()).getAsString());
         }
         return states;
     }

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightFaweAdapter.java
@@ -227,7 +227,7 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public Collection<String> getRegisteredDefaultBlockStates() {
         ArrayList<String> states = new ArrayList<>();
         for (final Block block : BuiltInRegistries.BLOCK) {
-            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+            states.add(CraftBlockData.fromData(block.defaultBlockState()).getAsString());
         }
         return states;
     }

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
@@ -227,7 +227,7 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public Collection<String> getRegisteredDefaultBlockStates() {
         ArrayList<String> states = new ArrayList<>();
         for (final Block block : BuiltInRegistries.BLOCK) {
-            states.add(CraftBlockData.createData(block.defaultBlockState()).getAsString());
+            states.add(CraftBlockData.fromData(block.defaultBlockState()).getAsString());
         }
         return states;
     }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

After #3057, FAWE fails to start due to the `CraftBlockData.createData(…)` method only existing on Paper. Spigot and Paper both have a method `CraftBlockData.fromData(…)` that can be used instead to restore Spigot compatibility.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
