### PR TITLE
Use RandomPattern instead of RandomStatePattern

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomStatePatternParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/parser/pattern/RandomStatePatternParser.java
@@ -24,9 +24,10 @@ import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.input.ParserContext;
 import com.sk89q.worldedit.function.pattern.Pattern;
-import com.sk89q.worldedit.function.pattern.RandomStatePattern;
+import com.sk89q.worldedit.function.pattern.RandomPattern;
 import com.sk89q.worldedit.internal.registry.InputParser;
 import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.FuzzyBlockState;
 
 import java.util.Collections;
@@ -66,8 +67,15 @@ public class RandomStatePatternParser extends InputParser<Pattern> implements Al
         if (block.getStates().size() == block.getBlockType().getPropertyMap().size()) {
             // they requested random with *, but didn't leave any states empty - simplify
             return block;
-        } else if (block.toImmutableState() instanceof FuzzyBlockState) {
-            return new RandomStatePattern((FuzzyBlockState) block.toImmutableState());
+            // FAWE start - use RandomPattern instead of RandomStatePattern
+        } else if (block.toImmutableState() instanceof FuzzyBlockState fbs) {
+            RandomPattern randomPattern = new RandomPattern();
+            fbs.getBlockType().getAllStates().stream()
+                    .filter(fbs::equalsFuzzy)
+                    .map(BlockState::toBaseBlock)
+                    .forEach(bb -> randomPattern.add(bb, 1.0));
+            return randomPattern;
+            // FAWE end
         } else {
             return null; // only should happen if parseLogic changes
         }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

This allows  using `*<blockstate>` to be used directly in other patterns that require a `RandomPattern` input, e.g., noise patterns. Example `//set #simplex[5][*snow]`:
<img width="1763" height="885" src="https://github.com/user-attachments/assets/a11a2737-4cbe-4be5-87e8-1f55d3809a9a" />

RandomStatePattern is basically just a cut-down variant of RandomPattern, there really isn't much reason to use it at all imo.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
