### PR TITLE
fix: update Discord announcement workflow to use correct release tag output

### DIFF
--- a/.github/workflows/announce-release-on-discord.yml
+++ b/.github/workflows/announce-release-on-discord.yml
@@ -1,9 +1,9 @@
 name: Announce release on discord
-#on:
-#  workflow_run:
-#    workflows: ["Upload release assets"]
-#    types:
-#      - completed
+on:
+  workflow_run:
+    workflows: [Upload release assets]
+    types:
+      - completed
 jobs:
   send_announcement:
     runs-on: ubuntu-latest
@@ -18,9 +18,9 @@ jobs:
           args: |
             "<@&525015715300900875> <@&706463154804097105> <@&671372968462516240>"
             ""
-            "<:fawe:730750370984493106> **FastAsyncWorldEdit ${{ github.event.release.tag_name }} has been released!**"
+            "<:fawe:730750370984493106> **FastAsyncWorldEdit ${{ github.event.workflow_run.outputs.tag }} has been released!**"
             ""
-            "Click here to view changelog: https://github.com/IntellectualSites/FastAsyncWorldEdit/releases/tag/${{ github.event.release.tag_name }}"
+            "Click here to view changelog: https://github.com/IntellectualSites/FastAsyncWorldEdit/releases/tag/${{ github.event.workflow_run.outputs.tag }}"
             ""
             "The download is available at:"
             "- Spigot: <https://www.spigotmc.org/resources/13932/>"

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -24,3 +24,5 @@ jobs:
           files: 'worldedit-bukkit/build/libs/FastAsyncWorldEdit-*.jar'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-tag: ${{ github.event.release.tag_name }}
+    outputs:
+      tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Overview
This pr allow to use the workflow again for publish releases.

## Description


### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
