### PR TITLE
feat: add upstream's trim command (EngineHub/WorldEdit#2278)

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/SelectionCommands.java
@@ -47,11 +47,15 @@ import com.sk89q.worldedit.extension.platform.permission.ActorSelectorLimits;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.function.block.BlockDistributionCounter;
 import com.sk89q.worldedit.function.mask.Mask;
+import com.sk89q.worldedit.function.mask.MaskIntersection;
+import com.sk89q.worldedit.function.mask.Masks;
+import com.sk89q.worldedit.function.mask.RegionMask;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.function.visitor.RegionVisitor;
 import com.sk89q.worldedit.internal.annotation.Direction;
 import com.sk89q.worldedit.internal.annotation.MultiDirection;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionOperationException;
 import com.sk89q.worldedit.regions.RegionSelector;
@@ -506,6 +510,138 @@ public class SelectionCommands {
         }
 
         return changes.build().map(v -> v.multiply(amount)).toArray(BlockVector3[]::new);
+    }
+
+    @Command(
+            name = "/trim",
+            desc = "Minimize the selection to encompass matching blocks"
+    )
+    @Logging(REGION)
+    @CommandPermissions("worldedit.selection.trim")
+    public void trim(Actor actor, World world, LocalSession session,
+                     @Arg(desc = "Mask of blocks to keep within the selection", def = "#existing")
+                         Mask mask) throws WorldEditException {
+        // Avoid checking blocks outside the original region but within the cuboid region
+        Region originalRegion = session.getSelection(world);
+        if (!(originalRegion instanceof CuboidRegion)) {
+            mask = new MaskIntersection(new RegionMask(originalRegion), mask);
+        }
+
+        // Result region will be cuboid
+        CuboidRegion region = originalRegion.getBoundingBox();
+
+        BlockVector3 min = region.getMinimumPoint();
+        BlockVector3 max = region.getMaximumPoint();
+
+        int minY = 0;
+        boolean found = false;
+
+        outer: for (int y = min.y(); y <= max.y(); y++) {
+            for (int x = min.x(); x <= max.x(); x++) {
+                for (int z = min.z(); z <= max.z(); z++) {
+                    BlockVector3 vec = BlockVector3.at(x, y, z);
+
+                    if (mask.test(vec)) {
+                        found = true;
+                        minY = y;
+
+                        break outer;
+                    }
+                }
+            }
+        }
+
+        // If anything was found in the first pass, then the remaining variables are guaranteed to be set
+        if (!found) {
+            throw new StopExecutionException(Caption.of("worldedit.trim.no-blocks"));
+        }
+
+        int maxY = minY;
+
+        outer: for (int y = max.y(); y > minY; y--) {
+            for (int x = min.x(); x <= max.x(); x++) {
+                for (int z = min.z(); z <= max.z(); z++) {
+                    BlockVector3 vec = BlockVector3.at(x, y, z);
+
+                    if (mask.test(vec)) {
+                        maxY = y;
+                        break outer;
+                    }
+                }
+            }
+        }
+
+        int minX = 0;
+
+        outer: for (int x = min.x(); x <= max.x(); x++) {
+            for (int z = min.z(); z <= max.z(); z++) {
+                for (int y = minY; y <= maxY; y++) {
+                    BlockVector3 vec = BlockVector3.at(x, y, z);
+
+                    if (mask.test(vec)) {
+                        minX = x;
+                        break outer;
+                    }
+                }
+            }
+        }
+
+        int maxX = minX;
+
+        outer: for (int x = max.x(); x > minX; x--) {
+            for (int z = min.z(); z <= max.z(); z++) {
+                for (int y = minY; y <= maxY; y++) {
+                    BlockVector3 vec = BlockVector3.at(x, y, z);
+
+                    if (mask.test(vec)) {
+                        maxX = x;
+                        break outer;
+                    }
+                }
+            }
+        }
+
+        int minZ = 0;
+
+        outer: for (int z = min.z(); z <= max.z(); z++) {
+            for (int x = minX; x <= maxX; x++) {
+                for (int y = minY; y <= maxY; y++) {
+                    BlockVector3 vec = BlockVector3.at(x, y, z);
+
+                    if (mask.test(vec)) {
+                        minZ = z;
+                        break outer;
+                    }
+                }
+            }
+        }
+
+        int maxZ = minZ;
+
+        outer: for (int z = max.z(); z > minZ; z--) {
+            for (int x = minX; x <= maxX; x++) {
+                for (int y = minY; y <= maxY; y++) {
+                    BlockVector3 vec = BlockVector3.at(x, y, z);
+
+                    if (mask.test(vec)) {
+                        maxZ = z;
+                        break outer;
+                    }
+                }
+            }
+        }
+
+        final CuboidRegionSelector selector;
+        if (session.getRegionSelector(world) instanceof ExtendingCuboidRegionSelector) {
+            selector = new ExtendingCuboidRegionSelector(world, BlockVector3.at(minX, minY, minZ), BlockVector3.at(maxX, maxY, maxZ));
+        } else {
+            selector = new CuboidRegionSelector(world, BlockVector3.at(minX, minY, minZ), BlockVector3.at(maxX, maxY, maxZ));
+        }
+        session.setRegionSelector(world, selector);
+
+        session.getRegionSelector(world).learnChanges();
+        session.getRegionSelector(world).explainRegionAdjust(actor, session);
+        actor.print(Caption.of("worldedit.trim.trim"));
     }
 
     @Command(

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -416,6 +416,8 @@
   "worldedit.shift.shifted": "Region shifted.",
   "worldedit.outset.outset": "Region outset.",
   "worldedit.inset.inset": "Region inset.",
+  "worldedit.trim.trim": "Region trimmed.",
+  "worldedit.trim.no-blocks": "No blocks matched the trim mask.",
   "worldedit.size.offset": "{0}: {1} @ {2} ({3} blocks)",
   "worldedit.size.type": "Type: {0}",
   "worldedit.size.size": "Size: {0}",


### PR DESCRIPTION
* Add the trim command

* Fix issues from PR review

* Cleanup usages of deprecated Vector getters

* chore: cleanup translations & memoize mask

---------

## Overview
Fixes EngineHub/WorldEdit#1629

## Description
Adds upstream's `//trim` command.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
