### PR TITLE
Properly relight surrounding chunks

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/StarlightRelighter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/StarlightRelighter.java
@@ -118,10 +118,14 @@ public abstract class StarlightRelighter<SERVER_LEVEL, CHUNK_POS> implements Rel
     public boolean addChunk(int cx, int cz, byte[] skipReason, int bitmask) {
         areaLock.lock();
         try {
-            long key = MathMan.pairInt(cx >> CHUNKS_PER_BATCH_SQRT_LOG2, cz >> CHUNKS_PER_BATCH_SQRT_LOG2);
-            // TODO probably submit here already if chunks.size == CHUNKS_PER_BATCH?
-            LongSet chunks = this.regions.computeIfAbsent(key, k -> new LongArraySet(CHUNKS_PER_BATCH >> 2));
-            chunks.add(asLong(cx, cz));
+            // light can go into neighboring chunks, make sure they are relighted too.
+            for (int x = cx - 1; x <= cx + 1; x++) {
+                for (int z = cz - 1; z <= cz + 1; z++) {
+                    long key = MathMan.pairInt(x >> CHUNKS_PER_BATCH_SQRT_LOG2, z >> CHUNKS_PER_BATCH_SQRT_LOG2);
+                    LongSet chunks = this.regions.computeIfAbsent(key, k -> new LongArraySet(CHUNKS_PER_BATCH >> 2));
+                    chunks.add(asLong(x, z));
+                }
+            }
         } finally {
             areaLock.unlock();
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3145

## Description
<!-- Please describe what this pull request does. -->

We need to make sure chunks bordering a change are relighted too, as light could spread into them. By just enqueuing 3x3 chunks, light is always properly recalculated now.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
