### PR TITLE
Fix crash due to race condition when calling markUnsaved

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -590,7 +590,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     set.getMaxSectionPosition()
             );
 
-            Runnable[] syncTasks = null;
+            List<Runnable> syncTasks = new ArrayList<>();
 
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
@@ -599,24 +599,17 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
-
-                syncTasks = new Runnable[4];
-
-                syncTasks[3] = () -> {
+                syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
                     }
-                };
+                });
             }
 
             Set<UUID> entityRemoves = set.getEntityRemoves();
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[3];
-                }
-
-                syncTasks[2] = () -> {
+                syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
                     final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
@@ -642,16 +635,12 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     // Only save entities that were actually removed to history
                     set.getEntityRemoves().clear();
                     set.getEntityRemoves().addAll(entitiesRemoved);
-                };
+                });
             }
 
             Collection<FaweCompoundTag> entities = set.entities();
             if (entities != null && !entities.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[2];
-                }
-
-                syncTasks[1] = () -> {
+                syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
                         final FaweCompoundTag nativeTag = iterator.next();
@@ -696,17 +685,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             // set tiles
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[1];
-                }
-
-                syncTasks[0] = () -> {
+                syncTasks.add(() -> {
                     for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
                         final FaweCompoundTag nativeTag = entry.getValue();
                         final BlockVector3 blockHash = entry.getKey();
@@ -730,7 +715,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             Runnable callback;
@@ -738,11 +723,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 callback = null;
             } else {
                 int finalMask = bitMask != 0 ? bitMask : lightUpdate ? set.getBitMask() : 0;
-                callback = () -> {
+                syncTasks.add(() -> {
                     // Set Modified
-                    nmsChunk.setLightCorrect(true); // Set Modified
+                    nmsChunk.setLightCorrect(true);
                     nmsChunk.mustNotSave = false;
                     nmsChunk.setUnsaved(true);
+                });
+                callback = () -> {
                     // send to player
                     if (!set
                             .getSideEffectSet()

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
@@ -590,7 +590,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     set.getMaxSectionPosition()
             );
 
-            Runnable[] syncTasks = null;
+            List<Runnable> syncTasks = new ArrayList<>();
 
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
@@ -599,24 +599,17 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
-
-                syncTasks = new Runnable[4];
-
-                syncTasks[3] = () -> {
+                syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
                     }
-                };
+                });
             }
 
             Set<UUID> entityRemoves = set.getEntityRemoves();
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[3];
-                }
-
-                syncTasks[2] = () -> {
+                syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
                     final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
@@ -642,16 +635,12 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     // Only save entities that were actually removed to history
                     set.getEntityRemoves().clear();
                     set.getEntityRemoves().addAll(entitiesRemoved);
-                };
+                });
             }
 
             Collection<FaweCompoundTag> entities = set.entities();
             if (entities != null && !entities.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[2];
-                }
-
-                syncTasks[1] = () -> {
+                syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
                         final FaweCompoundTag nativeTag = iterator.next();
@@ -697,17 +686,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             // set tiles
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[1];
-                }
-
-                syncTasks[0] = () -> {
+                syncTasks.add(() -> {
                     for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
                         final FaweCompoundTag nativeTag = entry.getValue();
                         final BlockVector3 blockHash = entry.getKey();
@@ -731,7 +716,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             Runnable callback;
@@ -739,11 +724,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 callback = null;
             } else {
                 int finalMask = bitMask != 0 ? bitMask : lightUpdate ? set.getBitMask() : 0;
-                callback = () -> {
+                syncTasks.add(() -> {
                     // Set Modified
-                    nmsChunk.setLightCorrect(true); // Set Modified
+                    nmsChunk.setLightCorrect(true);
                     nmsChunk.mustNotSave = false;
                     nmsChunk.setUnsaved(true);
+                });
+                callback = () -> {
                     // send to player
                     if (!set
                             .getSideEffectSet()

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
@@ -591,7 +591,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     set.getMaxSectionPosition()
             );
 
-            Runnable[] syncTasks = null;
+            List<Runnable> syncTasks = new ArrayList<>();
 
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
@@ -600,24 +600,17 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
-
-                syncTasks = new Runnable[4];
-
-                syncTasks[3] = () -> {
+                syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
                     }
-                };
+                });
             }
 
             Set<UUID> entityRemoves = set.getEntityRemoves();
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[3];
-                }
-
-                syncTasks[2] = () -> {
+                syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
                     final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
@@ -643,16 +636,12 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     // Only save entities that were actually removed to history
                     set.getEntityRemoves().clear();
                     set.getEntityRemoves().addAll(entitiesRemoved);
-                };
+                });
             }
 
             Collection<FaweCompoundTag> entities = set.entities();
             if (entities != null && !entities.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[2];
-                }
-
-                syncTasks[1] = () -> {
+                syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
                         final FaweCompoundTag nativeTag = iterator.next();
@@ -698,17 +687,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             // set tiles
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[1];
-                }
-
-                syncTasks[0] = () -> {
+                syncTasks.add(() -> {
                     for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
                         final FaweCompoundTag nativeTag = entry.getValue();
                         final BlockVector3 blockHash = entry.getKey();
@@ -732,7 +717,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             Runnable callback;
@@ -740,11 +725,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 callback = null;
             } else {
                 int finalMask = bitMask != 0 ? bitMask : lightUpdate ? set.getBitMask() : 0;
-                callback = () -> {
+                syncTasks.add(() -> {
                     // Set Modified
-                    nmsChunk.setLightCorrect(true); // Set Modified
+                    nmsChunk.setLightCorrect(true);
                     nmsChunk.mustNotSave = false;
                     nmsChunk.setUnsaved(true);
+                });
+                callback = () -> {
                     // send to player
                     if (!set
                             .getSideEffectSet()

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
@@ -585,7 +585,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     set.getMaxSectionPosition()
             );
 
-            Runnable[] syncTasks = null;
+            List<Runnable> syncTasks = new ArrayList<>();
 
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
@@ -594,24 +594,17 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
-
-                syncTasks = new Runnable[4];
-
-                syncTasks[3] = () -> {
+                syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
                     }
-                };
+                });
             }
 
             Set<UUID> entityRemoves = set.getEntityRemoves();
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[3];
-                }
-
-                syncTasks[2] = () -> {
+                syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
                     final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
@@ -637,16 +630,12 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     // Only save entities that were actually removed to history
                     set.getEntityRemoves().clear();
                     set.getEntityRemoves().addAll(entitiesRemoved);
-                };
+                });
             }
 
             Collection<FaweCompoundTag> entities = set.entities();
             if (entities != null && !entities.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[2];
-                }
-
-                syncTasks[1] = () -> {
+                syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
                         final FaweCompoundTag nativeTag = iterator.next();
@@ -691,17 +680,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             // set tiles
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[1];
-                }
-
-                syncTasks[0] = () -> {
+                syncTasks.add(() -> {
                     for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
                         final FaweCompoundTag nativeTag = entry.getValue();
                         final BlockVector3 blockHash = entry.getKey();
@@ -725,7 +710,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             Runnable callback;
@@ -733,11 +718,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 callback = null;
             } else {
                 int finalMask = bitMask != 0 ? bitMask : lightUpdate ? set.getBitMask() : 0;
-                callback = () -> {
+                syncTasks.add(() -> {
                     // Set Modified
-                    nmsChunk.setLightCorrect(true); // Set Modified
+                    nmsChunk.setLightCorrect(true);
                     nmsChunk.mustNotSave = false;
                     nmsChunk.markUnsaved();
+                });
+                callback = () -> {
                     // send to player
                     if (!set
                             .getSideEffectSet()

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
@@ -585,7 +585,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     set.getMaxSectionPosition()
             );
 
-            Runnable[] syncTasks = null;
+            List<Runnable> syncTasks = new ArrayList<>();
 
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
@@ -594,24 +594,17 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
-
-                syncTasks = new Runnable[4];
-
-                syncTasks[3] = () -> {
+                syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
                     }
-                };
+                });
             }
 
             Set<UUID> entityRemoves = set.getEntityRemoves();
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[3];
-                }
-
-                syncTasks[2] = () -> {
+                syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
                     final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
@@ -637,16 +630,12 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     // Only save entities that were actually removed to history
                     set.getEntityRemoves().clear();
                     set.getEntityRemoves().addAll(entitiesRemoved);
-                };
+                });
             }
 
             Collection<FaweCompoundTag> entities = set.entities();
             if (entities != null && !entities.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[2];
-                }
-
-                syncTasks[1] = () -> {
+                syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
                         final FaweCompoundTag nativeTag = iterator.next();
@@ -691,17 +680,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             // set tiles
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[1];
-                }
-
-                syncTasks[0] = () -> {
+                syncTasks.add(() -> {
                     for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
                         final FaweCompoundTag nativeTag = entry.getValue();
                         final BlockVector3 blockHash = entry.getKey();
@@ -725,7 +710,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             Runnable callback;
@@ -733,11 +718,12 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 callback = null;
             } else {
                 int finalMask = bitMask != 0 ? bitMask : lightUpdate ? set.getBitMask() : 0;
-                callback = () -> {
+                syncTasks.add(() -> {
                     // Set Modified
-                    nmsChunk.setLightCorrect(true); // Set Modified
+                    nmsChunk.setLightCorrect(true);
                     nmsChunk.mustNotSave = false;
-                    nmsChunk.markUnsaved();
+                });
+                callback = () -> {
                     // send to player
                     if (!set
                             .getSideEffectSet()

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
@@ -589,7 +589,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     set.getMaxSectionPosition()
             );
 
-            Runnable[] syncTasks = null;
+            List<Runnable> syncTasks = new ArrayList<>();
 
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
@@ -598,24 +598,17 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
-
-                syncTasks = new Runnable[4];
-
-                syncTasks[3] = () -> {
+                syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
                     }
-                };
+                });
             }
 
             Set<UUID> entityRemoves = set.getEntityRemoves();
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[3];
-                }
-
-                syncTasks[2] = () -> {
+                syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
                     final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
@@ -641,16 +634,12 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     // Only save entities that were actually removed to history
                     set.getEntityRemoves().clear();
                     set.getEntityRemoves().addAll(entitiesRemoved);
-                };
+                });
             }
 
             Collection<FaweCompoundTag> entities = set.entities();
             if (entities != null && !entities.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[2];
-                }
-
-                syncTasks[1] = () -> {
+                syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
                         final FaweCompoundTag nativeTag = iterator.next();
@@ -697,17 +686,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             // set tiles
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[1];
-                }
-
-                syncTasks[0] = () -> {
+                syncTasks.add(() -> {
                     for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
                         final FaweCompoundTag nativeTag = entry.getValue();
                         final BlockVector3 blockHash = entry.getKey();
@@ -733,7 +718,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             Runnable callback;
@@ -741,11 +726,12 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 callback = null;
             } else {
                 int finalMask = bitMask != 0 ? bitMask : lightUpdate ? set.getBitMask() : 0;
-                callback = () -> {
+                syncTasks.add(() -> {
                     // Set Modified
-                    nmsChunk.setLightCorrect(true); // Set Modified
+                    nmsChunk.setLightCorrect(true);
                     nmsChunk.mustNotSave = false;
-                    nmsChunk.markUnsaved();
+                });
+                callback = () -> {
                     // send to player
                     if (!set
                             .getSideEffectSet()

--- a/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightGetBlocks.java
@@ -587,7 +587,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     set.getMaxSectionPosition()
             );
 
-            Runnable[] syncTasks = null;
+            List<Runnable> syncTasks = new ArrayList<>();
 
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
@@ -597,23 +597,18 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
 
-                syncTasks = new Runnable[4];
-
-                syncTasks[3] = () -> {
+                syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
                     }
-                };
+                });
             }
 
             Set<UUID> entityRemoves = set.getEntityRemoves();
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[3];
-                }
 
-                syncTasks[2] = () -> {
+                syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
                     final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
@@ -639,16 +634,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     // Only save entities that were actually removed to history
                     set.getEntityRemoves().clear();
                     set.getEntityRemoves().addAll(entitiesRemoved);
-                };
+                });
             }
 
             Collection<FaweCompoundTag> entities = set.entities();
             if (entities != null && !entities.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[2];
-                }
 
-                syncTasks[1] = () -> {
+                syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
                         final FaweCompoundTag nativeTag = iterator.next();
@@ -695,17 +687,14 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             // set tiles
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[1];
-                }
 
-                syncTasks[0] = () -> {
+                syncTasks.add(() -> {
                     for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
                         final FaweCompoundTag nativeTag = entry.getValue();
                         final BlockVector3 blockHash = entry.getKey();
@@ -731,7 +720,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             }
                         }
                     }
-                };
+                });
             }
 
             Runnable callback;
@@ -739,11 +728,12 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 callback = null;
             } else {
                 int finalMask = bitMask != 0 ? bitMask : lightUpdate ? set.getBitMask() : 0;
-                callback = () -> {
+                syncTasks.add(() -> {
                     // Set Modified
-                    nmsChunk.setLightCorrect(true); // Set Modified
+                    nmsChunk.setLightCorrect(true);
                     nmsChunk.mustNotSave = false;
-                    nmsChunk.markUnsaved();
+                });
+                callback = () -> {
                     // send to player
                     if (!set
                             .getSideEffectSet()

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/AbstractBukkitGetBlocks.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/AbstractBukkitGetBlocks.java
@@ -17,6 +17,7 @@ import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -141,12 +142,12 @@ public abstract class AbstractBukkitGetBlocks<ServerLevel, LevelChunk> extends C
     }
 
     protected <T extends Future<T>> T handleCallFinalizer(
-            final Runnable[] syncTasks,
+            final List<Runnable> syncTasks,
             final Runnable callback,
             final Runnable finalizer
     ) throws
             Exception {
-        if (syncTasks != null) {
+        if (!syncTasks.isEmpty()) {
             QueueHandler queueHandler = Fawe.instance().getQueueHandler();
 
             // Chain the sync tasks and the callback


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3350

## Description
<!-- Please describe what this pull request does. -->

`markUnsaved` modifies a collection on Vanilla/Spigot. This can lead to crashes when run off the main thread. Let's just run it where it has to run instead.

Also `setLightCorrect` calls `markUnsaved`, so we don't need to do that again.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
