### PR TITLE
Remove unnecessary logger from RollbackOptimizedHistory

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/RollbackOptimizedHistory.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/RollbackOptimizedHistory.java
@@ -16,8 +16,6 @@ import java.util.UUID;
 
 public class RollbackOptimizedHistory extends DiskStorageHistory {
 
-    private static final Logger LOGGER = LogManagerCompat.getLogger();
-
     private long time;
 
     private int minX;
@@ -58,7 +56,6 @@ public class RollbackOptimizedHistory extends DiskStorageHistory {
         this.blockSize = (int) size;
         this.command = command;
         this.closed = true;
-        LOGGER.info("Size: {}", size);
     }
 
     public long getTime() {


### PR DESCRIPTION
## Overview
Fix Unwanted console logging when accessing RollbackOptimizedHistory

Fixes #3321

## Description
Removed the logging call in one of the RollbackOptimizedHistory constructors, removed the now unused logger.

### Submitter Checklist
- [v] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [v] Ensure that the pull request title represents the desired changelog entry.
- [v] New public fields and methods are annotated with `@since TODO`.
- [v] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
