### PR TITLE
fix: don't drop lz4 during minimization

### DIFF
--- a/build-logic/src/main/kotlin/buildlogic.platform.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.platform.gradle.kts
@@ -27,8 +27,9 @@ tasks.named<ShadowJar>("shadowJar") {
     exclude("LICENSE*")
     exclude("META-INF/maven/**")
     minimize {
-        // jchronic uses reflection to load things, so we need to exclude it from minimizing
+        // jchronic + lz4-java uses reflection to load things, so we need to exclude it from minimizing
         exclude(dependency(jchronic))
+        exclude(dependency(stringyLibs.getLibrary("lz4Java").get()))
     }
 }
 val javaComponent = components["java"] as AdhocComponentWithVariants

--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -163,8 +163,9 @@ tasks.register<ShadowJar>("reobfShadowJar") {
         exclude(dependency(libs.jsr305))
     }
     minimize {
-        // jchronic uses reflection to load things, so we need to exclude it from minimizing
+        // jchronic + lz4-java uses reflection to load things, so we need to exclude it from minimizing
         exclude(dependency(libs.jchronic))
+        exclude(dependency(libs.lz4Java))
     }
 
     // as is done by shadow for the default shadowJar


### PR DESCRIPTION
## Overview
Exceptions have been shared in the discord. Upon further investigation, the lz4 classes are not included in the JAR anymore.

> java.lang.ClassNotFoundException: net.jpountz.lz4.LZ4JavaSafeCompressor

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
