### PR TITLE
Fix WallMakeMask for regions not overriding contains(x, z)

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/WallMakeMask.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/WallMakeMask.java
@@ -15,11 +15,12 @@ public class WallMakeMask implements Mask {
     @Override
     public boolean test(BlockVector3 position) {
         int x = position.x();
+        int y = position.y();
         int z = position.z();
-        return !region.contains(x, z + 1) || !region.contains(x, z - 1) || !region.contains(x + 1, z) || !region.contains(
-                x - 1,
-                z
-        );
+        return !region.contains(x, y, z + 1) ||
+                !region.contains(x, y, z - 1) ||
+                !region.contains(x + 1, y, z) ||
+                !region.contains(x - 1, y, z);
     }
 
     @Override


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

For some region implementations, precise `contains(x, z)` implementations would require heavy computation, far more heavy than just also passing the Y coordinate. `FuzzyRegion` is a good example for that.
For such regions, `//walls` was broken before. This simple change addresses this problem.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
