### PR TITLE
Fix offset mask mutating vector

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetMask.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/mask/OffsetMask.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.function.mask;
 
+import com.fastasyncworldedit.core.math.MutableBlockVector3;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.Capability;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -115,6 +116,10 @@ public class OffsetMask extends AbstractMask {
     @Override
     public boolean test(BlockVector3 vector) {
         //FAWE start - ignore resultant position outside world height range
+        if (vector instanceof MutableBlockVector3) {
+            // make sure we don't modify a vector passed from the outside
+            vector = vector.toImmutable();
+        }
         BlockVector3 testPos = vector.add(offset);
         if (testPos.y() < minY || testPos.y() > maxY) {
             return false;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3134

## Description
<!-- Please describe what this pull request does. -->

ForwardCopyExtent uses a MutableVector3, and our current OffsetMask implementation modifies it. That results in applying the following function (and potentially other masks) to the wrong block.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
