### PR TITLE
Fix crash due to data race when removing block entity

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -13,6 +13,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
+import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitEntity;
@@ -340,38 +341,41 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             }
             copies.put(copyKey, copy);
         }
-        // Remove existing tiles. Create a copy so that we can remove blocks
-        Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
-        List<BlockEntity> beacons = null;
-        if (!chunkTiles.isEmpty()) {
-            for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
-                if (!set.hasSection(layer)) {
-                    continue;
-                }
-
-                int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
-                if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
-                    BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
-                        if (beacons == null) {
-                            beacons = new ArrayList<>();
-                        }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+        List<BlockEntity> beacons = TaskManager.taskManager().sync(() -> {
+            // Remove existing tiles. Create a copy so that we can remove blocks
+            Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
+            List<BlockEntity> beaconEntities = null;
+            if (!chunkTiles.isEmpty()) {
+                for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
+                    final BlockPos pos = entry.getKey();
+                    final int lx = pos.getX() & 15;
+                    final int ly = pos.getY();
+                    final int lz = pos.getZ() & 15;
+                    final int layer = ly >> 4;
+                    if (!set.hasSection(layer)) {
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
+
+                    int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
+                    if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
+                        BlockEntity tile = entry.getValue();
+                        if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                            if (beaconEntities == null) {
+                                beaconEntities = new ArrayList<>();
+                            }
+                            beaconEntities.add(tile);
+                            PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                            continue;
+                        }
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
                     }
                 }
             }
-        }
+            return beaconEntities;
+        });
         final BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
@@ -13,6 +13,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
+import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitEntity;
@@ -340,38 +341,41 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             }
             copies.put(copyKey, copy);
         }
-        // Remove existing tiles. Create a copy so that we can remove blocks
-        Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
-        List<BlockEntity> beacons = null;
-        if (!chunkTiles.isEmpty()) {
-            for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
-                if (!set.hasSection(layer)) {
-                    continue;
-                }
-
-                int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
-                if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
-                    BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
-                        if (beacons == null) {
-                            beacons = new ArrayList<>();
-                        }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+        List<BlockEntity> beacons = TaskManager.taskManager().sync(() -> {
+            // Remove existing tiles. Create a copy so that we can remove blocks
+            Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
+            List<BlockEntity> beaconEntities = null;
+            if (!chunkTiles.isEmpty()) {
+                for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
+                    final BlockPos pos = entry.getKey();
+                    final int lx = pos.getX() & 15;
+                    final int ly = pos.getY();
+                    final int lz = pos.getZ() & 15;
+                    final int layer = ly >> 4;
+                    if (!set.hasSection(layer)) {
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
+
+                    int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
+                    if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
+                        BlockEntity tile = entry.getValue();
+                        if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                            if (beaconEntities == null) {
+                                beaconEntities = new ArrayList<>();
+                            }
+                            beaconEntities.add(tile);
+                            PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                            continue;
+                        }
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
                     }
                 }
             }
-        }
+            return beaconEntities;
+        });
         final BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
@@ -13,6 +13,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
+import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitEntity;
@@ -341,38 +342,41 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             }
             copies.put(copyKey, copy);
         }
-        // Remove existing tiles. Create a copy so that we can remove blocks
-        Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
-        List<BlockEntity> beacons = null;
-        if (!chunkTiles.isEmpty()) {
-            for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
-                if (!set.hasSection(layer)) {
-                    continue;
-                }
-
-                int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
-                if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
-                    BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
-                        if (beacons == null) {
-                            beacons = new ArrayList<>();
-                        }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+        List<BlockEntity> beacons = TaskManager.taskManager().sync(() -> {
+            // Remove existing tiles. Create a copy so that we can remove blocks
+            Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
+            List<BlockEntity> beaconEntities = null;
+            if (!chunkTiles.isEmpty()) {
+                for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
+                    final BlockPos pos = entry.getKey();
+                    final int lx = pos.getX() & 15;
+                    final int ly = pos.getY();
+                    final int lz = pos.getZ() & 15;
+                    final int layer = ly >> 4;
+                    if (!set.hasSection(layer)) {
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
+
+                    int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
+                    if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
+                        BlockEntity tile = entry.getValue();
+                        if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                            if (beaconEntities == null) {
+                                beaconEntities = new ArrayList<>();
+                            }
+                            beaconEntities.add(tile);
+                            PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                            continue;
+                        }
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
                     }
                 }
             }
-        }
+            return beaconEntities;
+        });
         final BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
@@ -15,6 +15,7 @@ import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.queue.implementation.QueueHandler;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
+import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitEntity;
@@ -344,38 +345,41 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             }
             copies.put(copyKey, copy);
         }
-        // Remove existing tiles. Create a copy so that we can remove blocks
-        Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
-        List<BlockEntity> beacons = null;
-        if (!chunkTiles.isEmpty()) {
-            for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
-                if (!set.hasSection(layer)) {
-                    continue;
-                }
-
-                int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
-                if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
-                    BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
-                        if (beacons == null) {
-                            beacons = new ArrayList<>();
-                        }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+        List<BlockEntity> beacons = TaskManager.taskManager().sync(() -> {
+            // Remove existing tiles. Create a copy so that we can remove blocks
+            Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
+            List<BlockEntity> beaconEntities = null;
+            if (!chunkTiles.isEmpty()) {
+                for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
+                    final BlockPos pos = entry.getKey();
+                    final int lx = pos.getX() & 15;
+                    final int ly = pos.getY();
+                    final int lz = pos.getZ() & 15;
+                    final int layer = ly >> 4;
+                    if (!set.hasSection(layer)) {
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
+
+                    int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
+                    if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
+                        BlockEntity tile = entry.getValue();
+                        if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                            if (beaconEntities == null) {
+                                beaconEntities = new ArrayList<>();
+                            }
+                            beaconEntities.add(tile);
+                            PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                            continue;
+                        }
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
                     }
                 }
             }
-        }
+            return beaconEntities;
+        });
         final BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;

--- a/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_3/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_3/PaperweightGetBlocks.java
@@ -13,6 +13,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
+import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitEntity;
@@ -342,38 +343,41 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             }
             copies.put(copyKey, copy);
         }
-        // Remove existing tiles. Create a copy so that we can remove blocks
-        Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
-        List<BlockEntity> beacons = null;
-        if (!chunkTiles.isEmpty()) {
-            for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
-                if (!set.hasSection(layer)) {
-                    continue;
-                }
-
-                int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
-                if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
-                    BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
-                        if (beacons == null) {
-                            beacons = new ArrayList<>();
-                        }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+        List<BlockEntity> beacons = TaskManager.taskManager().sync(() -> {
+            // Remove existing tiles. Create a copy so that we can remove blocks
+            Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
+            List<BlockEntity> beaconEntities = null;
+            if (!chunkTiles.isEmpty()) {
+                for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
+                    final BlockPos pos = entry.getKey();
+                    final int lx = pos.getX() & 15;
+                    final int ly = pos.getY();
+                    final int lz = pos.getZ() & 15;
+                    final int layer = ly >> 4;
+                    if (!set.hasSection(layer)) {
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
+
+                    int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
+                    if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
+                        BlockEntity tile = entry.getValue();
+                        if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                            if (beaconEntities == null) {
+                                beaconEntities = new ArrayList<>();
+                            }
+                            beaconEntities.add(tile);
+                            PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                            continue;
+                        }
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
                     }
                 }
             }
-        }
+            return beaconEntities;
+        });
         final BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3151

## Description
<!-- Please describe what this pull request does. -->

This is rather a quick fix for the server crash. Performance impact seems to be okay, but we might want to take a closer look in future. We could probably also use Minecraft's new tick freezing mechanism instead. The beacon special-casing can be removed too probably.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
