### PR TITLE
Set paperweight-userdev to version 2.0.0-beta.18

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation(gradleApi())
     implementation("org.ajoberstar.grgit:grgit-gradle:5.3.3")
     implementation("com.gradleup.shadow:shadow-gradle-plugin:8.3.9")
-    implementation("io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:2.0.0-SNAPSHOT")
+    implementation("io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:2.0.0-beta.18")
     constraints {
         val asmVersion = "[9.7,)"
         implementation("org.ow2.asm:asm:$asmVersion") {


### PR DESCRIPTION
## Overview
FAWE cannot compile with a clean gradle cache as the latest snapshot of paperweight-userdev is not compatible with gradle v8. 

## Description
Sets paperweight-userdev version in buildSrc to the fixed beta.18 rather than SNAPSHOT.

### Submitter Checklist
- [ ✓] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [ ✓] Ensure that the pull request title represents the desired changelog entry.
- [ -] New public fields and methods are annotated with `@since TODO`.
- [✓ ] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
