### PR TITLE
chore/fix: use mirror repository for paper dev-bundles

### DIFF
--- a/buildSrc/src/main/kotlin/CommonConfig.kt
+++ b/buildSrc/src/main/kotlin/CommonConfig.kt
@@ -14,6 +14,9 @@ fun Project.applyCommonConfiguration() {
         maven {
             name = "EngineHub"
             url = uri("https://maven.enginehub.org/repo/")
+            content {
+                excludeModule("io.papermc.paper", "dev-bundle")
+            }
         }
         maven {
             name = "OSS Sonatype Snapshots"
@@ -22,6 +25,13 @@ fun Project.applyCommonConfiguration() {
         maven {
             name = "Athion"
             url = uri("https://ci.athion.net/plugin/repository/tools/")
+        }
+        maven {
+            name = "IntellectualSites"
+            url = uri("https://repo.intellectualsites.dev/repository/paper-dev-bundles/")
+            content {
+                includeModule("io.papermc.paper", "dev-bundle")
+            }
         }
     }
 

--- a/worldedit-bukkit/adapters/adapter-1_21_6/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/build.gradle.kts
@@ -12,6 +12,6 @@ repositories {
 
 dependencies {
     // https://repo.papermc.io/service/rest/repository/browse/maven-public/io/papermc/paper/dev-bundle/
-    the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21.8-R0.1-20250720.221224-10")
+    the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21.8-R0.1-20250829.204528-51")
     compileOnly(libs.paperlib)
 }


### PR DESCRIPTION
## Overview
Uses a custom nexus repository, which caches the dev-bundles. Should help with the occasional CI errors. The repository should only be able to serve dev-bundles. 
Unused bundles (not used within the last 28 days) are deleted from the mirror. Otherwise, those are cached indefinitely. Listing for bundles is not possible - that's why renovate still needs to test against paper repo

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
