### PR TITLE
chore: update publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,18 +30,18 @@ jobs:
           fi
       - name: Publish Release
         if: ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
       - name: Publish Snapshot
         if: ${{ runner.os == 'Linux' && env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: ./gradlew publishToSonatype
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PASSWORD }}
       - name: Publish core javadoc
         if: ${{ runner.os == 'Linux' && env.STATUS == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
         uses: cpina/github-action-push-to-another-repository@main

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ import java.time.format.DateTimeFormatter
 import xyz.jpenilla.runpaper.task.RunServer
 
 plugins {
-    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     id("xyz.jpenilla.run-paper") version "2.3.1"
 }
 
@@ -101,14 +100,5 @@ tasks {
         pluginJars(*project(":worldedit-bukkit").getTasksByName("shadowJar", false).map { (it as Jar).archiveFile }
                 .toTypedArray())
 
-    }
-}
-
-nexusPublishing {
-    this.repositories {
-        sonatype {
-            nexusUrl.set(URI.create("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(URI.create("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
-        }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(gradleApi())
     implementation("org.ajoberstar.grgit:grgit-gradle:5.3.2")
     implementation("com.gradleup.shadow:shadow-gradle-plugin:8.3.8")
+    implementation("com.vanniktech:gradle-maven-publish-plugin:0.34.0")
     implementation("io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:2.0.0-SNAPSHOT")
     constraints {
         val asmVersion = "[9.7,)"

--- a/buildSrc/src/main/kotlin/PlatformConfig.kt
+++ b/buildSrc/src/main/kotlin/PlatformConfig.kt
@@ -1,16 +1,15 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Project
 import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.provideDelegate
-import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.the
 import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.SigningExtension
@@ -20,7 +19,7 @@ fun Project.applyPlatformAndCoreConfiguration() {
     apply(plugin = "java")
     apply(plugin = "eclipse")
     apply(plugin = "idea")
-    apply(plugin = "maven-publish")
+    apply(plugin = "com.vanniktech.maven.publish")
     apply(plugin = "com.gradleup.shadow")
     apply(plugin = "signing")
 
@@ -60,63 +59,60 @@ fun Project.applyPlatformAndCoreConfiguration() {
         }
     }
 
-    configure<PublishingExtension> {
-        publications {
-            register<MavenPublication>("maven") {
-                from(javaComponent)
+    configure<MavenPublishBaseExtension> {
+        coordinates(
+            groupId = "com.fastasyncworldedit",
+            artifactId = "${rootProject.name}-${project.description}",
+            version = "$version"
+        )
+        pom {
+            name.set("${rootProject.name}-${project.description}" + " " + project.version)
+            description.set("Blazingly fast Minecraft world manipulation for artists, builders and everyone else.")
+            url.set("https://github.com/IntellectualSites/FastAsyncWorldEdit")
 
-                group = "com.fastasyncworldedit"
-                artifactId = "${rootProject.name}-${project.description}"
-                version = version
-
-                pom {
-                    name.set("${rootProject.name}-${project.description}" + " " + project.version)
-                    description.set("Blazingly fast Minecraft world manipulation for artists, builders and everyone else.")
-                    url.set("https://github.com/IntellectualSites/FastAsyncWorldEdit")
-
-                    licenses {
-                        license {
-                            name.set("GNU General Public License, Version 3.0")
-                            url.set("https://www.gnu.org/licenses/gpl-3.0.html")
-                            distribution.set("repo")
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id.set("NotMyFault")
-                            name.set("Alexander Brandes")
-                            email.set("contact(at)notmyfault.dev")
-                            organization.set("IntellectualSites")
-                            organizationUrl.set("https://github.com/IntellectualSites")
-                        }
-                        developer {
-                            id.set("SirYwell")
-                            name.set("Hannes Greule")
-                            organization.set("IntellectualSites")
-                            organizationUrl.set("https://github.com/IntellectualSites")
-                        }
-                        developer {
-                            id.set("dordsor21")
-                            name.set("dordsor21")
-                            organization.set("IntellectualSites")
-                            organizationUrl.set("https://github.com/IntellectualSites")
-                        }
-                    }
-
-                    scm {
-                        url.set("https://github.com/IntellectualSites/FastAsyncWorldEdit")
-                        connection.set("scm:git:https://github.com/IntellectualSites/FastAsyncWorldEdit.git")
-                        developerConnection.set("scm:git:git@github.com:IntellectualSites/FastAsyncWorldEdit.git")
-                        tag.set("${project.version}")
-                    }
-
-                    issueManagement{
-                        system.set("GitHub")
-                        url.set("https://github.com/IntellectualSites/FastAsyncWorldEdit/issues")
-                    }
+            licenses {
+                license {
+                    name.set("GNU General Public License, Version 3.0")
+                    url.set("https://www.gnu.org/licenses/gpl-3.0.html")
+                    distribution.set("repo")
                 }
             }
+
+            developers {
+                developer {
+                    id.set("NotMyFault")
+                    name.set("Alexander Brandes")
+                    email.set("contact(at)notmyfault.dev")
+                    organization.set("IntellectualSites")
+                    organizationUrl.set("https://github.com/IntellectualSites")
+                }
+                developer {
+                    id.set("SirYwell")
+                    name.set("Hannes Greule")
+                    organization.set("IntellectualSites")
+                    organizationUrl.set("https://github.com/IntellectualSites")
+                }
+                developer {
+                    id.set("dordsor21")
+                    name.set("dordsor21")
+                    organization.set("IntellectualSites")
+                    organizationUrl.set("https://github.com/IntellectualSites")
+                }
+            }
+
+            scm {
+                url.set("https://github.com/IntellectualSites/FastAsyncWorldEdit")
+                connection.set("scm:git:https://github.com/IntellectualSites/FastAsyncWorldEdit.git")
+                developerConnection.set("scm:git:git@github.com:IntellectualSites/FastAsyncWorldEdit.git")
+                tag.set("${project.version}")
+            }
+
+            issueManagement {
+                system.set("GitHub")
+                url.set("https://github.com/IntellectualSites/FastAsyncWorldEdit/issues")
+            }
+
+            publishToMavenCentral()
         }
     }
 


### PR DESCRIPTION
## Description
Follows PlotSquared and updates the Sonatype publishing.
The plugin is quite limited when facing custom setups - it requires the java or java-library plugin to work. That's not really working for the libs - but as the platform setup is basically just specifying a publication, cloning that behavior is not really hard. Only annoying thing is the log messages:
```
> Configure project :worldedit-libs:core
No compatible plugin found in project :worldedit-libs:core for publishing

> Configure project :worldedit-libs:bukkit
No compatible plugin found in project :worldedit-libs:bukkit for publishing

> Configure project :worldedit-libs:cli
No compatible plugin found in project :worldedit-libs:cli for publishing

> Configure project :worldedit-libs:core:ap
No compatible plugin found in project :worldedit-libs:core:ap for publishing
```

I couldn't really test much here. The tasks are running and I'm receiving my Unauthorized response. The generated POMs and module-JSONs are looking correct.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
