### PR TITLE
Avoid copying already copied arrays in history

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -167,16 +167,14 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
                 continue;
             }
             // add each block and tile
-            char[] blocksGet;
-            char[] tmp = get.load(layer);
-            if (tmp == null) {
+            // assume "get" is a copy and doesn't get modified further
+            char[] blocksGet = get.load(layer);
+            if (blocksGet == null) {
                 blocksGet = FaweCache.INSTANCE.EMPTY_CHAR_4096;
-            } else {
-                System.arraycopy(tmp, 0, (blocksGet = new char[4096]), 0, 4096);
             }
-            char[] blocksSet;
+            // assume "set" is a copy and doesn't get modified further
             // loadIfPresent shouldn't be null if set.hasSection(layer) is true
-            System.arraycopy(Objects.requireNonNull(set.loadIfPresent(layer)), 0, (blocksSet = new char[4096]), 0, 4096);
+            char[] blocksSet = Objects.requireNonNull(set.loadIfPresent(layer));
 
             // Account for negative layers
             int by = layer << 4;


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

When writing changes, we already have copies of the get and set data. That means we don't need (and shouldn't) copy it again. This reduces memory allocations in the history by around 90%.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
