### PR TITLE
fix FastSchematicReaderV3 throwing / by 0 for 1-wide/long schematics

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/io/FastSchematicReaderV3.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/io/FastSchematicReaderV3.java
@@ -175,7 +175,7 @@ public class FastSchematicReaderV3 implements ClipboardReader {
                 default -> this.nbtInputStream.readTagPayloadLazy(type, 0);
             }
             if (clipboard == null && this.areDimensionsAvailable()) {
-                clipboard = createOutput.apply(this.dimensions);
+                clipboard = createOutput.apply(this.dimensions.toImmutable());
             }
         }
 


### PR DESCRIPTION
## Overview
Fixes [#3359](https://github.com/IntellectualSites/FastAsyncWorldEdit/issues/3359)

## Description
Ensure FastSchematicReaderV3 passes an immutable dimensions vector to the clipboard factory so the default pipeline can’t mutate the reader’s state and zero out `1xNx1` schematics, preventing a / by 0 when applying biome data.

### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
