### PR TITLE
Inform when vector api is present but not used

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/SimdSupport.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/internal/simd/SimdSupport.java
@@ -16,11 +16,13 @@ import com.sk89q.worldedit.world.block.BlockTypesCache;
 import jdk.incubator.vector.ShortVector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 
 public class SimdSupport {
 
+    private static final Logger LOGGER = LogManagerCompat.getLogger();
     private static final boolean VECTOR_API_PRESENT;
 
     static {
@@ -32,8 +34,16 @@ public class SimdSupport {
         }
         VECTOR_API_PRESENT = vectorApiPresent;
         if (!VECTOR_API_PRESENT && Settings.settings().EXPERIMENTAL.USE_VECTOR_API) {
-            LogManagerCompat.getLogger()
-                    .warn("FAWE use-vector-api is enabled but --add-modules=jdk.incubator.vector is not set.");
+            LOGGER.warn("""
+                    FAWE use-vector-api is enabled but --add-modules=jdk.incubator.vector is not set.
+                    Vector instructions will not be used.
+                    """);
+        } else if (VECTOR_API_PRESENT && !Settings.settings().EXPERIMENTAL.USE_VECTOR_API) {
+            LOGGER.warn("""
+                    The server is running with the --add-modules=jdk.incubator.vector option.
+                    FAWE can use vector instructions, but it is disabled in the config.
+                    Enable use-vector-api to benefit from vector instructions with FAWE.\
+                    """);
         }
     }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

Inform the user when they already use the --add-modules flag for the vector api but haven't enabled it in FAWE.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
