### PR TITLE
Update Minecraft 1.21.8 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,6 +27,10 @@ body:
       description: Which server version version you using? If your server version is not listed, it is not supported. Update to a supported version first.
       multiple: false
       options:
+        - '1.21.8'
+        - '1.21.7'
+        - '1.21.6'
+        - '1.21.5'
         - '1.21.4'
         - '1.21.1'
         - '1.20.6'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ allprojects {
 }
 
 applyCommonConfiguration()
-val supportedVersions = listOf("1.20.4", "1.20.5", "1.20.6", "1.21", "1.21.1", "1.21.4", "1.21.5", "1.21.7")
+val supportedVersions = listOf("1.20.4", "1.20.5", "1.20.6", "1.21", "1.21.1", "1.21.4", "1.21.5", "1.21.7", "1.21.8")
 
 tasks {
     supportedVersions.forEach {
@@ -97,7 +97,7 @@ tasks {
         }
     }
     runServer {
-        minecraftVersion("1.21.7")
+        minecraftVersion("1.21.8")
         pluginJars(*project(":worldedit-bukkit").getTasksByName("shadowJar", false).map { (it as Jar).archiveFile }
                 .toTypedArray())
 

--- a/worldedit-bukkit/adapters/adapter-1_21_6/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/build.gradle.kts
@@ -12,6 +12,6 @@ repositories {
 
 dependencies {
     // https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/
-    the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21.7-R0.1-20250701.225444-12")
+    the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21.8-R0.1-20250717.225444-12")
     compileOnly(libs.paperlib)
 }

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_6/PaperweightAdapter.java
@@ -213,8 +213,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
         CraftServer.class.cast(Bukkit.getServer());
 
         int dataVersion = SharedConstants.getCurrentVersion().dataVersion().version();
-        if (dataVersion != Constants.DATA_VERSION_MC_1_21_6 && dataVersion != Constants.DATA_VERSION_MC_1_21_7) {
-            throw new UnsupportedClassVersionError("Not 1.21.6 or 1.21.7!");
+        if (dataVersion != Constants.DATA_VERSION_MC_1_21_6 && dataVersion != Constants.DATA_VERSION_MC_1_21_7 && dataVersion != Constants.DATA_VERSION_MC_1_21_8) {
+            throw new UnsupportedClassVersionError("Not 1.21.6, 1.21.7 or 1.21.8!");
         }
 
         serverWorldsField = CraftServer.class.getDeclaredField("worlds");

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
@@ -118,4 +118,9 @@ public final class Constants {
      * The DataVersion for Minecraft 1.21.7
      */
     public static final int DATA_VERSION_MC_1_21_7 = 4438;
+
+    /**
+     * The DataVersion for Minecraft 1.21.8
+     */
+    public static final int DATA_VERSION_MC_1_21_8 = 4440;
 }


### PR DESCRIPTION
## Overview
This pull request introduces support for Minecraft server version 1.21.8 by updating configuration files, dependencies, and constants. The changes ensure compatibility with the new version while maintaining support for previous versions.

Fixes #3236

## Description
* Updated `.github/ISSUE_TEMPLATE/bug_report.yml` to include `1.21.8` as a selectable server version in the bug report template.
* Updated the `build.gradle.kts` file in the `adapter-1_21_6` module to use the Paper dev bundle for version `1.21.8-R0.1`.
* Modified `PaperweightAdapter.java` to include a check for `DATA_VERSION_MC_1_21_8` and updated the error message to reflect support for 1.21.6, 1.21.7, and 1.21.8.
* Added a new constant `DATA_VERSION_MC_1_21_8` with the value `4440` in `Constants.java`.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
