### PR TITLE
Set Extent on the Copy -m Mask flag

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java
@@ -306,6 +306,7 @@ public class ClipboardCommands {
         }
         final Mask firstSourceMask = mask != null ? mask : sourceMask;
         final Mask finalMask = MaskIntersection.of(firstSourceMask, new RegionMask(allowedRegion)).optimize();
+        new MaskTraverser(finalMask).setNewExtent(editSession);
         if (finalMask != Masks.alwaysTrue()) {
             copy.setSourceMask(finalMask);
         }


### PR DESCRIPTION
## Overview
While developing ezEdits @eztaK-red and I noticed that not using a MaskTraverser to set the extent on a mask results in significantly slower performance.

We assumed that this could also be why we noticed slow performance in the `-m` flag for `//copy`, and that does appear to be the case.

There may be other instances of masks in FAWE not having an extent set where performance could be improved, but I didn't want to get ahead of myself in case there were issues with the way that I have fixed it here.
Especially as during testing it appears older versions of FAWE (2.11.1) were even slower, so changes since then may have already had a positive impact on `-m` performance.

## Description
Sets the extent for the `finalMask` in the `createCopy()` method used by `//copy` which (going by previous FAWE commits) avoids using a WorldWrapper.

Rough runtime comparison using `-m #solid,>[!air],[/[0][90]],[|air]` (Before & After fix):
![2025-03-02_17 53 41](https://github.com/user-attachments/assets/e68f89cb-e0e1-4b50-bf24-a364abdd1b14)
![2025-03-02_18 03 13](https://github.com/user-attachments/assets/9db9d97a-0577-4ba6-b41a-b4f64f849b75)

Copying a large selection with a "complex" mask & pasting (After fix):
![2025-03-02_17 35 57](https://github.com/user-attachments/assets/b7fc0c85-af85-4f25-9b1e-df06582c617d)
![2025-03-02_17 36 21](https://github.com/user-attachments/assets/c21aee20-22ae-40aa-89bc-4b18ba35f5dd)

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
