### PR TITLE
feat: start work on paper anti-x-ray support

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_20_R2/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_20_R2/PaperweightAdapter.java
@@ -863,7 +863,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
             //FAWE end
     );
 

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -309,7 +309,8 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
     );
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweWorldNativeAccess.java
@@ -252,7 +252,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                     return;
                 }
                 for (IntPair chunk : toSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };
@@ -268,7 +271,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                         sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.UPDATE)
                 ));
                 for (IntPair chunk : cachedChunksToSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -747,7 +747,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     if (!set
                             .getSideEffectSet()
                             .shouldApply(SideEffect.LIGHTING) || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
-                        this.send();
+                        this.send(set.getSideEffectSet().shouldApply(SideEffect.PAPER_ANTI_XRAY));
                     }
                     if (finalizer != null) {
                         finalizer.run();
@@ -788,9 +788,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     @Override
-    public void send() {
+    public void send(boolean obfuscateAntiXRay) {
         synchronized (sendLock) {
-            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ);
+            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ, obfuscateAntiXRay);
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
@@ -1,5 +1,7 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2;
 
+import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray;
+import com.destroystokyo.paper.antixray.ChunkPacketInfoAntiXray;
 import com.destroystokyo.paper.util.maplist.EntityList;
 import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
 import com.fastasyncworldedit.bukkit.adapter.DelegateSemaphore;
@@ -25,6 +27,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -105,6 +108,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final Field fieldBiomes;
 
     private static final Field fieldRemove;
+
+    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -211,6 +216,16 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContaienrGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContaienrGet);
+
+            if (PaperLib.isPaper()) {
+                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
+                        "chunkData",
+                        "d"
+                ));
+                fieldChunkData.setAccessible(true);
+            } else {
+                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
+            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -343,7 +358,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     @SuppressWarnings("deprecation")
-    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ) {
+    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ, boolean obfuscateAntiXRay) {
         ChunkHolder chunkHolder = getPlayerChunk(nmsWorld, chunkX, chunkZ);
         if (chunkHolder == null) {
             return;
@@ -378,8 +393,19 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getChunkSource().getLightEngine(),
                             null,
                             null,
-                            false // last false is to not bother with x-ray
+                            false // false so we can handle anti-X-Ray ourselves
                     );
+                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
+                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
+                        info.setNearbyChunks(
+                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
+                        );
+                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
+                        antiXray.obfuscate(info);
+                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -390,6 +416,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
+            } catch (IllegalAccessException e) {
+                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
@@ -1,7 +1,5 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2;
 
-import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray;
-import com.destroystokyo.paper.antixray.ChunkPacketInfoAntiXray;
 import com.destroystokyo.paper.util.maplist.EntityList;
 import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
 import com.fastasyncworldedit.bukkit.adapter.DelegateSemaphore;
@@ -27,7 +25,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
-import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -108,8 +105,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final Field fieldBiomes;
 
     private static final Field fieldRemove;
-
-    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -216,16 +211,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContaienrGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContaienrGet);
-
-            if (PaperLib.isPaper()) {
-                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
-                        "chunkData",
-                        "d"
-                ));
-                fieldChunkData.setAccessible(true);
-            } else {
-                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
-            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -393,19 +378,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getChunkSource().getLightEngine(),
                             null,
                             null,
-                            false // false so we can handle anti-X-Ray ourselves
+                            obfuscateAntiXRay
                     );
-                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
-                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
-                        info.setNearbyChunks(
-                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
-                        );
-                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
-                        antiXray.obfuscate(info);
-                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -416,8 +390,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
-            } catch (IllegalAccessException e) {
-                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightStarlightRelighter.java
@@ -68,7 +68,7 @@ public class PaperweightStarlightRelighter extends StarlightRelighter<ServerLeve
             int x = pos.x;
             int z = pos.z;
             if (delay) { // we still need to send the block changes of that chunk
-                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z);
+                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z, this.obfuscateAntiXRay);
             }
             serverLevel.getChunkSource().removeTicketAtLevel(FAWE_TICKET, pos, LIGHT_LEVEL, Unit.INSTANCE);
         }

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext.fawe/v1_20_R3/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext.fawe/v1_20_R3/PaperweightAdapter.java
@@ -862,7 +862,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
             //FAWE end
     );
 

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
@@ -308,7 +308,8 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
     );
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweWorldNativeAccess.java
@@ -252,7 +252,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                     return;
                 }
                 for (IntPair chunk : toSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };
@@ -268,7 +271,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                         sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.UPDATE)
                 ));
                 for (IntPair chunk : cachedChunksToSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
@@ -748,7 +748,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     if (!set
                             .getSideEffectSet()
                             .shouldApply(SideEffect.LIGHTING) || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
-                        this.send();
+                        this.send(set.getSideEffectSet().shouldApply(SideEffect.PAPER_ANTI_XRAY));
                     }
                     if (finalizer != null) {
                         finalizer.run();
@@ -789,9 +789,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     @Override
-    public void send() {
+    public void send(boolean obfuscateAntiXRay) {
         synchronized (sendLock) {
-            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ);
+            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ, obfuscateAntiXRay);
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
@@ -1,7 +1,5 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3;
 
-import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray;
-import com.destroystokyo.paper.antixray.ChunkPacketInfoAntiXray;
 import com.destroystokyo.paper.util.maplist.EntityList;
 import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
 import com.fastasyncworldedit.bukkit.adapter.DelegateSemaphore;
@@ -27,7 +25,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
-import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -108,8 +105,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;
-
-    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -216,16 +211,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContaienrGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContaienrGet);
-
-            if (PaperLib.isPaper()) {
-                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
-                        "chunkData",
-                        "d"
-                ));
-                fieldChunkData.setAccessible(true);
-            } else {
-                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
-            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -393,19 +378,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getChunkSource().getLightEngine(),
                             null,
                             null,
-                            false // false so we can handle anti-X-Ray ourselves
+                            obfuscateAntiXRay
                     );
-                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
-                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
-                        info.setNearbyChunks(
-                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
-                        );
-                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
-                        antiXray.obfuscate(info);
-                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -416,8 +390,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
-            } catch (IllegalAccessException e) {
-                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
@@ -1,5 +1,7 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3;
 
+import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray;
+import com.destroystokyo.paper.antixray.ChunkPacketInfoAntiXray;
 import com.destroystokyo.paper.util.maplist.EntityList;
 import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
 import com.fastasyncworldedit.bukkit.adapter.DelegateSemaphore;
@@ -25,6 +27,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -105,6 +108,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;
+
+    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -211,6 +216,16 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContaienrGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContaienrGet);
+
+            if (PaperLib.isPaper()) {
+                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
+                        "chunkData",
+                        "d"
+                ));
+                fieldChunkData.setAccessible(true);
+            } else {
+                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
+            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -343,7 +358,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     @SuppressWarnings("deprecation")
-    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ) {
+    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ, boolean obfuscateAntiXRay) {
         ChunkHolder chunkHolder = getPlayerChunk(nmsWorld, chunkX, chunkZ);
         if (chunkHolder == null) {
             return;
@@ -378,8 +393,19 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getChunkSource().getLightEngine(),
                             null,
                             null,
-                            false // last false is to not bother with x-ray
+                            false // false so we can handle anti-X-Ray ourselves
                     );
+                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
+                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
+                        info.setNearbyChunks(
+                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
+                        );
+                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
+                        antiXray.obfuscate(info);
+                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -390,6 +416,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
+            } catch (IllegalAccessException e) {
+                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightStarlightRelighter.java
@@ -68,7 +68,7 @@ public class PaperweightStarlightRelighter extends StarlightRelighter<ServerLeve
             int x = pos.x;
             int z = pos.z;
             if (delay) { // we still need to send the block changes of that chunk
-                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z);
+                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z, this.obfuscateAntiXRay);
             }
             serverLevel.getChunkSource().removeTicketAtLevel(FAWE_TICKET, pos, LIGHT_LEVEL, Unit.INSTANCE);
         }

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext.fawe/v1_20_R4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext.fawe/v1_20_R4/PaperweightAdapter.java
@@ -886,7 +886,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
             //FAWE end
     );
 

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
@@ -317,7 +317,8 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
     );
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweWorldNativeAccess.java
@@ -253,7 +253,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                     return;
                 }
                 for (IntPair chunk : toSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };
@@ -269,7 +272,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                         sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.UPDATE)
                 ));
                 for (IntPair chunk : cachedChunksToSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
@@ -749,7 +749,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     if (!set
                             .getSideEffectSet()
                             .shouldApply(SideEffect.LIGHTING) || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
-                        this.send();
+                        this.send(set.getSideEffectSet().shouldApply(SideEffect.PAPER_ANTI_XRAY));
                     }
                     if (finalizer != null) {
                         finalizer.run();
@@ -790,9 +790,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     @Override
-    public void send() {
+    public void send(boolean obfuscateAntiXRay) {
         synchronized (sendLock) {
-            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ);
+            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ, obfuscateAntiXRay);
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightPlatformAdapter.java
@@ -1,5 +1,7 @@
 package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R4;
 
+import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray;
+import com.destroystokyo.paper.antixray.ChunkPacketInfoAntiXray;
 import com.destroystokyo.paper.util.maplist.EntityList;
 import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
 import com.fastasyncworldedit.bukkit.adapter.DelegateSemaphore;
@@ -24,6 +26,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -104,6 +107,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;
+
+    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -210,6 +215,16 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContaienrGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContaienrGet);
+
+            if (PaperLib.isPaper()) {
+                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
+                        "chunkData",
+                        "d"
+                ));
+                fieldChunkData.setAccessible(true);
+            } else {
+                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
+            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -342,7 +357,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     @SuppressWarnings("deprecation")
-    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ) {
+    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ, boolean obfuscateAntiXRay) {
         ChunkHolder chunkHolder = getPlayerChunk(nmsWorld, chunkX, chunkZ);
         if (chunkHolder == null) {
             return;
@@ -372,8 +387,19 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getChunkSource().getLightEngine(),
                             null,
                             null,
-                            false // last false is to not bother with x-ray
+                            false // false so we can handle anti-X-Ray ourselves
                     );
+                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
+                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
+                        info.setNearbyChunks(
+                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
+                        );
+                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
+                        antiXray.obfuscate(info);
+                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -384,6 +410,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
+            } catch (IllegalAccessException e) {
+                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightStarlightRelighter.java
@@ -68,7 +68,7 @@ public class PaperweightStarlightRelighter extends StarlightRelighter<ServerLeve
             int x = pos.x;
             int z = pos.z;
             if (delay) { // we still need to send the block changes of that chunk
-                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z);
+                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z, this.obfuscateAntiXRay);
             }
             serverLevel.getChunkSource().removeTicketAtLevel(FAWE_TICKET, pos, LIGHT_LEVEL, Unit.INSTANCE);
         }

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_R1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_R1/PaperweightAdapter.java
@@ -887,7 +887,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
             //FAWE end
     );
 

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -317,7 +317,8 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
     );
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweWorldNativeAccess.java
@@ -253,7 +253,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                     return;
                 }
                 for (IntPair chunk : toSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };
@@ -269,7 +272,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                         sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.UPDATE)
                 ));
                 for (IntPair chunk : cachedChunksToSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
@@ -746,7 +746,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     if (!set
                             .getSideEffectSet()
                             .shouldApply(SideEffect.LIGHTING) || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
-                        this.send();
+                        this.send(set.getSideEffectSet().shouldApply(SideEffect.PAPER_ANTI_XRAY));
                     }
                     if (finalizer != null) {
                         finalizer.run();
@@ -824,9 +824,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     @Override
-    public void send() {
+    public void send(boolean obfuscateAntiXRay) {
         synchronized (sendLock) {
-            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ);
+            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ, obfuscateAntiXRay);
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
@@ -2,8 +2,6 @@ package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1;
 
 import ca.spottedleaf.moonrise.patches.chunk_system.level.entity.ChunkEntitySlices;
 import ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkHolderManager;
-import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray;
-import com.destroystokyo.paper.antixray.ChunkPacketInfoAntiXray;
 import com.fastasyncworldedit.bukkit.adapter.CachedBukkitAdapter;
 import com.fastasyncworldedit.bukkit.adapter.DelegateSemaphore;
 import com.fastasyncworldedit.bukkit.adapter.NMSAdapter;
@@ -26,7 +24,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
-import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -106,8 +103,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;
-
-    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -199,16 +194,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContaienrGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContaienrGet);
-
-            if (PaperLib.isPaper()) {
-                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
-                        "chunkData",
-                        "d"
-                ));
-                fieldChunkData.setAccessible(true);
-            } else {
-                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
-            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -371,19 +356,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getChunkSource().getLightEngine(),
                             null,
                             null,
-                            false // false so we can handle anti-X-Ray ourselves
+                            obfuscateAntiXRay
                     );
-                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
-                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
-                        info.setNearbyChunks(
-                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
-                        );
-                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
-                        antiXray.obfuscate(info);
-                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -394,8 +368,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
-            } catch (IllegalAccessException e) {
-                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightStarlightRelighter.java
@@ -71,7 +71,7 @@ public class PaperweightStarlightRelighter extends StarlightRelighter<ServerLeve
             int x = pos.x;
             int z = pos.z;
             if (delay) { // we still need to send the block changes of that chunk
-                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z);
+                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z, this.obfuscateAntiXRay);
             }
             serverLevel.getChunkSource().removeTicketAtLevel(FAWE_TICKET, pos, LIGHT_LEVEL, Unit.INSTANCE);
         }

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_4/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_4/PaperweightAdapter.java
@@ -843,7 +843,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
             //FAWE end
     );
 

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
@@ -303,7 +303,8 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
     );
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweWorldNativeAccess.java
@@ -254,7 +254,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                     return;
                 }
                 for (IntPair chunk : toSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };
@@ -270,7 +273,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                         sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.UPDATE)
                 ));
                 for (IntPair chunk : cachedChunksToSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
@@ -742,7 +742,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     if (!set
                             .getSideEffectSet()
                             .shouldApply(SideEffect.LIGHTING) || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
-                        this.send();
+                        this.send(set.getSideEffectSet().shouldApply(SideEffect.PAPER_ANTI_XRAY));
                     }
                     if (finalizer != null) {
                         finalizer.run();
@@ -783,9 +783,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     @Override
-    public void send() {
+    public void send(boolean obfuscateAntiXRay) {
         synchronized (sendLock) {
-            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ);
+            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ, obfuscateAntiXRay);
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightPlatformAdapter.java
@@ -20,10 +20,13 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.antixray.ChunkPacketBlockControllerAntiXray;
+import io.papermc.paper.antixray.ChunkPacketInfoAntiXray;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -102,6 +105,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;
+
+    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -186,6 +191,16 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContaienrGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContaienrGet);
+
+            if (PaperLib.isPaper()) {
+                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
+                        "chunkData",
+                        "d"
+                ));
+                fieldChunkData.setAccessible(true);
+            } else {
+                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
+            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -318,7 +333,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     @SuppressWarnings("deprecation")
-    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ) {
+    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ, boolean obfuscateAntiXRay) {
         ChunkHolder chunkHolder = getPlayerChunk(nmsWorld, chunkX, chunkZ);
         if (chunkHolder == null) {
             return;
@@ -348,8 +363,19 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getLightEngine(),
                             null,
                             null,
-                            false // last false is to not bother with x-ray
+                            false // false so we can handle anti-X-Ray ourselves
                     );
+                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
+                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
+                        info.setNearbyChunks(
+                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
+                        );
+                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
+                        antiXray.obfuscate(info);
+                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -360,6 +386,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+            } catch (IllegalAccessException e) {
+                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightStarlightRelighter.java
@@ -71,7 +71,7 @@ public class PaperweightStarlightRelighter extends StarlightRelighter<ServerLeve
             int x = pos.x;
             int z = pos.z;
             if (delay) { // we still need to send the block changes of that chunk
-                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z);
+                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z, this.obfuscateAntiXRay);
             }
             serverLevel.getChunkSource().removeTicketAtLevel(FAWE_TICKET, pos, LIGHT_LEVEL, Unit.INSTANCE);
         }

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_5/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_5/PaperweightAdapter.java
@@ -837,7 +837,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
         SideEffect.VALIDATION,
         SideEffect.ENTITY_AI,
         SideEffect.EVENTS,
-        SideEffect.UPDATE
+        SideEffect.UPDATE,
+        SideEffect.PAPER_ANTI_XRAY
     );
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightFaweAdapter.java
@@ -303,7 +303,8 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
     );
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightFaweWorldNativeAccess.java
@@ -254,7 +254,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                     return;
                 }
                 for (IntPair chunk : toSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };
@@ -270,7 +273,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                         sideEffectSet.shouldApply(SideEffect.UPDATE) ? 0 : 512
                 ));
                 for (IntPair chunk : cachedChunksToSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
@@ -742,7 +742,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     if (!set
                             .getSideEffectSet()
                             .shouldApply(SideEffect.LIGHTING) || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
-                        this.send();
+                        this.send(set.getSideEffectSet().shouldApply(SideEffect.PAPER_ANTI_XRAY));
                     }
                     if (finalizer != null) {
                         finalizer.run();
@@ -783,9 +783,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     @Override
-    public void send() {
+    public void send(boolean obfuscateAntiXRay) {
         synchronized (sendLock) {
-            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ);
+            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ, obfuscateAntiXRay);
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightPlatformAdapter.java
@@ -20,10 +20,13 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.antixray.ChunkPacketBlockControllerAntiXray;
+import io.papermc.paper.antixray.ChunkPacketInfoAntiXray;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -101,6 +104,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;
+
+    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -185,6 +190,16 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContainerGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContainerGet);
+
+            if (PaperLib.isPaper()) {
+                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
+                        "chunkData",
+                        "d"
+                ));
+                fieldChunkData.setAccessible(true);
+            } else {
+                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
+            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -317,7 +332,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     @SuppressWarnings("deprecation")
-    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ) {
+    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ, boolean obfuscateAntiXRay) {
         ChunkHolder chunkHolder = getPlayerChunk(nmsWorld, chunkX, chunkZ);
         if (chunkHolder == null) {
             return;
@@ -347,8 +362,19 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getLightEngine(),
                             null,
                             null,
-                            false // last false is to not bother with x-ray
+                            false // false so we can handle anti-X-Ray ourselves
                     );
+                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
+                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
+                        info.setNearbyChunks(
+                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
+                        );
+                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
+                        antiXray.obfuscate(info);
+                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -359,6 +385,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+            } catch (IllegalAccessException e) {
+                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightPlatformAdapter.java
@@ -20,13 +20,10 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
-import io.papermc.paper.antixray.ChunkPacketBlockControllerAntiXray;
-import io.papermc.paper.antixray.ChunkPacketInfoAntiXray;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
-import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ChunkHolder;
@@ -104,8 +101,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;
-
-    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -190,16 +185,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContainerGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContainerGet);
-
-            if (PaperLib.isPaper()) {
-                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
-                        "chunkData",
-                        "d"
-                ));
-                fieldChunkData.setAccessible(true);
-            } else {
-                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
-            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -362,19 +347,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getLightEngine(),
                             null,
                             null,
-                            false // false so we can handle anti-X-Ray ourselves
+                            obfuscateAntiXRay
                     );
-                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
-                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
-                        info.setNearbyChunks(
-                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
-                        );
-                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
-                        antiXray.obfuscate(info);
-                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -385,8 +359,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
-            } catch (IllegalAccessException e) {
-                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightStarlightRelighter.java
@@ -72,7 +72,7 @@ public class PaperweightStarlightRelighter extends StarlightRelighter<ServerLeve
             int x = pos.x;
             int z = pos.z;
             if (delay) { // we still need to send the block changes of that chunk
-                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z);
+                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z, this.obfuscateAntiXRay);
             }
             serverLevel.getChunkSource().removeTicketAtLevel(FAWE_TICKET, pos, LIGHT_LEVEL);
         }

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_6/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/ext/fawe/v1_21_6/PaperweightAdapter.java
@@ -866,7 +866,8 @@ public final class PaperweightAdapter implements BukkitImplAdapter<net.minecraft
         SideEffect.VALIDATION,
         SideEffect.ENTITY_AI,
         SideEffect.EVENTS,
-        SideEffect.UPDATE
+        SideEffect.UPDATE,
+        SideEffect.PAPER_ANTI_XRAY
     );
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightFaweAdapter.java
@@ -313,7 +313,8 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
             SideEffect.HISTORY,
             SideEffect.HEIGHTMAPS,
             SideEffect.LIGHTING,
-            SideEffect.NEIGHBORS
+            SideEffect.NEIGHBORS,
+            SideEffect.PAPER_ANTI_XRAY
     );
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightFaweWorldNativeAccess.java
@@ -259,7 +259,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                     return;
                 }
                 for (IntPair chunk : toSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };
@@ -275,7 +278,10 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
                         sideEffectSet.shouldApply(SideEffect.UPDATE) ? 0 : 512
                 ));
                 for (IntPair chunk : cachedChunksToSend) {
-                    PaperweightPlatformAdapter.sendChunk(chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z());
+                    PaperweightPlatformAdapter.sendChunk(
+                            chunk, getLevel().getWorld().getHandle(), chunk.x(), chunk.z(),
+                            sideEffectSet != null && sideEffectSet.shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                 }
             }
         };

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
@@ -750,7 +750,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     if (!set
                             .getSideEffectSet()
                             .shouldApply(SideEffect.LIGHTING) || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
-                        this.send();
+                        this.send(set.getSideEffectSet().shouldApply(SideEffect.PAPER_ANTI_XRAY));
                     }
                     if (finalizer != null) {
                         finalizer.run();
@@ -791,9 +791,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     @Override
-    public void send() {
+    public void send(boolean obfuscateAntiXRay) {
         synchronized (sendLock) {
-            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ);
+            PaperweightPlatformAdapter.sendChunk(new IntPair(chunkX, chunkZ), serverLevel, chunkX, chunkZ, obfuscateAntiXRay);
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightPlatformAdapter.java
@@ -20,11 +20,14 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.antixray.ChunkPacketBlockControllerAntiXray;
+import io.papermc.paper.antixray.ChunkPacketInfoAntiXray;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
@@ -107,6 +110,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;
+
+    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -191,6 +196,16 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContainerGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContainerGet);
+
+            if (PaperLib.isPaper()) {
+                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
+                        "chunkData",
+                        "d"
+                ));
+                fieldChunkData.setAccessible(true);
+            } else {
+                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
+            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -346,7 +361,7 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     @SuppressWarnings("deprecation")
-    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ) {
+    public static void sendChunk(IntPair pair, ServerLevel nmsWorld, int chunkX, int chunkZ, boolean obfuscateAntiXRay) {
         ChunkHolder chunkHolder = getPlayerChunk(nmsWorld, chunkX, chunkZ);
         if (chunkHolder == null) {
             return;
@@ -376,8 +391,19 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getLightEngine(),
                             null,
                             null,
-                            false // last false is to not bother with x-ray
+                            false // false so we can handle anti-X-Ray ourselves
                     );
+                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
+                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
+                        info.setNearbyChunks(
+                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
+                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
+                        );
+                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
+                        antiXray.obfuscate(info);
+                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -388,6 +414,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+            } catch (IllegalAccessException e) {
+                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightPlatformAdapter.java
@@ -20,14 +20,11 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
-import io.papermc.paper.antixray.ChunkPacketBlockControllerAntiXray;
-import io.papermc.paper.antixray.ChunkPacketInfoAntiXray;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
@@ -110,8 +107,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     private static final MethodHandle methodremoveTickingBlockEntity;
 
     private static final Field fieldRemove;
-
-    private static final Field fieldChunkData;
 
     private static final Logger LOGGER = LogManagerCompat.getLogger();
 
@@ -196,16 +191,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
             );
             palettedContainerGet.setAccessible(true);
             PALETTED_CONTAINER_GET = lookup.unreflect(palettedContainerGet);
-
-            if (PaperLib.isPaper()) {
-                fieldChunkData = ClientboundLevelChunkWithLightPacket.class.getDeclaredField(Refraction.pickName(
-                        "chunkData",
-                        "d"
-                ));
-                fieldChunkData.setAccessible(true);
-            } else {
-                fieldChunkData = null; // not needed on Spigot as we don't touch Anti-X-Ray there
-            }
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -391,19 +376,8 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                             nmsWorld.getLightEngine(),
                             null,
                             null,
-                            false // false so we can handle anti-X-Ray ourselves
+                            obfuscateAntiXRay
                     );
-                    if (obfuscateAntiXRay && nmsWorld.chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray antiXray) {
-                        ChunkPacketInfoAntiXray info = antiXray.getChunkPacketInfo(packet, levelChunk);
-                        info.setNearbyChunks(
-                                nmsWorld.getChunkIfLoaded(chunkX - 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX + 1, chunkZ),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ - 1),
-                                nmsWorld.getChunkIfLoaded(chunkX, chunkZ + 1)
-                        );
-                        fieldChunkData.set(packet, new ClientboundLevelChunkPacketData(levelChunk, info));
-                        antiXray.obfuscate(info);
-                    }
                 } else {
                     // deprecated on paper - deprecation suppressed
                     packet = new ClientboundLevelChunkWithLightPacket(
@@ -414,8 +388,6 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                     );
                 }
                 nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
-            } catch (IllegalAccessException e) {
-                LOGGER.error("Failed to reflectively apply anti x-ray data", e);
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightStarlightRelighter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightStarlightRelighter.java
@@ -72,7 +72,7 @@ public class PaperweightStarlightRelighter extends StarlightRelighter<ServerLeve
             int x = pos.x;
             int z = pos.z;
             if (delay) { // we still need to send the block changes of that chunk
-                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z);
+                PaperweightPlatformAdapter.sendChunk(new IntPair(x, z), serverLevel, x, z, this.obfuscateAntiXRay);
             }
             serverLevel.getChunkSource().removeTicketAtLevel(FAWE_TICKET, pos, LIGHT_LEVEL);
         }

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/AbstractBukkitGetBlocks.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/AbstractBukkitGetBlocks.java
@@ -52,7 +52,7 @@ public abstract class AbstractBukkitGetBlocks<ServerLevel, LevelChunk> extends C
         this.chunkPos = new IntPair(chunkX, chunkZ);
     }
 
-    protected abstract void send();
+    protected abstract void send(boolean obfuscateAntiXRay);
 
     protected abstract CompletableFuture<LevelChunk> ensureLoaded(ServerLevel serverLevel);
 

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSAdapter.java
@@ -95,11 +95,11 @@ public class NMSAdapter implements FAWEPlatformAdapterImpl {
     }
 
     @Override
-    public void sendChunk(IChunkGet chunk, int mask, boolean lighting) {
-        if (!(chunk instanceof AbstractBukkitGetBlocks)) {
+    public void sendChunk(IChunkGet chunk, int mask, boolean lighting, boolean obfuscateAntiXRay) {
+        if (!(chunk instanceof AbstractBukkitGetBlocks<?, ?> abstractBukkitGetBlocks)) {
             throw new IllegalArgumentException("(IChunkGet) chunk not of type BukkitGetBlocks");
         }
-        ((AbstractBukkitGetBlocks) chunk).send();
+        abstractBukkitGetBlocks.send(obfuscateAntiXRay);
     }
 
     /**

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/StarlightRelighter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/StarlightRelighter.java
@@ -6,6 +6,8 @@ import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
+import com.sk89q.worldedit.util.SideEffect;
+import io.papermc.lib.PaperLib;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArraySet;
 import it.unimi.dsi.fastutil.longs.LongIterator;
@@ -41,10 +43,12 @@ public abstract class StarlightRelighter<SERVER_LEVEL, CHUNK_POS> implements Rel
     private final ReentrantLock areaLock = new ReentrantLock();
     private final NMSRelighter delegate;
     protected final SERVER_LEVEL serverLevel;
+    protected final boolean obfuscateAntiXRay;
 
     protected StarlightRelighter(SERVER_LEVEL serverLevel, IQueueExtent<?> queue) {
         this.serverLevel = serverLevel;
         this.delegate = new NMSRelighter(queue);
+        this.obfuscateAntiXRay = PaperLib.isPaper() && queue.getSideEffectSet().shouldApply(SideEffect.PAPER_ANTI_XRAY);
     }
 
     protected Set<CHUNK_POS> convertChunkKeysToChunkPos(LongSet chunks) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/FAWEPlatformAdapterImpl.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/FAWEPlatformAdapterImpl.java
@@ -1,9 +1,11 @@
 package com.fastasyncworldedit.core;
 
 import com.fastasyncworldedit.core.queue.IChunkGet;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public interface FAWEPlatformAdapterImpl {
 
-    void sendChunk(IChunkGet chunk, int mask, boolean lighting);
+    void sendChunk(IChunkGet chunk, int mask, boolean lighting, boolean obfuscateAntiXRay);
 
 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/lighting/NMSRelighter.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/processor/lighting/NMSRelighter.java
@@ -14,6 +14,7 @@ import com.sk89q.worldedit.registry.state.DirectionalProperty;
 import com.sk89q.worldedit.registry.state.EnumProperty;
 import com.sk89q.worldedit.registry.state.Property;
 import com.sk89q.worldedit.util.Direction;
+import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
@@ -931,7 +932,10 @@ public class NMSRelighter implements Relighter {
                     ChunkHolder<?> chunk = (ChunkHolder<?>) queue.getOrCreateChunk(x, z);
                     chunk.setBitMask(bitMask);
                     chunk.flushLightToGet();
-                    Fawe.platform().getPlatformAdapter().sendChunk(chunk.getOrCreateGet(), bitMask, true);
+                    Fawe.platform().getPlatformAdapter().sendChunk(
+                            chunk.getOrCreateGet(), bitMask, true,
+                            queue.getSideEffectSet().shouldApply(SideEffect.PAPER_ANTI_XRAY)
+                    );
                     iter.remove();
                 }
                 finished.set(true);

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/SideEffect.java
@@ -24,16 +24,16 @@ import com.fastasyncworldedit.core.configuration.Settings;
 import java.util.Locale;
 
 public enum SideEffect {
-    //FAWE start - adjust defaults, add history and heightmaps
+    //FAWE start - adjust defaults, add history, heightmaps and anti-x-ray
     HISTORY(State.ON, true),
     HEIGHTMAPS(State.ON, true),
     LIGHTING(Settings.settings().LIGHTING.MODE == 0 ? State.OFF : State.ON, true),
     NEIGHBORS(State.OFF, true),
     UPDATE(State.OFF, true),
-    //FAWE end
     VALIDATION(State.OFF, true),
     ENTITY_AI(State.OFF, true),
     EVENTS(State.OFF, true),
+    PAPER_ANTI_XRAY(State.OFF, true),
     /**
      * Internal use only.
      */

--- a/worldedit-core/src/main/resources/lang/strings.json
+++ b/worldedit-core/src/main/resources/lang/strings.json
@@ -649,6 +649,8 @@
   "worldedit.sideeffect.entity_ai.description": "Updates Entity AI paths for the block changes",
   "worldedit.sideeffect.events": "Mod/Plugin Events",
   "worldedit.sideeffect.events.description": "Tells other mods/plugins about these changes when applicable",
+  "worldedit.sideeffect.paper_anti_xray": "Anti-X-Ray Obfuscation",
+  "worldedit.sideeffect.paper_anti_xray.description": "Obfuscates block changes with Papers anti-x-ray system (if enabled)",
   "worldedit.sideeffect.state.on": "On",
   "worldedit.sideeffect.state.delayed": "Delayed",
   "worldedit.sideeffect.state.off": "Off",


### PR DESCRIPTION
## Description
Initial work on supporting papers anti x-ray system via SideEffects.
Doesn't work yet, but the actual bitstorage is overriden for affected chunks. No idea why yet. And surrounding chunks are updated (new chunk packets are sent) - no idea why, but that shouldn't happen (though it's just a packet, so not too bad lol)

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
