### PR TITLE
Folia Support

### DIFF
--- a/build-logic/src/main/kotlin/buildlogic.common.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.common.gradle.kts
@@ -11,9 +11,12 @@ configurations.all {
     }
 }
 
-plugins.withId("java") {
-    the<JavaPluginExtension>().toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+allprojects {
+    plugins.withId("java") {
+        the<JavaPluginExtension>().toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+            vendor.set(JvmVendorSpec.ADOPTIUM)
+        }
     }
 }
 

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweAdapter.java
@@ -10,6 +10,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
@@ -21,6 +22,7 @@ import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R2.regen.PaperweightRegen;
@@ -54,6 +56,7 @@ import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
@@ -127,6 +130,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -350,28 +355,45 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public BaseEntity getEntity(org.bukkit.entity.Entity entity) {
         Preconditions.checkNotNull(entity);
 
-        CraftEntity craftEntity = ((CraftEntity) entity);
-        Entity mcEntity = craftEntity.getHandle();
+        String id = entity.getType().getKey().toString();
+        EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
+        Supplier<LinCompoundTag> saveTag = () -> {
+            net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
+            Entity mcEntity;
 
-        String id = getEntityId(mcEntity);
-
-        if (id != null) {
-            EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
-            Supplier<LinCompoundTag> saveTag = () -> {
-                final net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
-                if (!readEntityIntoTag(mcEntity, minecraftTag)) {
+            if (FoliaUtil.isFoliaServer()) {
+                CompletableFuture<Entity> handleFuture = new CompletableFuture<>();
+                entity.getScheduler().run(
+                        WorldEditPlugin.getInstance(),
+                        (ScheduledTask task) -> {
+                            try {
+                                handleFuture.complete(((CraftEntity) entity).getHandle());
+                            } catch (Throwable t) {
+                                handleFuture.completeExceptionally(t);
+                            }
+                        },
+                        () -> handleFuture.completeExceptionally(new CancellationException("Entity scheduler task cancelled"))
+                );
+                try {
+                    mcEntity = handleFuture.join();
+                } catch (Throwable t) {
+                    LOGGER.error("Failed to safely get NMS handle for {}", id, t);
                     return null;
                 }
-                //add Id for AbstractChangeSet to work
-                final LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
-                final Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
-                tags.put("Id", LinStringTag.of(id));
-                return LinCompoundTag.of(tags);
-            };
-            return new LazyBaseEntity(type, saveTag);
-        } else {
-            return null;
-        }
+            } else {
+                mcEntity = ((CraftEntity) entity).getHandle();
+            }
+
+            if (mcEntity == null || !readEntityIntoTag(mcEntity, minecraftTag)) {
+                return null;
+            }
+
+            LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
+            Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
+            tags.put("Id", LinStringTag.of(id));
+            return LinCompoundTag.of(tags);
+        };
+        return new LazyBaseEntity(type, saveTag);
     }
 
     @Override
@@ -550,20 +572,62 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void preCaptureStates(final ServerLevel serverLevel) {
-        serverLevel.captureTreeGeneration = true;
-        serverLevel.captureBlockStates = true;
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override
     protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
-        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            return capturedStates != null ? new ArrayList<>(capturedStates.values()) : new ArrayList<>();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return new ArrayList<>();
+        }
     }
 
     @Override
     protected void postCaptureBlockStates(final ServerLevel serverLevel) {
-        serverLevel.captureBlockStates = false;
-        serverLevel.captureTreeGeneration = false;
-        serverLevel.capturedBlockStates.clear();
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            if (capturedStates != null) {
+                capturedStates.clear();
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightFaweWorldNativeAccess.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_20_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R2.block.data.CraftBlockData;
 import org.bukkit.event.block.BlockPhysicsEvent;
@@ -58,7 +59,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
         this.level = level;
         // Use the actual tick as minecraft-defined so we don't try to force blocks into the world when the server's already lagging.
         //  - With the caveat that we don't want to have too many cached changed (1024) so we'd flush those at 1024 anyway.
-        this.lastTick = new AtomicInteger(MinecraftServer.currentTick);
+        this.lastTick = new AtomicInteger(getCurrentTick());
     }
 
     private Level getLevel() {
@@ -94,7 +95,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             LevelChunk levelChunk, BlockPos blockPos,
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
-        int currentTick = MinecraftServer.currentTick;
+        int currentTick = getCurrentTick();
         if (Fawe.isMainThread()) {
             return levelChunk.setBlockState(blockPos, blockState,
                     this.sideEffectSet != null && this.sideEffectSet.shouldApply(SideEffect.UPDATE)
@@ -287,6 +288,18 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
 
+    }
+
+    private int getCurrentTick() {
+        try {
+            return MinecraftServer.currentTick;
+        } catch (NoSuchFieldError e) {
+            try {
+                return Bukkit.getCurrentTick();
+            } catch (Exception ex) {
+                return 0;
+            }
+        }
     }
 
 }

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -11,6 +11,7 @@ import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
@@ -56,6 +57,8 @@ import net.minecraft.world.level.chunk.PalettedContainerRO;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.lighting.LevelLightEngine;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_20_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R2.block.CraftBlock;
@@ -194,23 +197,30 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
+        try {
+            BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
+                    chunkX << 4), y, (z & 15) + (
+                    chunkZ << 4)));
+            if (blockEntity == null) {
+                return null;
+            }
+            return NMS_TO_TILE.apply(blockEntity);
+        } catch (NullPointerException e) {
             return null;
         }
-        return NMS_TO_TILE.apply(blockEntity);
-
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
+        try {
+            Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
+            if (nmsTiles.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        } catch (NullPointerException e) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -317,7 +327,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     private void removeEntity(Entity entity) {
-        entity.discard();
+        if (FoliaUtil.isFoliaServer()) {
+            entity.getBukkitEntity().getScheduler().execute(
+                    WorldEditPlugin.getInstance(),
+                    () -> {
+                        if (!entity.isRemoved()) {
+                            entity.discard();
+                        }
+                    },
+                    null,
+                    1L
+            );
+        } else if (!entity.isRemoved()) {
+            entity.discard();
+        }
     }
 
     @Override
@@ -345,11 +368,11 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         List<BlockEntity> beacons = null;
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
+                BlockPos pos = entry.getKey();
+                int lx = pos.getX() & 15;
+                int ly = pos.getY();
+                int lz = pos.getZ() & 15;
+                int layer = ly >> 4;
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -357,12 +380,26 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                 if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
                     BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity beacon) {
                         if (beacons == null) {
                             beacons = new ArrayList<>();
                         }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                        beacons.add(beacon);
+                        Location location = new Location(
+                                nmsWorld.getWorld(),
+                                beacon.getBlockPos().getX(),
+                                beacon.getBlockPos().getY(),
+                                beacon.getBlockPos().getZ()
+                        );
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(
+                                    WorldEditPlugin.getInstance(),
+                                    location,
+                                    () -> PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk)
+                            );
+                        } else {
+                            PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
+                        }
                         continue;
                     }
                     nmsChunk.removeBlockEntity(tile.getBlockPos());
@@ -372,7 +409,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 }
             }
         }
-        final BiomeType[][] biomes = set.getBiomes();
+        BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;
         synchronized (nmsChunk) {
@@ -598,7 +635,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // Call beacon deactivate events here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
-                final List<BlockEntity> finalBeacons = beacons;
+                List<BlockEntity> finalBeacons = beacons;
                 syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
@@ -611,7 +648,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
                 syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
-                    final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
+                    List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
                     for (Entity entity : entities) {
                         UUID uuid = entity.getUUID();
@@ -643,44 +680,60 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
-                        final FaweCompoundTag nativeTag = iterator.next();
-                        final LinCompoundTag linTag = nativeTag.linTag();
-                        final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
-                        final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
-                        final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
+                        FaweCompoundTag nativeTag = iterator.next();
+                        LinCompoundTag linTag = nativeTag.linTag();
+                        LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                        LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                        LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                         if (idTag == null || posTag == null || rotTag == null) {
                             LOGGER.error("Unknown entity tag: {}", nativeTag);
                             continue;
                         }
-                        final double x = posTag.get(0).valueAsDouble();
-                        final double y = posTag.get(1).valueAsDouble();
-                        final double z = posTag.get(2).valueAsDouble();
-                        final float yaw = rotTag.get(0).valueAsFloat();
-                        final float pitch = rotTag.get(1).valueAsFloat();
-                        final String id = idTag.value();
+                        double x = posTag.get(0).valueAsDouble();
+                        double y = posTag.get(1).valueAsDouble();
+                        double z = posTag.get(2).valueAsDouble();
+                        float yaw = rotTag.get(0).valueAsFloat();
+                        float pitch = rotTag.get(1).valueAsFloat();
+                        String id = idTag.value();
 
                         EntityType<?> type = EntityType.byString(id).orElse(null);
                         if (type != null) {
                             Entity entity = type.create(nmsWorld);
                             if (entity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
-                                for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
+                                CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
+                                for (String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                     tag.remove(name);
                                 }
                                 entity.load(tag);
                                 entity.absMoveTo(x, y, z, yaw, pitch);
                                 entity.setUUID(NbtUtils.uuid(nativeTag));
-                                if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
-                                    LOGGER.warn(
-                                            "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
-                                            id,
-                                            nmsWorld.getWorld().getName(),
-                                            x,
-                                            y,
-                                            z
-                                    );
-                                    // Unsuccessful create should not be saved to history
-                                    iterator.remove();
+                                Location location = new Location(nmsWorld.getWorld(), x, y, z);
+                                if (FoliaUtil.isFoliaServer()) {
+                                    Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, () -> {
+                                        if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                            LOGGER.warn(
+                                                    "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                    id,
+                                                    nmsWorld.getWorld().getName(),
+                                                    x,
+                                                    y,
+                                                    z
+                                            );
+                                            iterator.remove();
+                                        }
+                                    });
+                                } else {
+                                    if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                        LOGGER.warn(
+                                                "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                id,
+                                                nmsWorld.getWorld().getName(),
+                                                x,
+                                                y,
+                                                z
+                                        );
+                                        iterator.remove();
+                                    }
                                 }
                             }
                         }
@@ -692,27 +745,37 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
                 syncTasks.add(() -> {
-                    for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
-                        final FaweCompoundTag nativeTag = entry.getValue();
-                        final BlockVector3 blockHash = entry.getKey();
-                        final int x = blockHash.x() + bx;
-                        final int y = blockHash.y();
-                        final int z = blockHash.z() + bz;
-                        final BlockPos pos = new BlockPos(x, y, z);
+                    World world = nmsWorld.getWorld();
+                    for (Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                        FaweCompoundTag nativeTag = entry.getValue();
+                        BlockVector3 blockHash = entry.getKey();
+                        int x = blockHash.x() + bx;
+                        int y = blockHash.y();
+                        int z = blockHash.z() + bz;
+                        BlockPos pos = new BlockPos(x, y, z);
+                        Location location = new Location(world, x, y, z);
 
-                        synchronized (nmsWorld) {
-                            BlockEntity tileEntity = nmsWorld.getBlockEntity(pos);
-                            if (tileEntity == null || tileEntity.isRemoved()) {
-                                nmsWorld.removeBlockEntity(pos);
-                                tileEntity = nmsWorld.getBlockEntity(pos);
+                        Runnable setTile = () -> {
+                            synchronized (nmsChunk) {
+                                BlockEntity tileEntity = nmsChunk.getBlockEntity(pos);
+                                if (tileEntity == null || tileEntity.isRemoved()) {
+                                    nmsChunk.removeBlockEntity(pos);
+                                    tileEntity = nmsChunk.getBlockEntity(pos);
+                                }
+                                if (tileEntity != null) {
+                                    CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
+                                    tag.put("x", IntTag.valueOf(x));
+                                    tag.put("y", IntTag.valueOf(y));
+                                    tag.put("z", IntTag.valueOf(z));
+                                    tileEntity.load(tag);
+                                }
                             }
-                            if (tileEntity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
-                                tag.put("x", IntTag.valueOf(x));
-                                tag.put("y", IntTag.valueOf(y));
-                                tag.put("z", IntTag.valueOf(z));
-                                tileEntity.load(tag);
-                            }
+                        };
+
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, setTile);
+                        } else {
+                            setTile.run();
                         }
                     }
                 });

--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightPlatformAdapter.java
@@ -8,6 +8,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.mojang.datafixers.util.Either;
@@ -20,6 +21,7 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.util.MCUtil;
 import io.papermc.paper.world.ChunkEntitySlices;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -327,10 +329,22 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     private static void addTicket(ServerLevel serverLevel, int chunkX, int chunkZ) {
-        // Ensure chunk is definitely loaded before applying a ticket
-        io.papermc.paper.util.MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel
-                .getChunkSource()
-                .addRegionTicket(TicketType.UNLOAD_COOLDOWN, new ChunkPos(chunkX, chunkZ), 0, Unit.INSTANCE));
+        ChunkPos pos = new ChunkPos(chunkX, chunkZ);
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(TicketType.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+            return;
+        }
+        try {
+            MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel.getChunkSource().addRegionTicket(TicketType.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE));
+        } catch (Exception e) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(TicketType.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     public static ChunkHolder getPlayerChunk(ServerLevel nmsWorld, final int chunkX, final int chunkZ) {
@@ -348,19 +362,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (chunkHolder == null) {
             return;
         }
-        ChunkPos coordIntPair = new ChunkPos(chunkX, chunkZ);
-        LevelChunk levelChunk;
-        if (PaperLib.isPaper()) {
-            // getChunkAtIfLoadedImmediately is paper only
-            levelChunk = nmsWorld
-                    .getChunkSource()
-                    .getChunkAtIfLoadedImmediately(chunkX, chunkZ);
-        } else {
-            levelChunk = ((Optional<LevelChunk>) ((Either) chunkHolder
-                    .getTickingChunkFuture() // method is not present with new paper chunk system
-                    .getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK)).left())
-                    .orElse(null);
-        }
+        LevelChunk levelChunk = PaperLib.isPaper()
+                ? nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ)
+                : chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).left().orElse(null);
         if (levelChunk == null) {
             return;
         }
@@ -369,31 +373,37 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (lockHolder.chunkLock == null) {
             return;
         }
-        MinecraftServer.getServer().execute(() -> {
+
+        ChunkPos pos = levelChunk.getPos();
+        ClientboundLevelChunkWithLightPacket packet = PaperLib.isPaper()
+                ? new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null, false)
+                : new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null);
+
+        Runnable sendPacket = () -> nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+
+        if (FoliaUtil.isFoliaServer()) {
             try {
-                ClientboundLevelChunkWithLightPacket packet;
-                if (PaperLib.isPaper()) {
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getChunkSource().getLightEngine(),
-                            null,
-                            null,
-                            false // last false is to not bother with x-ray
-                    );
-                } else {
-                    // deprecated on paper - deprecation suppressed
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getChunkSource().getLightEngine(),
-                            null,
-                            null
-                    );
-                }
-                nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
+                sendPacket.run();
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }
-        });
+        } else {
+            try {
+                MinecraftServer.getServer().execute(() -> {
+                    try {
+                        sendPacket.run();
+                    } finally {
+                        NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                    }
+                });
+            } catch (Exception e) {
+                try {
+                    sendPacket.run();
+                } finally {
+                    NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                }
+            }
+        }
     }
 
     private static List<ServerPlayer> nearbyPlayers(ServerLevel serverLevel, ChunkPos coordIntPair) {
@@ -655,8 +665,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {
         try {
+            Map<BlockPos, BlockEntity> blockEntities = levelChunk.getBlockEntities();
             if (levelChunk.loaded || levelChunk.level.isClientSide()) {
-                BlockEntity blockEntity = levelChunk.blockEntities.remove(beacon.getBlockPos());
+                BlockEntity blockEntity = blockEntities.remove(beacon.getBlockPos());
                 if (blockEntity != null) {
                     if (!levelChunk.level.isClientSide) {
                         methodRemoveGameEventListener.invoke(levelChunk, beacon, levelChunk.level);

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweAdapter.java
@@ -10,6 +10,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
@@ -21,6 +22,7 @@ import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R3.regen.PaperweightRegen;
@@ -53,6 +55,7 @@ import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
@@ -126,6 +129,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -349,28 +354,45 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public BaseEntity getEntity(org.bukkit.entity.Entity entity) {
         Preconditions.checkNotNull(entity);
 
-        CraftEntity craftEntity = ((CraftEntity) entity);
-        Entity mcEntity = craftEntity.getHandle();
+        String id = entity.getType().getKey().toString();
+        EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
+        Supplier<LinCompoundTag> saveTag = () -> {
+            net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
+            Entity mcEntity;
 
-        String id = getEntityId(mcEntity);
-
-        if (id != null) {
-            EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
-            Supplier<LinCompoundTag> saveTag = () -> {
-                final net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
-                if (!readEntityIntoTag(mcEntity, minecraftTag)) {
+            if (FoliaUtil.isFoliaServer()) {
+                CompletableFuture<Entity> handleFuture = new CompletableFuture<>();
+                entity.getScheduler().run(
+                        WorldEditPlugin.getInstance(),
+                        (ScheduledTask task) -> {
+                            try {
+                                handleFuture.complete(((CraftEntity) entity).getHandle());
+                            } catch (Throwable t) {
+                                handleFuture.completeExceptionally(t);
+                            }
+                        },
+                        () -> handleFuture.completeExceptionally(new CancellationException("Entity scheduler task cancelled"))
+                );
+                try {
+                    mcEntity = handleFuture.join();
+                } catch (Throwable t) {
+                    LOGGER.error("Failed to safely get NMS handle for {}", id, t);
                     return null;
                 }
-                //add Id for AbstractChangeSet to work
-                final LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
-                final Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
-                tags.put("Id", LinStringTag.of(id));
-                return LinCompoundTag.of(tags);
-            };
-            return new LazyBaseEntity(type, saveTag);
-        } else {
-            return null;
-        }
+            } else {
+                mcEntity = ((CraftEntity) entity).getHandle();
+            }
+
+            if (mcEntity == null || !readEntityIntoTag(mcEntity, minecraftTag)) {
+                return null;
+            }
+
+            LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
+            Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
+            tags.put("Id", LinStringTag.of(id));
+            return LinCompoundTag.of(tags);
+        };
+        return new LazyBaseEntity(type, saveTag);
     }
 
     @Override
@@ -548,20 +570,62 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void preCaptureStates(final ServerLevel serverLevel) {
-        serverLevel.captureTreeGeneration = true;
-        serverLevel.captureBlockStates = true;
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override
     protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
-        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            return capturedStates != null ? new ArrayList<>(capturedStates.values()) : new ArrayList<>();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return new ArrayList<>();
+        }
     }
 
     @Override
     protected void postCaptureBlockStates(final ServerLevel serverLevel) {
-        serverLevel.captureBlockStates = false;
-        serverLevel.captureTreeGeneration = false;
-        serverLevel.capturedBlockStates.clear();
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            if (capturedStates != null) {
+                capturedStates.clear();
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightFaweWorldNativeAccess.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R3.block.data.CraftBlockData;
 import org.bukkit.event.block.BlockPhysicsEvent;
@@ -58,7 +59,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
         this.level = level;
         // Use the actual tick as minecraft-defined so we don't try to force blocks into the world when the server's already lagging.
         //  - With the caveat that we don't want to have too many cached changed (1024) so we'd flush those at 1024 anyway.
-        this.lastTick = new AtomicInteger(MinecraftServer.currentTick);
+        this.lastTick = new AtomicInteger(getCurrentTick());
     }
 
     private Level getLevel() {
@@ -94,7 +95,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             LevelChunk levelChunk, BlockPos blockPos,
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
-        int currentTick = MinecraftServer.currentTick;
+        int currentTick = getCurrentTick();
         if (Fawe.isMainThread()) {
             return levelChunk.setBlockState(blockPos, blockState,
                     this.sideEffectSet != null && this.sideEffectSet.shouldApply(SideEffect.UPDATE)
@@ -287,6 +288,19 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
 
+    }
+
+
+    private int getCurrentTick() {
+        try {
+            return MinecraftServer.currentTick;
+        } catch (NoSuchFieldError e) {
+            try {
+                return Bukkit.getCurrentTick();
+            } catch (Exception ex) {
+                return 0;
+            }
+        }
     }
 
 }

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
@@ -11,6 +11,7 @@ import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
@@ -56,6 +57,8 @@ import net.minecraft.world.level.chunk.PalettedContainerRO;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.lighting.LevelLightEngine;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_20_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R3.block.CraftBlock;
@@ -194,23 +197,30 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
+        try {
+            BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
+                    chunkX << 4), y, (z & 15) + (
+                    chunkZ << 4)));
+            if (blockEntity == null) {
+                return null;
+            }
+            return NMS_TO_TILE.apply(blockEntity);
+        } catch (NullPointerException e) {
             return null;
         }
-        return NMS_TO_TILE.apply(blockEntity);
-
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
+        try {
+            Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
+            if (nmsTiles.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        } catch (NullPointerException e) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -317,7 +327,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     private void removeEntity(Entity entity) {
-        entity.discard();
+        if (FoliaUtil.isFoliaServer()) {
+            entity.getBukkitEntity().getScheduler().execute(
+                    WorldEditPlugin.getInstance(),
+                    () -> {
+                        if (!entity.isRemoved()) {
+                            entity.discard();
+                        }
+                    },
+                    null,
+                    1L
+            );
+        } else if (!entity.isRemoved()) {
+            entity.discard();
+        }
     }
 
     @Override
@@ -345,11 +368,11 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         List<BlockEntity> beacons = null;
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
+                BlockPos pos = entry.getKey();
+                int lx = pos.getX() & 15;
+                int ly = pos.getY();
+                int lz = pos.getZ() & 15;
+                int layer = ly >> 4;
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -357,12 +380,26 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                 if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
                     BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity beacon) {
                         if (beacons == null) {
                             beacons = new ArrayList<>();
                         }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                        beacons.add(beacon);
+                        Location location = new Location(
+                                nmsWorld.getWorld(),
+                                beacon.getBlockPos().getX(),
+                                beacon.getBlockPos().getY(),
+                                beacon.getBlockPos().getZ()
+                        );
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(
+                                    WorldEditPlugin.getInstance(),
+                                    location,
+                                    () -> PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk)
+                            );
+                        } else {
+                            PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
+                        }
                         continue;
                     }
                     nmsChunk.removeBlockEntity(tile.getBlockPos());
@@ -372,7 +409,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 }
             }
         }
-        final BiomeType[][] biomes = set.getBiomes();
+        BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;
         synchronized (nmsChunk) {
@@ -598,7 +635,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // Call beacon deactivate events here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
-                final List<BlockEntity> finalBeacons = beacons;
+                List<BlockEntity> finalBeacons = beacons;
                 syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
@@ -611,7 +648,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
                 syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
-                    final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
+                    List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
                     for (Entity entity : entities) {
                         UUID uuid = entity.getUUID();
@@ -643,45 +680,60 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
-                        final FaweCompoundTag nativeTag = iterator.next();
-                        final LinCompoundTag linTag = nativeTag.linTag();
-                        final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
-                        final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
-                        final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
+                        FaweCompoundTag nativeTag = iterator.next();
+                        LinCompoundTag linTag = nativeTag.linTag();
+                        LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                        LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                        LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                         if (idTag == null || posTag == null || rotTag == null) {
                             LOGGER.error("Unknown entity tag: {}", nativeTag);
                             continue;
                         }
-                        final double x = posTag.get(0).valueAsDouble();
-                        final double y = posTag.get(1).valueAsDouble();
-                        final double z = posTag.get(2).valueAsDouble();
-                        final float yaw = rotTag.get(0).valueAsFloat();
-                        final float pitch = rotTag.get(1).valueAsFloat();
-                        final String id = idTag.value();
+                        double x = posTag.get(0).valueAsDouble();
+                        double y = posTag.get(1).valueAsDouble();
+                        double z = posTag.get(2).valueAsDouble();
+                        float yaw = rotTag.get(0).valueAsFloat();
+                        float pitch = rotTag.get(1).valueAsFloat();
+                        String id = idTag.value();
 
                         EntityType<?> type = EntityType.byString(id).orElse(null);
                         if (type != null) {
                             Entity entity = type.create(nmsWorld);
                             if (entity != null) {
-                                final net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) adapter.fromNativeLin(
-                                        linTag);
-                                for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
+                                CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
+                                for (String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                     tag.remove(name);
                                 }
                                 entity.load(tag);
                                 entity.absMoveTo(x, y, z, yaw, pitch);
                                 entity.setUUID(NbtUtils.uuid(nativeTag));
-                                if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
-                                    LOGGER.warn(
-                                            "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
-                                            id,
-                                            nmsWorld.getWorld().getName(),
-                                            x,
-                                            y,
-                                            z
-                                    );
-                                    // Unsuccessful create should not be saved to history
-                                    iterator.remove();
+                                Location location = new Location(nmsWorld.getWorld(), x, y, z);
+                                if (FoliaUtil.isFoliaServer()) {
+                                    Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, () -> {
+                                        if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                            LOGGER.warn(
+                                                    "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                    id,
+                                                    nmsWorld.getWorld().getName(),
+                                                    x,
+                                                    y,
+                                                    z
+                                            );
+                                            iterator.remove();
+                                        }
+                                    });
+                                } else {
+                                    if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                        LOGGER.warn(
+                                                "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                id,
+                                                nmsWorld.getWorld().getName(),
+                                                x,
+                                                y,
+                                                z
+                                        );
+                                        iterator.remove();
+                                    }
                                 }
                             }
                         }
@@ -693,27 +745,37 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
                 syncTasks.add(() -> {
-                    for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
-                        final FaweCompoundTag nativeTag = entry.getValue();
-                        final BlockVector3 blockHash = entry.getKey();
-                        final int x = blockHash.x() + bx;
-                        final int y = blockHash.y();
-                        final int z = blockHash.z() + bz;
-                        final BlockPos pos = new BlockPos(x, y, z);
+                    World world = nmsWorld.getWorld();
+                    for (Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                        FaweCompoundTag nativeTag = entry.getValue();
+                        BlockVector3 blockHash = entry.getKey();
+                        int x = blockHash.x() + bx;
+                        int y = blockHash.y();
+                        int z = blockHash.z() + bz;
+                        BlockPos pos = new BlockPos(x, y, z);
+                        Location location = new Location(world, x, y, z);
 
-                        synchronized (nmsWorld) {
-                            BlockEntity tileEntity = nmsWorld.getBlockEntity(pos);
-                            if (tileEntity == null || tileEntity.isRemoved()) {
-                                nmsWorld.removeBlockEntity(pos);
-                                tileEntity = nmsWorld.getBlockEntity(pos);
+                        Runnable setTile = () -> {
+                            synchronized (nmsChunk) {
+                                BlockEntity tileEntity = nmsChunk.getBlockEntity(pos);
+                                if (tileEntity == null || tileEntity.isRemoved()) {
+                                    nmsChunk.removeBlockEntity(pos);
+                                    tileEntity = nmsChunk.getBlockEntity(pos);
+                                }
+                                if (tileEntity != null) {
+                                    CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
+                                    tag.put("x", IntTag.valueOf(x));
+                                    tag.put("y", IntTag.valueOf(y));
+                                    tag.put("z", IntTag.valueOf(z));
+                                    tileEntity.load(tag);
+                                }
                             }
-                            if (tileEntity != null) {
-                                final net.minecraft.nbt.CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
-                                tag.put("x", IntTag.valueOf(x));
-                                tag.put("y", IntTag.valueOf(y));
-                                tag.put("z", IntTag.valueOf(z));
-                                tileEntity.load(tag);
-                            }
+                        };
+
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, setTile);
+                        } else {
+                            setTile.run();
                         }
                     }
                 });

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightPlatformAdapter.java
@@ -8,6 +8,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.mojang.datafixers.util.Either;
@@ -20,6 +21,7 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.util.MCUtil;
 import io.papermc.paper.world.ChunkEntitySlices;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -327,10 +329,22 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     private static void addTicket(ServerLevel serverLevel, int chunkX, int chunkZ) {
-        // Ensure chunk is definitely loaded before applying a ticket
-        io.papermc.paper.util.MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel
-                .getChunkSource()
-                .addRegionTicket(TicketType.UNLOAD_COOLDOWN, new ChunkPos(chunkX, chunkZ), 0, Unit.INSTANCE));
+        ChunkPos pos = new ChunkPos(chunkX, chunkZ);
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(TicketType.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+            return;
+        }
+        try {
+            MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel.getChunkSource().addRegionTicket(TicketType.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE));
+        } catch (Exception e) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(TicketType.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     public static ChunkHolder getPlayerChunk(ServerLevel nmsWorld, final int chunkX, final int chunkZ) {
@@ -348,19 +362,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (chunkHolder == null) {
             return;
         }
-        ChunkPos coordIntPair = new ChunkPos(chunkX, chunkZ);
-        LevelChunk levelChunk;
-        if (PaperLib.isPaper()) {
-            // getChunkAtIfLoadedImmediately is paper only
-            levelChunk = nmsWorld
-                    .getChunkSource()
-                    .getChunkAtIfLoadedImmediately(chunkX, chunkZ);
-        } else {
-            levelChunk = ((Optional<LevelChunk>) ((Either) chunkHolder
-                    .getTickingChunkFuture() // method is not present with new paper chunk system
-                    .getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK)).left())
-                    .orElse(null);
-        }
+        LevelChunk levelChunk = PaperLib.isPaper()
+                ? nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ)
+                : chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).left().orElse(null);
         if (levelChunk == null) {
             return;
         }
@@ -369,31 +373,37 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (lockHolder.chunkLock == null) {
             return;
         }
-        MinecraftServer.getServer().execute(() -> {
+
+        ChunkPos pos = levelChunk.getPos();
+        ClientboundLevelChunkWithLightPacket packet = PaperLib.isPaper()
+                ? new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null, false)
+                : new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null);
+
+        Runnable sendPacket = () -> nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+
+        if (FoliaUtil.isFoliaServer()) {
             try {
-                ClientboundLevelChunkWithLightPacket packet;
-                if (PaperLib.isPaper()) {
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getChunkSource().getLightEngine(),
-                            null,
-                            null,
-                            false // last false is to not bother with x-ray
-                    );
-                } else {
-                    // deprecated on paper - deprecation suppressed
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getChunkSource().getLightEngine(),
-                            null,
-                            null
-                    );
-                }
-                nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
+                sendPacket.run();
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }
-        });
+        } else {
+            try {
+                MinecraftServer.getServer().execute(() -> {
+                    try {
+                        sendPacket.run();
+                    } finally {
+                        NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                    }
+                });
+            } catch (Exception e) {
+                try {
+                    sendPacket.run();
+                } finally {
+                    NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                }
+            }
+        }
     }
 
     private static List<ServerPlayer> nearbyPlayers(ServerLevel serverLevel, ChunkPos coordIntPair) {
@@ -655,8 +665,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {
         try {
+            Map<BlockPos, BlockEntity> blockEntities = levelChunk.getBlockEntities();
             if (levelChunk.loaded || levelChunk.level.isClientSide()) {
-                BlockEntity blockEntity = levelChunk.blockEntities.remove(beacon.getBlockPos());
+                BlockEntity blockEntity = blockEntities.remove(beacon.getBlockPos());
                 if (blockEntity != null) {
                     if (!levelChunk.level.isClientSide) {
                         methodRemoveGameEventListener.invoke(levelChunk, beacon, levelChunk.level);

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweAdapter.java
@@ -10,6 +10,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
@@ -22,6 +23,7 @@ import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R4.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_20_R4.regen.PaperweightRegen;
@@ -55,6 +57,7 @@ import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
@@ -131,6 +134,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -357,28 +362,45 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public BaseEntity getEntity(org.bukkit.entity.Entity entity) {
         Preconditions.checkNotNull(entity);
 
-        CraftEntity craftEntity = ((CraftEntity) entity);
-        Entity mcEntity = craftEntity.getHandle();
+        String id = entity.getType().getKey().toString();
+        EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
+        Supplier<LinCompoundTag> saveTag = () -> {
+            net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
+            Entity mcEntity;
 
-        String id = getEntityId(mcEntity);
-
-        if (id != null) {
-            EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
-            Supplier<LinCompoundTag> saveTag = () -> {
-                final net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
-                if (!readEntityIntoTag(mcEntity, minecraftTag)) {
+            if (FoliaUtil.isFoliaServer()) {
+                CompletableFuture<Entity> handleFuture = new CompletableFuture<>();
+                entity.getScheduler().run(
+                        WorldEditPlugin.getInstance(),
+                        (ScheduledTask task) -> {
+                            try {
+                                handleFuture.complete(((CraftEntity) entity).getHandle());
+                            } catch (Throwable t) {
+                                handleFuture.completeExceptionally(t);
+                            }
+                        },
+                        () -> handleFuture.completeExceptionally(new CancellationException("Entity scheduler task cancelled"))
+                );
+                try {
+                    mcEntity = handleFuture.join();
+                } catch (Throwable t) {
+                    LOGGER.error("Failed to safely get NMS handle for {}", id, t);
                     return null;
                 }
-                //add Id for AbstractChangeSet to work
-                final LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
-                final Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
-                tags.put("Id", LinStringTag.of(id));
-                return LinCompoundTag.of(tags);
-            };
-            return new LazyBaseEntity(type, saveTag);
-        } else {
-            return null;
-        }
+            } else {
+                mcEntity = ((CraftEntity) entity).getHandle();
+            }
+
+            if (mcEntity == null || !readEntityIntoTag(mcEntity, minecraftTag)) {
+                return null;
+            }
+
+            LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
+            Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
+            tags.put("Id", LinStringTag.of(id));
+            return LinCompoundTag.of(tags);
+        };
+        return new LazyBaseEntity(type, saveTag);
     }
 
     @Override
@@ -563,20 +585,62 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void preCaptureStates(final ServerLevel serverLevel) {
-        serverLevel.captureTreeGeneration = true;
-        serverLevel.captureBlockStates = true;
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override
     protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
-        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            return capturedStates != null ? new ArrayList<>(capturedStates.values()) : new ArrayList<>();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return new ArrayList<>();
+        }
     }
 
     @Override
     protected void postCaptureBlockStates(final ServerLevel serverLevel) {
-        serverLevel.captureBlockStates = false;
-        serverLevel.captureTreeGeneration = false;
-        serverLevel.capturedBlockStates.clear();
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            if (capturedStates != null) {
+                capturedStates.clear();
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightFaweWorldNativeAccess.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.event.block.BlockPhysicsEvent;
@@ -59,7 +60,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
         this.level = level;
         // Use the actual tick as minecraft-defined so we don't try to force blocks into the world when the server's already lagging.
         //  - With the caveat that we don't want to have too many cached changed (1024) so we'd flush those at 1024 anyway.
-        this.lastTick = new AtomicInteger(MinecraftServer.currentTick);
+        this.lastTick = new AtomicInteger(getCurrentTick());
     }
 
     private Level getLevel() {
@@ -95,7 +96,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             LevelChunk levelChunk, BlockPos blockPos,
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
-        int currentTick = MinecraftServer.currentTick;
+        int currentTick = getCurrentTick();
         if (Fawe.isMainThread()) {
             return levelChunk.setBlockState(blockPos, blockState,
                     this.sideEffectSet != null && this.sideEffectSet.shouldApply(SideEffect.UPDATE)
@@ -288,6 +289,18 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
 
+    }
+
+    private int getCurrentTick() {
+        try {
+            return MinecraftServer.currentTick;
+        } catch (NoSuchFieldError e) {
+            try {
+                return Bukkit.getCurrentTick();
+            } catch (Exception ex) {
+                return 0;
+            }
+        }
     }
 
 }

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
@@ -11,6 +11,7 @@ import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
@@ -57,6 +58,8 @@ import net.minecraft.world.level.chunk.PalettedContainerRO;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.lighting.LevelLightEngine;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.CraftBlock;
@@ -195,23 +198,30 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
+        try {
+            BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
+                    chunkX << 4), y, (z & 15) + (
+                    chunkZ << 4)));
+            if (blockEntity == null) {
+                return null;
+            }
+            return NMS_TO_TILE.apply(blockEntity);
+        } catch (NullPointerException e) {
             return null;
         }
-        return NMS_TO_TILE.apply(blockEntity);
-
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
+        try {
+            Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
+            if (nmsTiles.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        } catch (NullPointerException e) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -318,7 +328,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     private void removeEntity(Entity entity) {
-        entity.discard();
+        if (FoliaUtil.isFoliaServer()) {
+            entity.getBukkitEntity().getScheduler().execute(
+                    WorldEditPlugin.getInstance(),
+                    () -> {
+                        if (!entity.isRemoved()) {
+                            entity.discard();
+                        }
+                    },
+                    null,
+                    1L
+            );
+        } else if (!entity.isRemoved()) {
+            entity.discard();
+        }
     }
 
     @Override
@@ -346,11 +369,11 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         List<BlockEntity> beacons = null;
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
+                BlockPos pos = entry.getKey();
+                int lx = pos.getX() & 15;
+                int ly = pos.getY();
+                int lz = pos.getZ() & 15;
+                int layer = ly >> 4;
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -358,12 +381,26 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                 if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
                     BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity beacon) {
                         if (beacons == null) {
                             beacons = new ArrayList<>();
                         }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                        beacons.add(beacon);
+                        Location location = new Location(
+                                nmsWorld.getWorld(),
+                                beacon.getBlockPos().getX(),
+                                beacon.getBlockPos().getY(),
+                                beacon.getBlockPos().getZ()
+                        );
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(
+                                    WorldEditPlugin.getInstance(),
+                                    location,
+                                    () -> PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk)
+                            );
+                        } else {
+                            PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
+                        }
                         continue;
                     }
                     nmsChunk.removeBlockEntity(tile.getBlockPos());
@@ -373,7 +410,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 }
             }
         }
-        final BiomeType[][] biomes = set.getBiomes();
+        BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;
         synchronized (nmsChunk) {
@@ -599,7 +636,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // Call beacon deactivate events here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
-                final List<BlockEntity> finalBeacons = beacons;
+                List<BlockEntity> finalBeacons = beacons;
                 syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
@@ -612,7 +649,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
                 syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
-                    final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
+                    List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
                     for (Entity entity : entities) {
                         UUID uuid = entity.getUUID();
@@ -644,45 +681,60 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
-                        final FaweCompoundTag nativeTag = iterator.next();
-                        final LinCompoundTag linTag = nativeTag.linTag();
-                        final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
-                        final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
-                        final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
+                        FaweCompoundTag nativeTag = iterator.next();
+                        LinCompoundTag linTag = nativeTag.linTag();
+                        LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                        LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                        LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                         if (idTag == null || posTag == null || rotTag == null) {
                             LOGGER.error("Unknown entity tag: {}", nativeTag);
                             continue;
                         }
-                        final double x = posTag.get(0).valueAsDouble();
-                        final double y = posTag.get(1).valueAsDouble();
-                        final double z = posTag.get(2).valueAsDouble();
-                        final float yaw = rotTag.get(0).valueAsFloat();
-                        final float pitch = rotTag.get(1).valueAsFloat();
-                        final String id = idTag.value();
+                        double x = posTag.get(0).valueAsDouble();
+                        double y = posTag.get(1).valueAsDouble();
+                        double z = posTag.get(2).valueAsDouble();
+                        float yaw = rotTag.get(0).valueAsFloat();
+                        float pitch = rotTag.get(1).valueAsFloat();
+                        String id = idTag.value();
 
                         EntityType<?> type = EntityType.byString(id).orElse(null);
                         if (type != null) {
                             Entity entity = type.create(nmsWorld);
                             if (entity != null) {
-                                final net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) adapter.fromNativeLin(
-                                        linTag);
-                                for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
+                                CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
+                                for (String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                     tag.remove(name);
                                 }
                                 entity.load(tag);
                                 entity.absMoveTo(x, y, z, yaw, pitch);
                                 entity.setUUID(NbtUtils.uuid(nativeTag));
-                                if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
-                                    LOGGER.warn(
-                                            "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
-                                            id,
-                                            nmsWorld.getWorld().getName(),
-                                            x,
-                                            y,
-                                            z
-                                    );
-                                    // Unsuccessful create should not be saved to history
-                                    iterator.remove();
+                                Location location = new Location(nmsWorld.getWorld(), x, y, z);
+                                if (FoliaUtil.isFoliaServer()) {
+                                    Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, () -> {
+                                        if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                            LOGGER.warn(
+                                                    "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                    id,
+                                                    nmsWorld.getWorld().getName(),
+                                                    x,
+                                                    y,
+                                                    z
+                                            );
+                                            iterator.remove();
+                                        }
+                                    });
+                                } else {
+                                    if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                        LOGGER.warn(
+                                                "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                id,
+                                                nmsWorld.getWorld().getName(),
+                                                x,
+                                                y,
+                                                z
+                                        );
+                                        iterator.remove();
+                                    }
                                 }
                             }
                         }
@@ -694,27 +746,37 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
                 syncTasks.add(() -> {
-                    for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
-                        final FaweCompoundTag nativeTag = entry.getValue();
-                        final BlockVector3 blockHash = entry.getKey();
-                        final int x = blockHash.x() + bx;
-                        final int y = blockHash.y();
-                        final int z = blockHash.z() + bz;
-                        final BlockPos pos = new BlockPos(x, y, z);
+                    World world = nmsWorld.getWorld();
+                    for (Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                        FaweCompoundTag nativeTag = entry.getValue();
+                        BlockVector3 blockHash = entry.getKey();
+                        int x = blockHash.x() + bx;
+                        int y = blockHash.y();
+                        int z = blockHash.z() + bz;
+                        BlockPos pos = new BlockPos(x, y, z);
+                        Location location = new Location(world, x, y, z);
 
-                        synchronized (nmsWorld) {
-                            BlockEntity tileEntity = nmsWorld.getBlockEntity(pos);
-                            if (tileEntity == null || tileEntity.isRemoved()) {
-                                nmsWorld.removeBlockEntity(pos);
-                                tileEntity = nmsWorld.getBlockEntity(pos);
+                        Runnable setTile = () -> {
+                            synchronized (nmsChunk) {
+                                BlockEntity tileEntity = nmsChunk.getBlockEntity(pos);
+                                if (tileEntity == null || tileEntity.isRemoved()) {
+                                    nmsChunk.removeBlockEntity(pos);
+                                    tileEntity = nmsChunk.getBlockEntity(pos);
+                                }
+                                if (tileEntity != null) {
+                                    CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
+                                    tag.put("x", IntTag.valueOf(x));
+                                    tag.put("y", IntTag.valueOf(y));
+                                    tag.put("z", IntTag.valueOf(z));
+                                    tileEntity.loadWithComponents(tag, DedicatedServer.getServer().registryAccess());
+                                }
                             }
-                            if (tileEntity != null) {
-                                final net.minecraft.nbt.CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
-                                tag.put("x", IntTag.valueOf(x));
-                                tag.put("y", IntTag.valueOf(y));
-                                tag.put("z", IntTag.valueOf(z));
-                                tileEntity.loadWithComponents(tag, DedicatedServer.getServer().registryAccess());
-                            }
+                        };
+
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, setTile);
+                        } else {
+                            setTile.run();
                         }
                     }
                 });

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightPlatformAdapter.java
@@ -8,6 +8,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
@@ -19,6 +20,7 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.util.MCUtil;
 import io.papermc.paper.world.ChunkEntitySlices;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -326,10 +328,22 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     private static void addTicket(ServerLevel serverLevel, int chunkX, int chunkZ) {
-        // Ensure chunk is definitely loaded before applying a ticket
-        io.papermc.paper.util.MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel
-                .getChunkSource()
-                .addRegionTicket(TicketType.UNLOAD_COOLDOWN, new ChunkPos(chunkX, chunkZ), 0, Unit.INSTANCE));
+        ChunkPos pos = new ChunkPos(chunkX, chunkZ);
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(TicketType.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+            return;
+        }
+        try {
+            MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel.getChunkSource().addRegionTicket(TicketType.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE));
+        } catch (Exception e) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(TicketType.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     public static ChunkHolder getPlayerChunk(ServerLevel nmsWorld, final int chunkX, final int chunkZ) {
@@ -347,14 +361,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (chunkHolder == null) {
             return;
         }
-        ChunkPos coordIntPair = new ChunkPos(chunkX, chunkZ);
-        LevelChunk levelChunk;
-        if (PaperLib.isPaper()) {
-            // getChunkAtIfLoadedImmediately is paper only
-            levelChunk = nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ);
-        } else {
-            levelChunk = chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
-        }
+        LevelChunk levelChunk = PaperLib.isPaper()
+                ? nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ)
+                : chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
         if (levelChunk == null) {
             return;
         }
@@ -363,31 +372,37 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (lockHolder.chunkLock == null) {
             return;
         }
-        MinecraftServer.getServer().execute(() -> {
+
+        ChunkPos pos = levelChunk.getPos();
+        ClientboundLevelChunkWithLightPacket packet = PaperLib.isPaper()
+                ? new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null, false)
+                : new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null);
+
+        Runnable sendPacket = () -> nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+
+        if (FoliaUtil.isFoliaServer()) {
             try {
-                ClientboundLevelChunkWithLightPacket packet;
-                if (PaperLib.isPaper()) {
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getChunkSource().getLightEngine(),
-                            null,
-                            null,
-                            false // last false is to not bother with x-ray
-                    );
-                } else {
-                    // deprecated on paper - deprecation suppressed
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getChunkSource().getLightEngine(),
-                            null,
-                            null
-                    );
-                }
-                nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
+                sendPacket.run();
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }
-        });
+        } else {
+            try {
+                MinecraftServer.getServer().execute(() -> {
+                    try {
+                        sendPacket.run();
+                    } finally {
+                        NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                    }
+                });
+            } catch (Exception e) {
+                try {
+                    sendPacket.run();
+                } finally {
+                    NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                }
+            }
+        }
     }
 
     private static List<ServerPlayer> nearbyPlayers(ServerLevel serverLevel, ChunkPos coordIntPair) {
@@ -649,8 +664,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {
         try {
+            Map<BlockPos, BlockEntity> blockEntities = levelChunk.getBlockEntities();
             if (levelChunk.loaded || levelChunk.level.isClientSide()) {
-                BlockEntity blockEntity = levelChunk.blockEntities.remove(beacon.getBlockPos());
+                BlockEntity blockEntity = blockEntities.remove(beacon.getBlockPos());
                 if (blockEntity != null) {
                     if (!levelChunk.level.isClientSide) {
                         methodRemoveGameEventListener.invoke(levelChunk, beacon, levelChunk.level);

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/regen/PaperweightRegen.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Lifecycle;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -42,6 +43,8 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -207,7 +210,50 @@ public class PaperweightRegen extends Regenerator {
         if (paperConfigField != null) {
             paperConfigField.set(freshWorld, originalServerWorld.paperConfig());
         }
+
+        if (FoliaUtil.isFoliaServer()) {
+            return initWorldForFolia(newWorldData);
+        }
+
         return true;
+    }
+
+    private boolean initWorldForFolia(PrimaryLevelData worldData) throws ExecutionException, InterruptedException {
+        MinecraftServer console = ((CraftServer) Bukkit.getServer()).getServer();
+
+        ChunkPos spawnChunk = new ChunkPos(
+                freshWorld.getChunkSource().randomState().sampler().findSpawnPosition()
+        );
+
+        setRandomSpawnSelection(spawnChunk);
+
+        CompletableFuture<Boolean> initFuture = new CompletableFuture<>();
+
+        Bukkit.getServer().getRegionScheduler().run(
+                WorldEditPlugin.getInstance(),
+                freshWorld.getWorld(),
+                spawnChunk.x, spawnChunk.z,
+                task -> {
+                    try {
+                        console.initWorld(freshWorld, worldData, worldData, worldData.worldGenOptions());
+                        initFuture.complete(true);
+                    } catch (Exception e) {
+                        initFuture.completeExceptionally(e);
+                    }
+                }
+        );
+
+        return initFuture.get();
+    }
+
+    private void setRandomSpawnSelection(ChunkPos spawnChunk) {
+        try {
+            Field randomSpawnField = ServerLevel.class.getDeclaredField("randomSpawnSelection");
+            randomSpawnField.setAccessible(true);
+            randomSpawnField.set(freshWorld, spawnChunk);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set randomSpawnSelection for Folia world initialization", e);
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweAdapter.java
@@ -10,6 +10,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
@@ -22,6 +23,7 @@ import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1.nbt.PaperweightLazyCompoundTag;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1.regen.PaperweightRegen;
@@ -55,6 +57,7 @@ import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
@@ -131,6 +134,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -357,28 +362,45 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public BaseEntity getEntity(org.bukkit.entity.Entity entity) {
         Preconditions.checkNotNull(entity);
 
-        CraftEntity craftEntity = ((CraftEntity) entity);
-        Entity mcEntity = craftEntity.getHandle();
+        String id = entity.getType().getKey().toString();
+        EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
+        Supplier<LinCompoundTag> saveTag = () -> {
+            net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
+            Entity mcEntity;
 
-        String id = getEntityId(mcEntity);
-
-        if (id != null) {
-            EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
-            Supplier<LinCompoundTag> saveTag = () -> {
-                final net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
-                if (!readEntityIntoTag(mcEntity, minecraftTag)) {
+            if (FoliaUtil.isFoliaServer()) {
+                CompletableFuture<Entity> handleFuture = new CompletableFuture<>();
+                entity.getScheduler().run(
+                        WorldEditPlugin.getInstance(),
+                        (ScheduledTask task) -> {
+                            try {
+                                handleFuture.complete(((CraftEntity) entity).getHandle());
+                            } catch (Throwable t) {
+                                handleFuture.completeExceptionally(t);
+                            }
+                        },
+                        () -> handleFuture.completeExceptionally(new CancellationException("Entity scheduler task cancelled"))
+                );
+                try {
+                    mcEntity = handleFuture.join();
+                } catch (Throwable t) {
+                    LOGGER.error("Failed to safely get NMS handle for {}", id, t);
                     return null;
                 }
-                //add Id for AbstractChangeSet to work
-                final LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
-                final Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
-                tags.put("Id", LinStringTag.of(id));
-                return LinCompoundTag.of(tags);
-            };
-            return new LazyBaseEntity(type, saveTag);
-        } else {
-            return null;
-        }
+            } else {
+                mcEntity = ((CraftEntity) entity).getHandle();
+            }
+
+            if (mcEntity == null || !readEntityIntoTag(mcEntity, minecraftTag)) {
+                return null;
+            }
+
+            LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
+            Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
+            tags.put("Id", LinStringTag.of(id));
+            return LinCompoundTag.of(tags);
+        };
+        return new LazyBaseEntity(type, saveTag);
     }
 
     @Override
@@ -564,20 +586,62 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void preCaptureStates(final ServerLevel serverLevel) {
-        serverLevel.captureTreeGeneration = true;
-        serverLevel.captureBlockStates = true;
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override
     protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
-        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            return capturedStates != null ? new ArrayList<>(capturedStates.values()) : new ArrayList<>();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return new ArrayList<>();
+        }
     }
 
     @Override
     protected void postCaptureBlockStates(final ServerLevel serverLevel) {
-        serverLevel.captureBlockStates = false;
-        serverLevel.captureTreeGeneration = false;
-        serverLevel.capturedBlockStates.clear();
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            if (capturedStates != null) {
+                capturedStates.clear();
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightFaweWorldNativeAccess.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.event.block.BlockPhysicsEvent;
@@ -59,7 +60,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
         this.level = level;
         // Use the actual tick as minecraft-defined so we don't try to force blocks into the world when the server's already lagging.
         //  - With the caveat that we don't want to have too many cached changed (1024) so we'd flush those at 1024 anyway.
-        this.lastTick = new AtomicInteger(MinecraftServer.currentTick);
+        this.lastTick = new AtomicInteger(getCurrentTick());
     }
 
     private Level getLevel() {
@@ -95,7 +96,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             LevelChunk levelChunk, BlockPos blockPos,
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
-        int currentTick = MinecraftServer.currentTick;
+        int currentTick = getCurrentTick();
         if (Fawe.isMainThread()) {
             return levelChunk.setBlockState(blockPos, blockState,
                     this.sideEffectSet != null && this.sideEffectSet.shouldApply(SideEffect.UPDATE)
@@ -288,6 +289,18 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
 
+    }
+
+    private int getCurrentTick() {
+        try {
+            return MinecraftServer.currentTick;
+        } catch (NoSuchFieldError e) {
+            try {
+                return Bukkit.getCurrentTick();
+            } catch (Exception ex) {
+                return 0;
+            }
+        }
     }
 
 }

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
@@ -3,7 +3,6 @@ package com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_R1;
 import com.fastasyncworldedit.bukkit.adapter.AbstractBukkitGetBlocks;
 import com.fastasyncworldedit.bukkit.adapter.DelegateSemaphore;
 import com.fastasyncworldedit.bukkit.adapter.NativeEntityFunctionSet;
-import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.heightmap.HeightMapType;
@@ -12,7 +11,7 @@ import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
-import com.fastasyncworldedit.core.queue.implementation.QueueHandler;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
@@ -59,6 +58,8 @@ import net.minecraft.world.level.chunk.PalettedContainerRO;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.lighting.LevelLightEngine;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.CraftBlock;
@@ -82,7 +83,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -198,23 +198,30 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
+        try {
+            BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
+                    chunkX << 4), y, (z & 15) + (
+                    chunkZ << 4)));
+            if (blockEntity == null) {
+                return null;
+            }
+            return NMS_TO_TILE.apply(blockEntity);
+        } catch (NullPointerException e) {
             return null;
         }
-        return NMS_TO_TILE.apply(blockEntity);
-
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
+        try {
+            Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
+            if (nmsTiles.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        } catch (NullPointerException e) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -321,7 +328,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     private void removeEntity(Entity entity) {
-        entity.discard();
+        if (FoliaUtil.isFoliaServer()) {
+            entity.getBukkitEntity().getScheduler().execute(
+                    WorldEditPlugin.getInstance(),
+                    () -> {
+                        if (!entity.isRemoved()) {
+                            entity.discard();
+                        }
+                    },
+                    null,
+                    1L
+            );
+        } else if (!entity.isRemoved()) {
+            entity.discard();
+        }
     }
 
     @Override
@@ -349,11 +369,11 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         List<BlockEntity> beacons = null;
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
+                BlockPos pos = entry.getKey();
+                int lx = pos.getX() & 15;
+                int ly = pos.getY();
+                int lz = pos.getZ() & 15;
+                int layer = ly >> 4;
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -361,12 +381,26 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                 if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
                     BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity beacon) {
                         if (beacons == null) {
                             beacons = new ArrayList<>();
                         }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                        beacons.add(beacon);
+                        Location location = new Location(
+                                nmsWorld.getWorld(),
+                                beacon.getBlockPos().getX(),
+                                beacon.getBlockPos().getY(),
+                                beacon.getBlockPos().getZ()
+                        );
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(
+                                    WorldEditPlugin.getInstance(),
+                                    location,
+                                    () -> PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk)
+                            );
+                        } else {
+                            PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
+                        }
                         continue;
                     }
                     nmsChunk.removeBlockEntity(tile.getBlockPos());
@@ -376,7 +410,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 }
             }
         }
-        final BiomeType[][] biomes = set.getBiomes();
+        BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;
         synchronized (nmsChunk) {
@@ -589,7 +623,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     set.getMaxSectionPosition()
             );
 
-            Runnable[] syncTasks = null;
+            List<Runnable> syncTasks = new ArrayList<>();
 
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
@@ -597,27 +631,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // Call beacon deactivate events here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
-                final List<BlockEntity> finalBeacons = beacons;
-
-                syncTasks = new Runnable[4];
-
-                syncTasks[3] = () -> {
+                List<BlockEntity> finalBeacons = beacons;
+                syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
                     }
-                };
+                });
             }
 
             Set<UUID> entityRemoves = set.getEntityRemoves();
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[3];
-                }
-
-                syncTasks[2] = () -> {
+                syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
-                    final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
+                    List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
                     for (Entity entity : entities) {
                         UUID uuid = entity.getUUID();
@@ -641,95 +668,113 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     // Only save entities that were actually removed to history
                     set.getEntityRemoves().clear();
                     set.getEntityRemoves().addAll(entitiesRemoved);
-                };
+                });
             }
 
             Collection<FaweCompoundTag> entities = set.entities();
             if (entities != null && !entities.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[2];
-                }
-
-                syncTasks[1] = () -> {
+                syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
-                        final FaweCompoundTag nativeTag = iterator.next();
-                        final LinCompoundTag linTag = nativeTag.linTag();
-                        final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
-                        final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
-                        final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
+                        FaweCompoundTag nativeTag = iterator.next();
+                        LinCompoundTag linTag = nativeTag.linTag();
+                        LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                        LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                        LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                         if (idTag == null || posTag == null || rotTag == null) {
                             LOGGER.error("Unknown entity tag: {}", nativeTag);
                             continue;
                         }
-                        final double x = posTag.get(0).valueAsDouble();
-                        final double y = posTag.get(1).valueAsDouble();
-                        final double z = posTag.get(2).valueAsDouble();
-                        final float yaw = rotTag.get(0).valueAsFloat();
-                        final float pitch = rotTag.get(1).valueAsFloat();
-                        final String id = idTag.value();
+                        double x = posTag.get(0).valueAsDouble();
+                        double y = posTag.get(1).valueAsDouble();
+                        double z = posTag.get(2).valueAsDouble();
+                        float yaw = rotTag.get(0).valueAsFloat();
+                        float pitch = rotTag.get(1).valueAsFloat();
+                        String id = idTag.value();
 
                         EntityType<?> type = EntityType.byString(id).orElse(null);
                         if (type != null) {
                             Entity entity = type.create(nmsWorld);
                             if (entity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
-                                for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
+                                CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
+                                for (String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                     tag.remove(name);
                                 }
                                 entity.load(tag);
                                 entity.absMoveTo(x, y, z, yaw, pitch);
                                 entity.setUUID(NbtUtils.uuid(nativeTag));
-                                if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
-                                    LOGGER.warn(
-                                            "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
-                                            id,
-                                            nmsWorld.getWorld().getName(),
-                                            x,
-                                            y,
-                                            z
-                                    );
-                                    // Unsuccessful create should not be saved to history
-                                    iterator.remove();
+                                Location location = new Location(nmsWorld.getWorld(), x, y, z);
+                                if (FoliaUtil.isFoliaServer()) {
+                                    Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, () -> {
+                                        if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                            LOGGER.warn(
+                                                    "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                    id,
+                                                    nmsWorld.getWorld().getName(),
+                                                    x,
+                                                    y,
+                                                    z
+                                            );
+                                            iterator.remove();
+                                        }
+                                    });
+                                } else {
+                                    if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                        LOGGER.warn(
+                                                "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                id,
+                                                nmsWorld.getWorld().getName(),
+                                                x,
+                                                y,
+                                                z
+                                        );
+                                        iterator.remove();
+                                    }
                                 }
                             }
                         }
                     }
-                };
+                });
             }
 
             // set tiles
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
-                if (syncTasks == null) {
-                    syncTasks = new Runnable[1];
-                }
+                syncTasks.add(() -> {
+                    World world = nmsWorld.getWorld();
+                    for (Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                        FaweCompoundTag nativeTag = entry.getValue();
+                        BlockVector3 blockHash = entry.getKey();
+                        int x = blockHash.x() + bx;
+                        int y = blockHash.y();
+                        int z = blockHash.z() + bz;
+                        BlockPos pos = new BlockPos(x, y, z);
+                        Location location = new Location(world, x, y, z);
 
-                syncTasks[0] = () -> {
-                    for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
-                        final FaweCompoundTag nativeTag = entry.getValue();
-                        final BlockVector3 blockHash = entry.getKey();
-                        final int x = blockHash.x() + bx;
-                        final int y = blockHash.y();
-                        final int z = blockHash.z() + bz;
-                        final BlockPos pos = new BlockPos(x, y, z);
+                        Runnable setTile = () -> {
+                            synchronized (nmsChunk) {
+                                BlockEntity tileEntity = nmsChunk.getBlockEntity(pos);
+                                if (tileEntity == null || tileEntity.isRemoved()) {
+                                    nmsChunk.removeBlockEntity(pos);
+                                    tileEntity = nmsChunk.getBlockEntity(pos);
+                                }
+                                if (tileEntity != null) {
+                                    CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
+                                    tag.put("x", IntTag.valueOf(x));
+                                    tag.put("y", IntTag.valueOf(y));
+                                    tag.put("z", IntTag.valueOf(z));
+                                    tileEntity.loadWithComponents(tag, DedicatedServer.getServer().registryAccess());
+                                }
+                            }
+                        };
 
-                        synchronized (nmsWorld) {
-                            BlockEntity tileEntity = nmsWorld.getBlockEntity(pos);
-                            if (tileEntity == null || tileEntity.isRemoved()) {
-                                nmsWorld.removeBlockEntity(pos);
-                                tileEntity = nmsWorld.getBlockEntity(pos);
-                            }
-                            if (tileEntity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
-                                tag.put("x", IntTag.valueOf(x));
-                                tag.put("y", IntTag.valueOf(y));
-                                tag.put("z", IntTag.valueOf(z));
-                                tileEntity.loadWithComponents(tag, DedicatedServer.getServer().registryAccess());
-                            }
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, setTile);
+                        } else {
+                            setTile.run();
                         }
                     }
-                };
+                });
             }
 
             Runnable callback;
@@ -737,11 +782,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 callback = null;
             } else {
                 int finalMask = bitMask != 0 ? bitMask : lightUpdate ? set.getBitMask() : 0;
-                callback = () -> {
+                syncTasks.add(() -> {
                     // Set Modified
-                    nmsChunk.setLightCorrect(true); // Set Modified
+                    nmsChunk.setLightCorrect(true);
                     nmsChunk.mustNotSave = false;
                     nmsChunk.setUnsaved(true);
+                });
+                callback = () -> {
                     // send to player
                     if (!set
                             .getSideEffectSet()
@@ -753,45 +800,8 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     }
                 };
             }
-            if (syncTasks != null) {
-                QueueHandler queueHandler = Fawe.instance().getQueueHandler();
-                Runnable[] finalSyncTasks = syncTasks;
-
-                // Chain the sync tasks and the callback
-                Callable<Future> chain = () -> {
-                    try {
-                        // Run the sync tasks
-                        for (Runnable task : finalSyncTasks) {
-                            if (task != null) {
-                                task.run();
-                            }
-                        }
-                        if (callback == null) {
-                            if (finalizer != null) {
-                                queueHandler.async(finalizer, null);
-                            }
-                            return null;
-                        } else {
-                            return queueHandler.async(callback, null);
-                        }
-                    } catch (Throwable e) {
-                        LOGGER.error("Error performing final chunk calling at {},{}", chunkX, chunkZ, e);
-                        throw e;
-                    }
-                };
-                //noinspection unchecked - required at compile time
-                return (T) (Future) queueHandler.sync(chain);
-            } else {
-                if (callback == null) {
-                    if (finalizer != null) {
-                        finalizer.run();
-                    }
-                } else {
-                    callback.run();
-                }
-            }
+            return handleCallFinalizer(syncTasks, callback, finalizer);
         }
-        return null;
     }
 
     private void updateGet(

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightPlatformAdapter.java
@@ -9,6 +9,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
@@ -20,6 +21,7 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.util.MCUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
@@ -316,10 +318,22 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     private static void addTicket(ServerLevel serverLevel, int chunkX, int chunkZ) {
-        // Ensure chunk is definitely loaded before applying a ticket
-        io.papermc.paper.util.MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel
-                .getChunkSource()
-                .addRegionTicket(ChunkHolderManager.UNLOAD_COOLDOWN, new ChunkPos(chunkX, chunkZ), 0, Unit.INSTANCE));
+        ChunkPos pos = new ChunkPos(chunkX, chunkZ);
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+            return;
+        }
+        try {
+            MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel.getChunkSource().addRegionTicket(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE));
+        } catch (Exception e) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     public static ChunkHolder getPlayerChunk(ServerLevel nmsWorld, final int chunkX, final int chunkZ) {
@@ -337,14 +351,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (chunkHolder == null) {
             return;
         }
-        ChunkPos coordIntPair = new ChunkPos(chunkX, chunkZ);
-        LevelChunk levelChunk;
-        if (PaperLib.isPaper()) {
-            // getChunkAtIfLoadedImmediately is paper only
-            levelChunk = nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ);
-        } else {
-            levelChunk = chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
-        }
+        LevelChunk levelChunk = PaperLib.isPaper()
+                ? nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ)
+                : chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
         if (levelChunk == null) {
             return;
         }
@@ -353,31 +362,37 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (lockHolder.chunkLock == null) {
             return;
         }
-        MinecraftServer.getServer().execute(() -> {
+
+        ChunkPos pos = levelChunk.getPos();
+        ClientboundLevelChunkWithLightPacket packet = PaperLib.isPaper()
+                ? new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null, false)
+                : new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null);
+
+        Runnable sendPacket = () -> nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+
+        if (FoliaUtil.isFoliaServer()) {
             try {
-                ClientboundLevelChunkWithLightPacket packet;
-                if (PaperLib.isPaper()) {
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getChunkSource().getLightEngine(),
-                            null,
-                            null,
-                            false // last false is to not bother with x-ray
-                    );
-                } else {
-                    // deprecated on paper - deprecation suppressed
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getChunkSource().getLightEngine(),
-                            null,
-                            null
-                    );
-                }
-                nearbyPlayers(nmsWorld, coordIntPair).forEach(p -> p.connection.send(packet));
+                sendPacket.run();
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }
-        });
+        } else {
+            try {
+                MinecraftServer.getServer().execute(() -> {
+                    try {
+                        sendPacket.run();
+                    } finally {
+                        NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                    }
+                });
+            } catch (Exception e) {
+                try {
+                    sendPacket.run();
+                } finally {
+                    NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                }
+            }
+        }
     }
 
     private static List<ServerPlayer> nearbyPlayers(ServerLevel serverLevel, ChunkPos coordIntPair) {
@@ -639,8 +654,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {
         try {
+            Map<BlockPos, BlockEntity> blockEntities = levelChunk.getBlockEntities();
             if (levelChunk.loaded || levelChunk.level.isClientSide()) {
-                BlockEntity blockEntity = levelChunk.blockEntities.remove(beacon.getBlockPos());
+                BlockEntity blockEntity = blockEntities.remove(beacon.getBlockPos());
                 if (blockEntity != null) {
                     if (!levelChunk.level.isClientSide) {
                         methodRemoveGameEventListener.invoke(levelChunk, beacon, levelChunk.level);

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/regen/PaperweightRegen.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Lifecycle;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -42,6 +43,8 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -207,7 +210,50 @@ public class PaperweightRegen extends Regenerator {
         if (paperConfigField != null) {
             paperConfigField.set(freshWorld, originalServerWorld.paperConfig());
         }
+
+        if (FoliaUtil.isFoliaServer()) {
+            return initWorldForFolia(newWorldData);
+        }
+
         return true;
+    }
+
+    private boolean initWorldForFolia(PrimaryLevelData worldData) throws ExecutionException, InterruptedException {
+        MinecraftServer console = ((CraftServer) Bukkit.getServer()).getServer();
+
+        ChunkPos spawnChunk = new ChunkPos(
+                freshWorld.getChunkSource().randomState().sampler().findSpawnPosition()
+        );
+
+        setRandomSpawnSelection(spawnChunk);
+
+        CompletableFuture<Boolean> initFuture = new CompletableFuture<>();
+
+        Bukkit.getServer().getRegionScheduler().run(
+                WorldEditPlugin.getInstance(),
+                freshWorld.getWorld(),
+                spawnChunk.x, spawnChunk.z,
+                task -> {
+                    try {
+                        console.initWorld(freshWorld, worldData, worldData, worldData.worldGenOptions());
+                        initFuture.complete(true);
+                    } catch (Exception e) {
+                        initFuture.completeExceptionally(e);
+                    }
+                }
+        );
+
+        return initFuture.get();
+    }
+
+    private void setRandomSpawnSelection(ChunkPos spawnChunk) {
+        try {
+            Field randomSpawnField = ServerLevel.class.getDeclaredField("randomSpawnSelection");
+            randomSpawnField.setAccessible(true);
+            randomSpawnField.set(freshWorld, spawnChunk);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set randomSpawnSelection for Folia world initialization", e);
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweAdapter.java
@@ -10,6 +10,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
@@ -20,6 +21,7 @@ import com.mojang.serialization.Codec;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_21_4.PaperweightAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_4.regen.PaperweightRegen;
@@ -53,6 +55,7 @@ import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
@@ -129,6 +132,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -334,7 +339,7 @@ public final class PaperweightFaweAdapter extends FaweAdapter<Tag, ServerLevel> 
     }
 
     @Override
-    public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(World world) {
+    public WorldNativeAccess<?, ?, ?> createWorldNativeAccess(org.bukkit.World world) {
         return new PaperweightFaweWorldNativeAccess(this, new WeakReference<>(getServerLevel(world)));
     }
 
@@ -342,24 +347,45 @@ public final class PaperweightFaweAdapter extends FaweAdapter<Tag, ServerLevel> 
     public BaseEntity getEntity(org.bukkit.entity.Entity entity) {
         Preconditions.checkNotNull(entity);
 
-        CraftEntity craftEntity = ((CraftEntity) entity);
-        Entity mcEntity = craftEntity.getHandle();
-
-        String id = getEntityId(mcEntity);
+        String id = entity.getType().getKey().toString();
         EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
         Supplier<LinCompoundTag> saveTag = () -> {
-            final net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
-            if (!readEntityIntoTag(mcEntity, minecraftTag)) {
+            net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
+            Entity mcEntity;
+
+            if (FoliaUtil.isFoliaServer()) {
+                CompletableFuture<Entity> handleFuture = new CompletableFuture<>();
+                entity.getScheduler().run(
+                        WorldEditPlugin.getInstance(),
+                        (ScheduledTask task) -> {
+                            try {
+                                handleFuture.complete(((CraftEntity) entity).getHandle());
+                            } catch (Throwable t) {
+                                handleFuture.completeExceptionally(t);
+                            }
+                        },
+                        () -> handleFuture.completeExceptionally(new CancellationException("Entity scheduler task cancelled"))
+                );
+                try {
+                    mcEntity = handleFuture.join();
+                } catch (Throwable t) {
+                    LOGGER.error("Failed to safely get NMS handle for {}", id, t);
+                    return null;
+                }
+            } else {
+                mcEntity = ((CraftEntity) entity).getHandle();
+            }
+
+            if (mcEntity == null || !readEntityIntoTag(mcEntity, minecraftTag)) {
                 return null;
             }
-            //add Id for AbstractChangeSet to work
-            final LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
-            final Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
+
+            LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
+            Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
             tags.put("Id", LinStringTag.of(id));
             return LinCompoundTag.of(tags);
         };
         return new LazyBaseEntity(type, saveTag);
-
     }
 
     @Override
@@ -546,20 +572,62 @@ public final class PaperweightFaweAdapter extends FaweAdapter<Tag, ServerLevel> 
 
     @Override
     protected void preCaptureStates(final ServerLevel serverLevel) {
-        serverLevel.captureTreeGeneration = true;
-        serverLevel.captureBlockStates = true;
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override
     protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
-        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            return capturedStates != null ? new ArrayList<>(capturedStates.values()) : new ArrayList<>();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return new ArrayList<>();
+        }
     }
 
     @Override
     protected void postCaptureBlockStates(final ServerLevel serverLevel) {
-        serverLevel.captureBlockStates = false;
-        serverLevel.captureTreeGeneration = false;
-        serverLevel.capturedBlockStates.clear();
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            if (capturedStates != null) {
+                capturedStates.clear();
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightFaweWorldNativeAccess.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.redstone.ExperimentalRedstoneUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.event.block.BlockPhysicsEvent;
@@ -60,7 +61,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
         this.level = level;
         // Use the actual tick as minecraft-defined so we don't try to force blocks into the world when the server's already lagging.
         //  - With the caveat that we don't want to have too many cached changed (1024) so we'd flush those at 1024 anyway.
-        this.lastTick = new AtomicInteger(MinecraftServer.currentTick);
+        this.lastTick = new AtomicInteger(getCurrentTick());
     }
 
     private Level getLevel() {
@@ -96,7 +97,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             LevelChunk levelChunk, BlockPos blockPos,
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
-        int currentTick = MinecraftServer.currentTick;
+        int currentTick = getCurrentTick();
         if (Fawe.isMainThread()) {
             return levelChunk.setBlockState(blockPos, blockState,
                     this.sideEffectSet != null && this.sideEffectSet.shouldApply(SideEffect.UPDATE)
@@ -289,6 +290,19 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
 
+    }
+
+
+    private int getCurrentTick() {
+        try {
+            return MinecraftServer.currentTick;
+        } catch (NoSuchFieldError e) {
+            try {
+                return Bukkit.getCurrentTick();
+            } catch (Exception ex) {
+                return 0;
+            }
+        }
     }
 
 }

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightPlatformAdapter.java
@@ -9,6 +9,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
@@ -20,6 +21,7 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.util.MCUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
@@ -302,10 +304,22 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     private static void addTicket(ServerLevel serverLevel, int chunkX, int chunkZ) {
-        // Ensure chunk is definitely loaded before applying a ticket
-        io.papermc.paper.util.MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel
-                .getChunkSource()
-                .addRegionTicket(ChunkHolderManager.UNLOAD_COOLDOWN, new ChunkPos(chunkX, chunkZ), 0, Unit.INSTANCE));
+        ChunkPos pos = new ChunkPos(chunkX, chunkZ);
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+            return;
+        }
+        try {
+            MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel.getChunkSource().addRegionTicket(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE));
+        } catch (Exception e) {
+            try {
+                serverLevel.getChunkSource().addRegionTicket(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0, Unit.INSTANCE);
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     public static ChunkHolder getPlayerChunk(ServerLevel nmsWorld, final int chunkX, final int chunkZ) {
@@ -323,13 +337,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (chunkHolder == null) {
             return;
         }
-        LevelChunk levelChunk;
-        if (PaperLib.isPaper()) {
-            // getChunkAtIfLoadedImmediately is paper only
-            levelChunk = nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ);
-        } else {
-            levelChunk = chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
-        }
+        LevelChunk levelChunk = PaperLib.isPaper()
+                ? nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ)
+                : chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
         if (levelChunk == null) {
             return;
         }
@@ -338,32 +348,37 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (lockHolder.chunkLock == null) {
             return;
         }
-        MinecraftServer.getServer().execute(() -> {
+
+        ChunkPos pos = levelChunk.getPos();
+        ClientboundLevelChunkWithLightPacket packet = PaperLib.isPaper()
+                ? new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null, false)
+                : new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null);
+
+        Runnable sendPacket = () -> nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+
+        if (FoliaUtil.isFoliaServer()) {
             try {
-                ChunkPos pos = levelChunk.getPos();
-                ClientboundLevelChunkWithLightPacket packet;
-                if (PaperLib.isPaper()) {
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getLightEngine(),
-                            null,
-                            null,
-                            false // last false is to not bother with x-ray
-                    );
-                } else {
-                    // deprecated on paper - deprecation suppressed
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getLightEngine(),
-                            null,
-                            null
-                    );
-                }
-                nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+                sendPacket.run();
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }
-        });
+        } else {
+            try {
+                MinecraftServer.getServer().execute(() -> {
+                    try {
+                        sendPacket.run();
+                    } finally {
+                        NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                    }
+                });
+            } catch (Exception e) {
+                try {
+                    sendPacket.run();
+                } finally {
+                    NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                }
+            }
+        }
     }
 
     private static List<ServerPlayer> nearbyPlayers(ServerLevel serverLevel, ChunkPos coordIntPair) {
@@ -625,8 +640,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {
         try {
+            Map<BlockPos, BlockEntity> blockEntities = levelChunk.getBlockEntities();
             if (levelChunk.loaded || levelChunk.level.isClientSide()) {
-                BlockEntity blockEntity = levelChunk.blockEntities.remove(beacon.getBlockPos());
+                BlockEntity blockEntity = blockEntities.remove(beacon.getBlockPos());
                 if (blockEntity != null) {
                     if (!levelChunk.level.isClientSide) {
                         methodRemoveGameEventListener.invoke(levelChunk, beacon, levelChunk.level);

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/regen/PaperweightRegen.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Lifecycle;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -41,6 +42,8 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -206,7 +209,50 @@ public class PaperweightRegen extends Regenerator {
         if (paperConfigField != null) {
             paperConfigField.set(freshWorld, originalServerWorld.paperConfig());
         }
+
+        if (FoliaUtil.isFoliaServer()) {
+            return initWorldForFolia(newWorldData);
+        }
+
         return true;
+    }
+
+    private boolean initWorldForFolia(PrimaryLevelData worldData) throws ExecutionException, InterruptedException {
+        MinecraftServer console = ((CraftServer) Bukkit.getServer()).getServer();
+
+        ChunkPos spawnChunk = new ChunkPos(
+                freshWorld.getChunkSource().randomState().sampler().findSpawnPosition()
+        );
+
+        setRandomSpawnSelection(spawnChunk);
+
+        CompletableFuture<Boolean> initFuture = new CompletableFuture<>();
+
+        Bukkit.getServer().getRegionScheduler().run(
+                WorldEditPlugin.getInstance(),
+                freshWorld.getWorld(),
+                spawnChunk.x, spawnChunk.z,
+                task -> {
+                    try {
+                        console.initWorld(freshWorld, worldData, worldData, worldData.worldGenOptions());
+                        initFuture.complete(true);
+                    } catch (Exception e) {
+                        initFuture.completeExceptionally(e);
+                    }
+                }
+        );
+
+        return initFuture.get();
+    }
+
+    private void setRandomSpawnSelection(ChunkPos spawnChunk) {
+        try {
+            Field randomSpawnField = ServerLevel.class.getDeclaredField("randomSpawnSelection");
+            randomSpawnField.setAccessible(true);
+            randomSpawnField.set(freshWorld, spawnChunk);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set randomSpawnSelection for Folia world initialization", e);
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightFaweWorldNativeAccess.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.redstone.ExperimentalRedstoneUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.event.block.BlockPhysicsEvent;
@@ -60,7 +61,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
         this.level = level;
         // Use the actual tick as minecraft-defined so we don't try to force blocks into the world when the server's already lagging.
         //  - With the caveat that we don't want to have too many cached changed (1024) so we'd flush those at 1024 anyway.
-        this.lastTick = new AtomicInteger(MinecraftServer.currentTick);
+        this.lastTick = new AtomicInteger(getCurrentTick());
     }
 
     private Level getLevel() {
@@ -96,7 +97,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             LevelChunk levelChunk, BlockPos blockPos,
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
-        int currentTick = MinecraftServer.currentTick;
+        int currentTick = getCurrentTick();
         if (Fawe.isMainThread()) {
             return levelChunk.setBlockState(blockPos, blockState,
                     this.sideEffectSet.shouldApply(SideEffect.UPDATE) ? 0 : 512
@@ -289,6 +290,18 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
 
+    }
+
+    private int getCurrentTick() {
+        try {
+            return MinecraftServer.currentTick;
+        } catch (NoSuchFieldError e) {
+            try {
+                return Bukkit.getCurrentTick();
+            } catch (Exception ex) {
+                return 0;
+            }
+        }
     }
 
 }

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
@@ -11,6 +11,7 @@ import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
@@ -58,6 +59,8 @@ import net.minecraft.world.level.chunk.PalettedContainerRO;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.lighting.LevelLightEngine;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.CraftBlock;
@@ -196,23 +199,30 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
+        try {
+            BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
+                    chunkX << 4), y, (z & 15) + (
+                    chunkZ << 4)));
+            if (blockEntity == null) {
+                return null;
+            }
+            return NMS_TO_TILE.apply(blockEntity);
+        } catch (NullPointerException e) {
             return null;
         }
-        return NMS_TO_TILE.apply(blockEntity);
-
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
+        try {
+            Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
+            if (nmsTiles.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        } catch (NullPointerException e) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -319,7 +329,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     private void removeEntity(Entity entity) {
-        entity.discard();
+        if (FoliaUtil.isFoliaServer()) {
+            entity.getBukkitEntity().getScheduler().execute(
+                    WorldEditPlugin.getInstance(),
+                    () -> {
+                        if (!entity.isRemoved()) {
+                            entity.discard();
+                        }
+                    },
+                    null,
+                    1L
+            );
+        } else if (!entity.isRemoved()) {
+            entity.discard();
+        }
     }
 
     @Override
@@ -339,7 +362,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         if (createCopy) {
             if (copies.containsKey(copyKey)) {
                 throw new IllegalStateException("Copy key already used.");
-                }
+            }
             copies.put(copyKey, copy);
         }
         // Remove existing tiles. Create a copy so that we can remove blocks
@@ -347,11 +370,11 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         List<BlockEntity> beacons = null;
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
+                BlockPos pos = entry.getKey();
+                int lx = pos.getX() & 15;
+                int ly = pos.getY();
+                int lz = pos.getZ() & 15;
+                int layer = ly >> 4;
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -359,12 +382,26 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                 if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
                     BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity beacon) {
                         if (beacons == null) {
                             beacons = new ArrayList<>();
                         }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                        beacons.add(beacon);
+                        Location location = new Location(
+                                nmsWorld.getWorld(),
+                                beacon.getBlockPos().getX(),
+                                beacon.getBlockPos().getY(),
+                                beacon.getBlockPos().getZ()
+                        );
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(
+                                    WorldEditPlugin.getInstance(),
+                                    location,
+                                    () -> PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk)
+                            );
+                        } else {
+                            PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
+                        }
                         continue;
                     }
                     nmsChunk.removeBlockEntity(tile.getBlockPos());
@@ -374,7 +411,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 }
             }
         }
-        final BiomeType[][] biomes = set.getBiomes();
+        BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;
         synchronized (nmsChunk) {
@@ -593,7 +630,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // Call beacon deactivate events here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
-                final List<BlockEntity> finalBeacons = beacons;
+                List<BlockEntity> finalBeacons = beacons;
                 syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
@@ -606,7 +643,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
                 syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
-                    final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
+                    List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
                     for (Entity entity : entities) {
                         UUID uuid = entity.getUUID();
@@ -638,44 +675,60 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
-                        final FaweCompoundTag nativeTag = iterator.next();
-                        final LinCompoundTag linTag = nativeTag.linTag();
-                        final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
-                        final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
-                        final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
+                        FaweCompoundTag nativeTag = iterator.next();
+                        LinCompoundTag linTag = nativeTag.linTag();
+                        LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                        LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                        LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                         if (idTag == null || posTag == null || rotTag == null) {
                             LOGGER.error("Unknown entity tag: {}", nativeTag);
                             continue;
                         }
-                        final double x = posTag.get(0).valueAsDouble();
-                        final double y = posTag.get(1).valueAsDouble();
-                        final double z = posTag.get(2).valueAsDouble();
-                        final float yaw = rotTag.get(0).valueAsFloat();
-                        final float pitch = rotTag.get(1).valueAsFloat();
-                        final String id = idTag.value();
+                        double x = posTag.get(0).valueAsDouble();
+                        double y = posTag.get(1).valueAsDouble();
+                        double z = posTag.get(2).valueAsDouble();
+                        float yaw = rotTag.get(0).valueAsFloat();
+                        float pitch = rotTag.get(1).valueAsFloat();
+                        String id = idTag.value();
 
                         EntityType<?> type = EntityType.byString(id).orElse(null);
                         if (type != null) {
                             Entity entity = type.create(nmsWorld, EntitySpawnReason.COMMAND);
                             if (entity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
-                                for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
+                                CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
+                                for (String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                     tag.remove(name);
                                 }
                                 entity.load(tag);
                                 entity.absSnapTo(x, y, z, yaw, pitch);
                                 entity.setUUID(NbtUtils.uuid(nativeTag));
-                                if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
-                                    LOGGER.warn(
-                                            "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
-                                            id,
-                                            nmsWorld.getWorld().getName(),
-                                            x,
-                                            y,
-                                            z
-                                    );
-                                    // Unsuccessful create should not be saved to history
-                                    iterator.remove();
+                                Location location = new Location(nmsWorld.getWorld(), x, y, z);
+                                if (FoliaUtil.isFoliaServer()) {
+                                    Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, () -> {
+                                        if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                            LOGGER.warn(
+                                                    "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                    id,
+                                                    nmsWorld.getWorld().getName(),
+                                                    x,
+                                                    y,
+                                                    z
+                                            );
+                                            iterator.remove();
+                                        }
+                                    });
+                                } else {
+                                    if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                        LOGGER.warn(
+                                                "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                id,
+                                                nmsWorld.getWorld().getName(),
+                                                x,
+                                                y,
+                                                z
+                                        );
+                                        iterator.remove();
+                                    }
                                 }
                             }
                         }
@@ -687,27 +740,37 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
                 syncTasks.add(() -> {
-                    for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
-                        final FaweCompoundTag nativeTag = entry.getValue();
-                        final BlockVector3 blockHash = entry.getKey();
-                        final int x = blockHash.x() + bx;
-                        final int y = blockHash.y();
-                        final int z = blockHash.z() + bz;
-                        final BlockPos pos = new BlockPos(x, y, z);
+                    World world = nmsWorld.getWorld();
+                    for (Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                        FaweCompoundTag nativeTag = entry.getValue();
+                        BlockVector3 blockHash = entry.getKey();
+                        int x = blockHash.x() + bx;
+                        int y = blockHash.y();
+                        int z = blockHash.z() + bz;
+                        BlockPos pos = new BlockPos(x, y, z);
+                        Location location = new Location(world, x, y, z);
 
-                        synchronized (nmsWorld) {
-                            BlockEntity tileEntity = nmsWorld.getBlockEntity(pos);
-                            if (tileEntity == null || tileEntity.isRemoved()) {
-                                nmsWorld.removeBlockEntity(pos);
-                                tileEntity = nmsWorld.getBlockEntity(pos);
+                        Runnable setTile = () -> {
+                            synchronized (nmsChunk) {
+                                BlockEntity tileEntity = nmsChunk.getBlockEntity(pos);
+                                if (tileEntity == null || tileEntity.isRemoved()) {
+                                    nmsChunk.removeBlockEntity(pos);
+                                    tileEntity = nmsChunk.getBlockEntity(pos);
+                                }
+                                if (tileEntity != null) {
+                                    CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
+                                    tag.put("x", IntTag.valueOf(x));
+                                    tag.put("y", IntTag.valueOf(y));
+                                    tag.put("z", IntTag.valueOf(z));
+                                    tileEntity.loadWithComponents(tag, DedicatedServer.getServer().registryAccess());
+                                }
                             }
-                            if (tileEntity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
-                                tag.put("x", IntTag.valueOf(x));
-                                tag.put("y", IntTag.valueOf(y));
-                                tag.put("z", IntTag.valueOf(z));
-                                tileEntity.loadWithComponents(tag, DedicatedServer.getServer().registryAccess());
-                            }
+                        };
+
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, setTile);
+                        } else {
+                            setTile.run();
                         }
                     }
                 });

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/regen/PaperweightRegen.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Lifecycle;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -41,6 +42,8 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -206,7 +209,50 @@ public class PaperweightRegen extends Regenerator {
         if (paperConfigField != null) {
             paperConfigField.set(freshWorld, originalServerWorld.paperConfig());
         }
+
+        if (FoliaUtil.isFoliaServer()) {
+            return initWorldForFolia(newWorldData);
+        }
+
         return true;
+    }
+
+    private boolean initWorldForFolia(PrimaryLevelData worldData) throws ExecutionException, InterruptedException {
+        MinecraftServer console = ((CraftServer) Bukkit.getServer()).getServer();
+
+        ChunkPos spawnChunk = new ChunkPos(
+                freshWorld.getChunkSource().randomState().sampler().findSpawnPosition()
+        );
+
+        setRandomSpawnSelection(spawnChunk);
+
+        CompletableFuture<Boolean> initFuture = new CompletableFuture<>();
+
+        Bukkit.getServer().getRegionScheduler().run(
+                WorldEditPlugin.getInstance(),
+                freshWorld.getWorld(),
+                spawnChunk.x, spawnChunk.z,
+                task -> {
+                    try {
+                        console.initWorld(freshWorld, worldData, worldData, worldData.worldGenOptions());
+                        initFuture.complete(true);
+                    } catch (Exception e) {
+                        initFuture.completeExceptionally(e);
+                    }
+                }
+        );
+
+        return initFuture.get();
+    }
+
+    private void setRandomSpawnSelection(ChunkPos spawnChunk) {
+        try {
+            Field randomSpawnField = ServerLevel.class.getDeclaredField("randomSpawnSelection");
+            randomSpawnField.setAccessible(true);
+            randomSpawnField.set(freshWorld, spawnChunk);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set randomSpawnSelection for Folia world initialization", e);
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightFaweAdapter.java
@@ -10,6 +10,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
@@ -21,6 +22,7 @@ import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_21_6.PaperweightAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_6.regen.PaperweightRegen;
@@ -54,6 +56,7 @@ import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
@@ -131,6 +134,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -353,24 +358,45 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public BaseEntity getEntity(org.bukkit.entity.Entity entity) {
         Preconditions.checkNotNull(entity);
 
-        CraftEntity craftEntity = ((CraftEntity) entity);
-        Entity mcEntity = craftEntity.getHandle();
-
-        String id = getEntityId(mcEntity);
+        String id = entity.getType().getKey().toString();
         EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
         Supplier<LinCompoundTag> saveTag = () -> {
-            final net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
-            if (!readEntityIntoTag(mcEntity, minecraftTag)) {
+            net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
+            Entity mcEntity;
+
+            if (FoliaUtil.isFoliaServer()) {
+                CompletableFuture<Entity> handleFuture = new CompletableFuture<>();
+                entity.getScheduler().run(
+                        WorldEditPlugin.getInstance(),
+                        (ScheduledTask task) -> {
+                            try {
+                                handleFuture.complete(((CraftEntity) entity).getHandle());
+                            } catch (Throwable t) {
+                                handleFuture.completeExceptionally(t);
+                            }
+                        },
+                        () -> handleFuture.completeExceptionally(new CancellationException("Entity scheduler task cancelled"))
+                );
+                try {
+                    mcEntity = handleFuture.join();
+                } catch (Throwable t) {
+                    LOGGER.error("Failed to safely get NMS handle for {}", id, t);
+                    return null;
+                }
+            } else {
+                mcEntity = ((CraftEntity) entity).getHandle();
+            }
+
+            if (mcEntity == null || !readEntityIntoTag(mcEntity, minecraftTag)) {
                 return null;
             }
-            //add Id for AbstractChangeSet to work
-            final LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
-            final Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
+
+            LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
+            Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
             tags.put("Id", LinStringTag.of(id));
             return LinCompoundTag.of(tags);
         };
         return new LazyBaseEntity(type, saveTag);
-
     }
 
     @Override
@@ -557,20 +583,62 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void preCaptureStates(final ServerLevel serverLevel) {
-        serverLevel.captureTreeGeneration = true;
-        serverLevel.captureBlockStates = true;
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override
     protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
-        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            return capturedStates != null ? new ArrayList<>(capturedStates.values()) : new ArrayList<>();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return new ArrayList<>();
+        }
     }
 
     @Override
     protected void postCaptureBlockStates(final ServerLevel serverLevel) {
-        serverLevel.captureBlockStates = false;
-        serverLevel.captureTreeGeneration = false;
-        serverLevel.capturedBlockStates.clear();
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            if (capturedStates != null) {
+                capturedStates.clear();
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override
@@ -761,7 +829,6 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
             }
         }
     }
-
 
     @Override
     protected ServerLevel getServerLevel(final World world) {

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightFaweWorldNativeAccess.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.redstone.ExperimentalRedstoneUtils;
 import net.minecraft.world.level.storage.ValueInput;
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.event.block.BlockPhysicsEvent;
@@ -62,7 +63,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
         this.level = level;
         // Use the actual tick as minecraft-defined so we don't try to force blocks into the world when the server's already lagging.
         //  - With the caveat that we don't want to have too many cached changed (1024) so we'd flush those at 1024 anyway.
-        this.lastTick = new AtomicInteger(MinecraftServer.currentTick);
+        this.lastTick = new AtomicInteger(getCurrentTick());
     }
 
     private Level getLevel() {
@@ -98,7 +99,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             LevelChunk levelChunk, BlockPos blockPos,
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
-        int currentTick = MinecraftServer.currentTick;
+        int currentTick = getCurrentTick();
         if (Fawe.isMainThread()) {
             return levelChunk.setBlockState(
                     blockPos, blockState,
@@ -307,6 +308,18 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
 
+    }
+
+    private int getCurrentTick() {
+        try {
+            return MinecraftServer.currentTick;
+        } catch (NoSuchFieldError e) {
+            try {
+                return Bukkit.getCurrentTick();
+            } catch (Exception ex) {
+                return 0;
+            }
+        }
     }
 
 }

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
@@ -11,6 +11,7 @@ import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
@@ -59,6 +60,8 @@ import net.minecraft.world.level.lighting.LevelLightEngine;
 import net.minecraft.world.level.storage.TagValueOutput;
 import net.minecraft.world.level.storage.ValueInput;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.CraftBlock;
@@ -199,23 +202,30 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
+        try {
+            BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
+                    chunkX << 4), y, (z & 15) + (
+                    chunkZ << 4)));
+            if (blockEntity == null) {
+                return null;
+            }
+            return NMS_TO_TILE.apply(blockEntity);
+        } catch (NullPointerException e) {
             return null;
         }
-        return NMS_TO_TILE.apply(blockEntity);
-
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
+        try {
+            Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
+            if (nmsTiles.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        } catch (NullPointerException e) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -323,7 +333,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     private void removeEntity(Entity entity) {
-        entity.discard();
+        if (FoliaUtil.isFoliaServer()) {
+            entity.getBukkitEntity().getScheduler().execute(
+                    WorldEditPlugin.getInstance(),
+                    () -> {
+                        if (!entity.isRemoved()) {
+                            entity.discard();
+                        }
+                    },
+                    null,
+                    1L
+            );
+        } else if (!entity.isRemoved()) {
+            entity.discard();
+        }
     }
 
     @Override
@@ -343,7 +366,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         if (createCopy) {
             if (copies.containsKey(copyKey)) {
                 throw new IllegalStateException("Copy key already used.");
-                }
+            }
             copies.put(copyKey, copy);
         }
         // Remove existing tiles. Create a copy so that we can remove blocks
@@ -351,11 +374,11 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         List<BlockEntity> beacons = null;
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
+                BlockPos pos = entry.getKey();
+                int lx = pos.getX() & 15;
+                int ly = pos.getY();
+                int lz = pos.getZ() & 15;
+                int layer = ly >> 4;
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -363,12 +386,26 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                 if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
                     BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity beacon) {
                         if (beacons == null) {
                             beacons = new ArrayList<>();
                         }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                        beacons.add(beacon);
+                        Location location = new Location(
+                                nmsWorld.getWorld(),
+                                beacon.getBlockPos().getX(),
+                                beacon.getBlockPos().getY(),
+                                beacon.getBlockPos().getZ()
+                        );
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(
+                                    WorldEditPlugin.getInstance(),
+                                    location,
+                                    () -> PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk)
+                            );
+                        } else {
+                            PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
+                        }
                         continue;
                     }
                     nmsChunk.removeBlockEntity(tile.getBlockPos());
@@ -378,7 +415,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 }
             }
         }
-        final BiomeType[][] biomes = set.getBiomes();
+        BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;
         synchronized (nmsChunk) {
@@ -597,7 +634,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // Call beacon deactivate events here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
-                final List<BlockEntity> finalBeacons = beacons;
+                List<BlockEntity> finalBeacons = beacons;
                 syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
@@ -610,7 +647,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
                 syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
-                    final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
+                    List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
                     for (Entity entity : entities) {
                         UUID uuid = entity.getUUID();
@@ -642,28 +679,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
-                        final FaweCompoundTag nativeTag = iterator.next();
-                        final LinCompoundTag linTag = nativeTag.linTag();
-                        final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
-                        final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
-                        final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
+                        FaweCompoundTag nativeTag = iterator.next();
+                        LinCompoundTag linTag = nativeTag.linTag();
+                        LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                        LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                        LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                         if (idTag == null || posTag == null || rotTag == null) {
                             LOGGER.error("Unknown entity tag: {}", nativeTag);
                             continue;
                         }
-                        final double x = posTag.get(0).valueAsDouble();
-                        final double y = posTag.get(1).valueAsDouble();
-                        final double z = posTag.get(2).valueAsDouble();
-                        final float yaw = rotTag.get(0).valueAsFloat();
-                        final float pitch = rotTag.get(1).valueAsFloat();
-                        final String id = idTag.value();
+                        double x = posTag.get(0).valueAsDouble();
+                        double y = posTag.get(1).valueAsDouble();
+                        double z = posTag.get(2).valueAsDouble();
+                        float yaw = rotTag.get(0).valueAsFloat();
+                        float pitch = rotTag.get(1).valueAsFloat();
+                        String id = idTag.value();
 
                         EntityType<?> type = EntityType.byString(id).orElse(null);
                         if (type != null) {
                             Entity entity = type.create(nmsWorld, EntitySpawnReason.COMMAND);
                             if (entity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
-                                for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
+                                CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
+                                for (String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                     tag.remove(name);
                                 }
                                 // TODO (VI/O)
@@ -671,17 +708,33 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                                 entity.load(input);
                                 entity.absSnapTo(x, y, z, yaw, pitch);
                                 entity.setUUID(NbtUtils.uuid(nativeTag));
-                                if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
-                                    LOGGER.warn(
-                                            "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
-                                            id,
-                                            nmsWorld.getWorld().getName(),
-                                            x,
-                                            y,
-                                            z
-                                    );
-                                    // Unsuccessful create should not be saved to history
-                                    iterator.remove();
+                                Location location = new Location(nmsWorld.getWorld(), x, y, z);
+                                if (FoliaUtil.isFoliaServer()) {
+                                    Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, () -> {
+                                        if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                            LOGGER.warn(
+                                                    "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                    id,
+                                                    nmsWorld.getWorld().getName(),
+                                                    x,
+                                                    y,
+                                                    z
+                                            );
+                                            iterator.remove();
+                                        }
+                                    });
+                                } else {
+                                    if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                        LOGGER.warn(
+                                                "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                id,
+                                                nmsWorld.getWorld().getName(),
+                                                x,
+                                                y,
+                                                z
+                                        );
+                                        iterator.remove();
+                                    }
                                 }
                             }
                         }
@@ -693,29 +746,38 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
                 syncTasks.add(() -> {
-                    for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
-                        final FaweCompoundTag nativeTag = entry.getValue();
-                        final BlockVector3 blockHash = entry.getKey();
-                        final int x = blockHash.x() + bx;
-                        final int y = blockHash.y();
-                        final int z = blockHash.z() + bz;
-                        final BlockPos pos = new BlockPos(x, y, z);
+                    World world = nmsWorld.getWorld();
+                    for (Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                        FaweCompoundTag nativeTag = entry.getValue();
+                        BlockVector3 blockHash = entry.getKey();
+                        int x = blockHash.x() + bx;
+                        int y = blockHash.y();
+                        int z = blockHash.z() + bz;
+                        BlockPos pos = new BlockPos(x, y, z);
+                        Location location = new Location(world, x, y, z);
 
-                        synchronized (nmsWorld) {
-                            BlockEntity tileEntity = nmsWorld.getBlockEntity(pos);
-                            if (tileEntity == null || tileEntity.isRemoved()) {
-                                nmsWorld.removeBlockEntity(pos);
-                                tileEntity = nmsWorld.getBlockEntity(pos);
+                        Runnable setTile = () -> {
+                            synchronized (nmsChunk) {
+                                BlockEntity tileEntity = nmsChunk.getBlockEntity(pos);
+                                if (tileEntity == null || tileEntity.isRemoved()) {
+                                    nmsChunk.removeBlockEntity(pos);
+                                    tileEntity = nmsChunk.getBlockEntity(pos);
+                                }
+                                if (tileEntity != null) {
+                                    CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
+                                    tag.put("x", IntTag.valueOf(x));
+                                    tag.put("y", IntTag.valueOf(y));
+                                    tag.put("z", IntTag.valueOf(z));
+                                    ValueInput input = createInput(tag);
+                                    tileEntity.loadWithComponents(input);
+                                }
                             }
-                            if (tileEntity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
-                                tag.put("x", IntTag.valueOf(x));
-                                tag.put("y", IntTag.valueOf(y));
-                                tag.put("z", IntTag.valueOf(z));
-                                // TODO (VI/O)
-                                ValueInput input = createInput(tag);
-                                tileEntity.loadWithComponents(input);
-                            }
+                        };
+
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, setTile);
+                        } else {
+                            setTile.run();
                         }
                     }
                 });

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightPlatformAdapter.java
@@ -9,6 +9,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
@@ -20,6 +21,7 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.util.MCUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
@@ -330,10 +332,22 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     private static void addTicket(ServerLevel serverLevel, int chunkX, int chunkZ) {
-        // Ensure chunk is definitely loaded before applying a ticket
-        io.papermc.paper.util.MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel
-                .getChunkSource()
-                .addTicketWithRadius(ChunkHolderManager.UNLOAD_COOLDOWN, new ChunkPos(chunkX, chunkZ), 0));
+        ChunkPos pos = new ChunkPos(chunkX, chunkZ);
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                serverLevel.getChunkSource().addTicketWithRadius(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0);
+            } catch (Exception ignored) {
+            }
+            return;
+        }
+        try {
+            MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel.getChunkSource().addTicketWithRadius(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0));
+        } catch (Exception e) {
+            try {
+                serverLevel.getChunkSource().addTicketWithRadius(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0);
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     public static ChunkHolder getPlayerChunk(ServerLevel nmsWorld, final int chunkX, final int chunkZ) {
@@ -351,13 +365,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (chunkHolder == null) {
             return;
         }
-        LevelChunk levelChunk;
-        if (PaperLib.isPaper()) {
-            // getChunkAtIfLoadedImmediately is paper only
-            levelChunk = nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ);
-        } else {
-            levelChunk = chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
-        }
+        LevelChunk levelChunk = PaperLib.isPaper()
+                ? nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ)
+                : chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
         if (levelChunk == null) {
             return;
         }
@@ -366,32 +376,37 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (lockHolder.chunkLock == null) {
             return;
         }
-        MinecraftServer.getServer().execute(() -> {
+
+        ChunkPos pos = levelChunk.getPos();
+        ClientboundLevelChunkWithLightPacket packet = PaperLib.isPaper()
+                ? new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null, false)
+                : new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null);
+
+        Runnable sendPacket = () -> nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+
+        if (FoliaUtil.isFoliaServer()) {
             try {
-                ChunkPos pos = levelChunk.getPos();
-                ClientboundLevelChunkWithLightPacket packet;
-                if (PaperLib.isPaper()) {
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getLightEngine(),
-                            null,
-                            null,
-                            false // last false is to not bother with x-ray
-                    );
-                } else {
-                    // deprecated on paper - deprecation suppressed
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getLightEngine(),
-                            null,
-                            null
-                    );
-                }
-                nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+                sendPacket.run();
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }
-        });
+        } else {
+            try {
+                MinecraftServer.getServer().execute(() -> {
+                    try {
+                        sendPacket.run();
+                    } finally {
+                        NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                    }
+                });
+            } catch (Exception e) {
+                try {
+                    sendPacket.run();
+                } finally {
+                    NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                }
+            }
+        }
     }
 
     private static List<ServerPlayer> nearbyPlayers(ServerLevel serverLevel, ChunkPos coordIntPair) {
@@ -653,8 +668,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {
         try {
+            Map<BlockPos, BlockEntity> blockEntities = levelChunk.getBlockEntities();
             if (levelChunk.loaded || levelChunk.level.isClientSide()) {
-                BlockEntity blockEntity = levelChunk.blockEntities.remove(beacon.getBlockPos());
+                BlockEntity blockEntity = blockEntities.remove(beacon.getBlockPos());
                 if (blockEntity != null) {
                     if (!levelChunk.level.isClientSide) {
                         methodRemoveGameEventListener.invoke(levelChunk, beacon, levelChunk.level);

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/regen/PaperweightRegen.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Lifecycle;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -41,6 +42,8 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -206,7 +209,50 @@ public class PaperweightRegen extends Regenerator {
         if (paperConfigField != null) {
             paperConfigField.set(freshWorld, originalServerWorld.paperConfig());
         }
+
+        if (FoliaUtil.isFoliaServer()) {
+            return initWorldForFolia(newWorldData);
+        }
+
         return true;
+    }
+
+    private boolean initWorldForFolia(PrimaryLevelData worldData) throws ExecutionException, InterruptedException {
+        MinecraftServer console = ((CraftServer) Bukkit.getServer()).getServer();
+
+        ChunkPos spawnChunk = new ChunkPos(
+                freshWorld.getChunkSource().randomState().sampler().findSpawnPosition()
+        );
+
+        setRandomSpawnSelection(spawnChunk);
+
+        CompletableFuture<Boolean> initFuture = new CompletableFuture<>();
+
+        Bukkit.getServer().getRegionScheduler().run(
+                WorldEditPlugin.getInstance(),
+                freshWorld.getWorld(),
+                spawnChunk.x, spawnChunk.z,
+                task -> {
+                    try {
+                        console.initWorld(freshWorld, worldData, worldData, worldData.worldGenOptions());
+                        initFuture.complete(true);
+                    } catch (Exception e) {
+                        initFuture.completeExceptionally(e);
+                    }
+                }
+        );
+
+        return initFuture.get();
+    }
+
+    private void setRandomSpawnSelection(ChunkPos spawnChunk) {
+        try {
+            Field randomSpawnField = ServerLevel.class.getDeclaredField("randomSpawnSelection");
+            randomSpawnField.setAccessible(true);
+            randomSpawnField.set(freshWorld, spawnChunk);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set randomSpawnSelection for Folia world initialization", e);
+        }
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightFaweAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightFaweAdapter.java
@@ -10,6 +10,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IBatchProcessor;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.google.common.base.Preconditions;
@@ -21,6 +22,7 @@ import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.adapter.BukkitImplAdapter;
 import com.sk89q.worldedit.bukkit.adapter.ext.fawe.v1_21_9.PaperweightAdapter;
 import com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_9.regen.PaperweightRegen;
@@ -54,6 +56,7 @@ import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.item.ItemType;
 import com.sk89q.worldedit.world.registry.BlockMaterial;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
@@ -131,6 +134,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -353,24 +358,45 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
     public BaseEntity getEntity(org.bukkit.entity.Entity entity) {
         Preconditions.checkNotNull(entity);
 
-        CraftEntity craftEntity = ((CraftEntity) entity);
-        Entity mcEntity = craftEntity.getHandle();
-
-        String id = getEntityId(mcEntity);
+        String id = entity.getType().getKey().toString();
         EntityType type = com.sk89q.worldedit.world.entity.EntityTypes.get(id);
         Supplier<LinCompoundTag> saveTag = () -> {
-            final net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
-            if (!readEntityIntoTag(mcEntity, minecraftTag)) {
+            net.minecraft.nbt.CompoundTag minecraftTag = new net.minecraft.nbt.CompoundTag();
+            Entity mcEntity;
+
+            if (FoliaUtil.isFoliaServer()) {
+                CompletableFuture<Entity> handleFuture = new CompletableFuture<>();
+                entity.getScheduler().run(
+                        WorldEditPlugin.getInstance(),
+                        (ScheduledTask task) -> {
+                            try {
+                                handleFuture.complete(((CraftEntity) entity).getHandle());
+                            } catch (Throwable t) {
+                                handleFuture.completeExceptionally(t);
+                            }
+                        },
+                        () -> handleFuture.completeExceptionally(new CancellationException("Entity scheduler task cancelled"))
+                );
+                try {
+                    mcEntity = handleFuture.join();
+                } catch (Throwable t) {
+                    LOGGER.error("Failed to safely get NMS handle for {}", id, t);
+                    return null;
+                }
+            } else {
+                mcEntity = ((CraftEntity) entity).getHandle();
+            }
+
+            if (mcEntity == null || !readEntityIntoTag(mcEntity, minecraftTag)) {
                 return null;
             }
-            //add Id for AbstractChangeSet to work
-            final LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
-            final Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
+
+            LinCompoundTag tag = (LinCompoundTag) toNativeLin(minecraftTag);
+            Map<String, LinTag<?>> tags = NbtUtils.getLinCompoundTagValues(tag);
             tags.put("Id", LinStringTag.of(id));
             return LinCompoundTag.of(tags);
         };
         return new LazyBaseEntity(type, saveTag);
-
     }
 
     @Override
@@ -557,20 +583,62 @@ public final class PaperweightFaweAdapter extends FaweAdapter<net.minecraft.nbt.
 
     @Override
     protected void preCaptureStates(final ServerLevel serverLevel) {
-        serverLevel.captureTreeGeneration = true;
-        serverLevel.captureBlockStates = true;
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
 
     @Override
     protected List<org.bukkit.block.BlockState> getCapturedBlockStatesCopy(final ServerLevel serverLevel) {
-        return new ArrayList<>(serverLevel.capturedBlockStates.values());
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            return capturedStates != null ? new ArrayList<>(capturedStates.values()) : new ArrayList<>();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return new ArrayList<>();
+        }
     }
 
     @Override
     protected void postCaptureBlockStates(final ServerLevel serverLevel) {
-        serverLevel.captureBlockStates = false;
-        serverLevel.captureTreeGeneration = false;
-        serverLevel.capturedBlockStates.clear();
+        try {
+            Field captureBlockField = ServerLevel.class.getDeclaredField("captureBlockStates");
+            captureBlockField.setAccessible(true);
+            captureBlockField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field captureTreeField = ServerLevel.class.getDeclaredField("captureTreeGeneration");
+            captureTreeField.setAccessible(true);
+            captureTreeField.setBoolean(serverLevel, false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
+        try {
+            Field capturedStatesField = ServerLevel.class.getDeclaredField("capturedBlockStates");
+            capturedStatesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<BlockPos, org.bukkit.block.BlockState> capturedStates = (Map<BlockPos, org.bukkit.block.BlockState>) capturedStatesField.get(serverLevel);
+            if (capturedStates != null) {
+                capturedStates.clear();
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // Unable to read captureTreeGeneration field
+        }
     }
     @Override
     public boolean generateFeature(ConfiguredFeatureType feature, World world, EditSession editSession, BlockVector3 pt) {

--- a/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightFaweWorldNativeAccess.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightFaweWorldNativeAccess.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.redstone.ExperimentalRedstoneUtils;
 import net.minecraft.world.level.storage.ValueInput;
+import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
 import org.bukkit.event.block.BlockPhysicsEvent;
@@ -62,7 +63,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
         this.level = level;
         // Use the actual tick as minecraft-defined so we don't try to force blocks into the world when the server's already lagging.
         //  - With the caveat that we don't want to have too many cached changed (1024) so we'd flush those at 1024 anyway.
-        this.lastTick = new AtomicInteger(MinecraftServer.currentTick);
+        this.lastTick = new AtomicInteger(getCurrentTick());
     }
 
     private Level getLevel() {
@@ -98,7 +99,7 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             LevelChunk levelChunk, BlockPos blockPos,
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
-        int currentTick = MinecraftServer.currentTick;
+        int currentTick = getCurrentTick();
         if (Fawe.isMainThread()) {
             return levelChunk.setBlockState(blockPos, blockState,
                     this.sideEffectSet.shouldApply(SideEffect.UPDATE) ? 0 : 512
@@ -294,6 +295,18 @@ public class PaperweightFaweWorldNativeAccess implements WorldNativeAccess<Level
             net.minecraft.world.level.block.state.BlockState blockState
     ) {
 
+    }
+
+    private int getCurrentTick() {
+        try {
+            return MinecraftServer.currentTick;
+        } catch (NoSuchFieldError e) {
+            try {
+                return Bukkit.getCurrentTick();
+            } catch (Exception ex) {
+                return 0;
+            }
+        }
     }
 
 }

--- a/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightGetBlocks.java
@@ -11,6 +11,7 @@ import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkSet;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.NbtUtils;
 import com.fastasyncworldedit.core.util.collection.AdaptedMap;
@@ -23,6 +24,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
 import io.papermc.paper.event.block.BeaconDeactivatedEvent;
@@ -58,6 +60,8 @@ import net.minecraft.world.level.lighting.LevelLightEngine;
 import net.minecraft.world.level.storage.TagValueOutput;
 import net.minecraft.world.level.storage.ValueInput;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.CraftBlock;
@@ -198,23 +202,30 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
+        try {
+            BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
+                    chunkX << 4), y, (z & 15) + (
+                    chunkZ << 4)));
+            if (blockEntity == null) {
+                return null;
+            }
+            return NMS_TO_TILE.apply(blockEntity);
+        } catch (NullPointerException e) {
             return null;
         }
-        return NMS_TO_TILE.apply(blockEntity);
-
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
+        try {
+            Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
+            if (nmsTiles.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        } catch (NullPointerException e) {
             return Collections.emptyMap();
         }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override
@@ -322,7 +333,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     }
 
     private void removeEntity(Entity entity) {
-        entity.discard();
+        if (FoliaUtil.isFoliaServer()) {
+            entity.getBukkitEntity().getScheduler().execute(
+                WorldEditPlugin.getInstance(),
+                () -> {
+                    if (!entity.isRemoved()) {
+                        entity.discard();
+                    }
+                },
+                null,
+                1L
+            );
+        } else if (!entity.isRemoved()) {
+            entity.discard();
+        }
     }
 
     @Override
@@ -350,11 +374,11 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         List<BlockEntity> beacons = null;
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
-                final BlockPos pos = entry.getKey();
-                final int lx = pos.getX() & 15;
-                final int ly = pos.getY();
-                final int lz = pos.getZ() & 15;
-                final int layer = ly >> 4;
+                BlockPos pos = entry.getKey();
+                int lx = pos.getX() & 15;
+                int ly = pos.getY();
+                int lz = pos.getZ() & 15;
+                int layer = ly >> 4;
                 if (!set.hasSection(layer)) {
                     continue;
                 }
@@ -362,12 +386,26 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 int ordinal = set.getBlock(lx, ly, lz).getOrdinal();
                 if (ordinal != BlockTypesCache.ReservedIDs.__RESERVED__) {
                     BlockEntity tile = entry.getValue();
-                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity) {
+                    if (PaperLib.isPaper() && tile instanceof BeaconBlockEntity beacon) {
                         if (beacons == null) {
                             beacons = new ArrayList<>();
                         }
-                        beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
+                        beacons.add(beacon);
+                        Location location = new Location(
+                                nmsWorld.getWorld(),
+                                beacon.getBlockPos().getX(),
+                                beacon.getBlockPos().getY(),
+                                beacon.getBlockPos().getZ()
+                        );
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(
+                                    WorldEditPlugin.getInstance(),
+                                    location,
+                                    () -> PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk)
+                            );
+                        } else {
+                            PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
+                        }
                         continue;
                     }
                     nmsChunk.removeBlockEntity(tile.getBlockPos());
@@ -377,7 +415,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 }
             }
         }
-        final BiomeType[][] biomes = set.getBiomes();
+        BiomeType[][] biomes = set.getBiomes();
 
         int bitMask = 0;
         synchronized (nmsChunk) {
@@ -595,8 +633,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // Call beacon deactivate events here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
-                final List<BlockEntity> finalBeacons = beacons;
-
+                List<BlockEntity> finalBeacons = beacons;
                 syncTasks.add(() -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
@@ -607,10 +644,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
             Set<UUID> entityRemoves = set.getEntityRemoves();
             if (entityRemoves != null && !entityRemoves.isEmpty()) {
-
                 syncTasks.add(() -> {
                     Set<UUID> entitiesRemoved = new HashSet<>();
-                    final List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
+                    List<Entity> entities = PaperweightPlatformAdapter.getEntities(nmsChunk);
 
                     for (Entity entity : entities) {
                         UUID uuid = entity.getUUID();
@@ -639,32 +675,31 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
             Collection<FaweCompoundTag> entities = set.entities();
             if (entities != null && !entities.isEmpty()) {
-
                 syncTasks.add(() -> {
                     Iterator<FaweCompoundTag> iterator = entities.iterator();
                     while (iterator.hasNext()) {
-                        final FaweCompoundTag nativeTag = iterator.next();
-                        final LinCompoundTag linTag = nativeTag.linTag();
-                        final LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
-                        final LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
-                        final LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
+                        FaweCompoundTag nativeTag = iterator.next();
+                        LinCompoundTag linTag = nativeTag.linTag();
+                        LinStringTag idTag = linTag.findTag("Id", LinTagType.stringTag());
+                        LinListTag<LinDoubleTag> posTag = linTag.findListTag("Pos", LinTagType.doubleTag());
+                        LinListTag<LinFloatTag> rotTag = linTag.findListTag("Rotation", LinTagType.floatTag());
                         if (idTag == null || posTag == null || rotTag == null) {
                             LOGGER.error("Unknown entity tag: {}", nativeTag);
                             continue;
                         }
-                        final double x = posTag.get(0).valueAsDouble();
-                        final double y = posTag.get(1).valueAsDouble();
-                        final double z = posTag.get(2).valueAsDouble();
-                        final float yaw = rotTag.get(0).valueAsFloat();
-                        final float pitch = rotTag.get(1).valueAsFloat();
-                        final String id = idTag.value();
+                        double x = posTag.get(0).valueAsDouble();
+                        double y = posTag.get(1).valueAsDouble();
+                        double z = posTag.get(2).valueAsDouble();
+                        float yaw = rotTag.get(0).valueAsFloat();
+                        float pitch = rotTag.get(1).valueAsFloat();
+                        String id = idTag.value();
 
                         EntityType<?> type = EntityType.byString(id).orElse(null);
                         if (type != null) {
                             Entity entity = type.create(nmsWorld, EntitySpawnReason.COMMAND);
                             if (entity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
-                                for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
+                                CompoundTag tag = (CompoundTag) adapter.fromNativeLin(linTag);
+                                for (String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
                                     tag.remove(name);
                                 }
                                 // TODO (VI/O)
@@ -672,17 +707,33 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                                 entity.load(input);
                                 entity.absSnapTo(x, y, z, yaw, pitch);
                                 entity.setUUID(NbtUtils.uuid(nativeTag));
-                                if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
-                                    LOGGER.warn(
-                                            "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
-                                            id,
-                                            nmsWorld.getWorld().getName(),
-                                            x,
-                                            y,
-                                            z
-                                    );
-                                    // Unsuccessful create should not be saved to history
-                                    iterator.remove();
+                                Location location = new Location(nmsWorld.getWorld(), x, y, z);
+                                if (FoliaUtil.isFoliaServer()) {
+                                    Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, () -> {
+                                        if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                            LOGGER.warn(
+                                                    "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                    id,
+                                                    nmsWorld.getWorld().getName(),
+                                                    x,
+                                                    y,
+                                                    z
+                                            );
+                                            iterator.remove();
+                                        }
+                                    });
+                                } else {
+                                    if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
+                                        LOGGER.warn(
+                                                "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                                id,
+                                                nmsWorld.getWorld().getName(),
+                                                x,
+                                                y,
+                                                z
+                                        );
+                                        iterator.remove();
+                                    }
                                 }
                             }
                         }
@@ -693,31 +744,39 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             // set tiles
             Map<BlockVector3, FaweCompoundTag> tiles = set.tiles();
             if (tiles != null && !tiles.isEmpty()) {
-
                 syncTasks.add(() -> {
-                    for (final Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
-                        final FaweCompoundTag nativeTag = entry.getValue();
-                        final BlockVector3 blockHash = entry.getKey();
-                        final int x = blockHash.x() + bx;
-                        final int y = blockHash.y();
-                        final int z = blockHash.z() + bz;
-                        final BlockPos pos = new BlockPos(x, y, z);
+                    World world = nmsWorld.getWorld();
+                    for (Map.Entry<BlockVector3, FaweCompoundTag> entry : tiles.entrySet()) {
+                        FaweCompoundTag nativeTag = entry.getValue();
+                        BlockVector3 blockHash = entry.getKey();
+                        int x = blockHash.x() + bx;
+                        int y = blockHash.y();
+                        int z = blockHash.z() + bz;
+                        BlockPos pos = new BlockPos(x, y, z);
+                        Location location = new Location(world, x, y, z);
 
-                        synchronized (nmsWorld) {
-                            BlockEntity tileEntity = nmsWorld.getBlockEntity(pos);
-                            if (tileEntity == null || tileEntity.isRemoved()) {
-                                nmsWorld.removeBlockEntity(pos);
-                                tileEntity = nmsWorld.getBlockEntity(pos);
+                        Runnable setTile = () -> {
+                            synchronized (nmsChunk) {
+                                BlockEntity tileEntity = nmsChunk.getBlockEntity(pos);
+                                if (tileEntity == null || tileEntity.isRemoved()) {
+                                    nmsChunk.removeBlockEntity(pos);
+                                    tileEntity = nmsChunk.getBlockEntity(pos);
+                                }
+                                if (tileEntity != null) {
+                                    CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
+                                    tag.put("x", IntTag.valueOf(x));
+                                    tag.put("y", IntTag.valueOf(y));
+                                    tag.put("z", IntTag.valueOf(z));
+                                    ValueInput input = createInput(tag);
+                                    tileEntity.loadWithComponents(input);
+                                }
                             }
-                            if (tileEntity != null) {
-                                final CompoundTag tag = (CompoundTag) adapter.fromNativeLin(nativeTag.linTag());
-                                tag.put("x", IntTag.valueOf(x));
-                                tag.put("y", IntTag.valueOf(y));
-                                tag.put("z", IntTag.valueOf(z));
-                                // TODO (VI/O)
-                                ValueInput input = createInput(tag);
-                                tileEntity.loadWithComponents(input);
-                            }
+                        };
+
+                        if (FoliaUtil.isFoliaServer()) {
+                            Bukkit.getServer().getRegionScheduler().execute(WorldEditPlugin.getInstance(), location, setTile);
+                        } else {
+                            setTile.run();
                         }
                     }
                 });
@@ -729,15 +788,13 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             } else {
                 int finalMask = bitMask != 0 ? bitMask : lightUpdate ? set.getBitMask() : 0;
                 syncTasks.add(() -> {
-                    // Set Modified
                     nmsChunk.setLightCorrect(true);
                     nmsChunk.mustNotSave = false;
                 });
                 callback = () -> {
-                    // send to player
-                    if (!set
-                            .getSideEffectSet()
-                            .shouldApply(SideEffect.LIGHTING) || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING || finalMask == 0 && biomes != null) {
+                    if (!set.getSideEffectSet().shouldApply(SideEffect.LIGHTING)
+                            || !Settings.settings().LIGHTING.DELAY_PACKET_SENDING
+                            || finalMask == 0 && biomes != null) {
                         this.send();
                     }
                     if (finalizer != null) {

--- a/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightPlatformAdapter.java
@@ -9,6 +9,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.FaweCache;
 import com.fastasyncworldedit.core.math.BitArrayUnstretched;
 import com.fastasyncworldedit.core.math.IntPair;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MathMan;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.mojang.serialization.DataResult;
@@ -21,6 +22,7 @@ import com.sk89q.worldedit.world.biome.BiomeTypes;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
 import io.papermc.lib.PaperLib;
+import io.papermc.paper.util.MCUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMap;
@@ -70,6 +72,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -337,10 +340,22 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
     }
 
     private static void addTicket(ServerLevel serverLevel, int chunkX, int chunkZ) {
-        // Ensure chunk is definitely loaded before applying a ticket
-        io.papermc.paper.util.MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel
-                .getChunkSource()
-                .addTicketWithRadius(ChunkHolderManager.UNLOAD_COOLDOWN, new ChunkPos(chunkX, chunkZ), 0));
+        ChunkPos pos = new ChunkPos(chunkX, chunkZ);
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                serverLevel.getChunkSource().addTicketWithRadius(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0);
+            } catch (Exception ignored) {
+            }
+            return;
+        }
+        try {
+            MCUtil.MAIN_EXECUTOR.execute(() -> serverLevel.getChunkSource().addTicketWithRadius(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0));
+        } catch (Exception e) {
+            try {
+                serverLevel.getChunkSource().addTicketWithRadius(ChunkHolderManager.UNLOAD_COOLDOWN, pos, 0);
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     public static ChunkHolder getPlayerChunk(ServerLevel nmsWorld, final int chunkX, final int chunkZ) {
@@ -358,13 +373,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (chunkHolder == null) {
             return;
         }
-        LevelChunk levelChunk;
-        if (PaperLib.isPaper()) {
-            // getChunkAtIfLoadedImmediately is paper only
-            levelChunk = nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ);
-        } else {
-            levelChunk = chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
-        }
+        LevelChunk levelChunk = PaperLib.isPaper()
+                ? nmsWorld.getChunkSource().getChunkAtIfLoadedImmediately(chunkX, chunkZ)
+                : chunkHolder.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
         if (levelChunk == null) {
             return;
         }
@@ -373,32 +384,37 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
         if (lockHolder.chunkLock == null) {
             return;
         }
-        MinecraftServer.getServer().execute(() -> {
+
+        ChunkPos pos = levelChunk.getPos();
+        ClientboundLevelChunkWithLightPacket packet = PaperLib.isPaper()
+                ? new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null, false)
+                : new ClientboundLevelChunkWithLightPacket(levelChunk, nmsWorld.getLightEngine(), null, null);
+
+        Runnable sendPacket = () -> nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+
+        if (FoliaUtil.isFoliaServer()) {
             try {
-                ChunkPos pos = levelChunk.getPos();
-                ClientboundLevelChunkWithLightPacket packet;
-                if (PaperLib.isPaper()) {
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getLightEngine(),
-                            null,
-                            null,
-                            false // last false is to not bother with x-ray
-                    );
-                } else {
-                    // deprecated on paper - deprecation suppressed
-                    packet = new ClientboundLevelChunkWithLightPacket(
-                            levelChunk,
-                            nmsWorld.getLightEngine(),
-                            null,
-                            null
-                    );
-                }
-                nearbyPlayers(nmsWorld, pos).forEach(p -> p.connection.send(packet));
+                sendPacket.run();
             } finally {
                 NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
             }
-        });
+        } else {
+            try {
+                MinecraftServer.getServer().execute(() -> {
+                    try {
+                        sendPacket.run();
+                    } finally {
+                        NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                    }
+                });
+            } catch (Exception e) {
+                try {
+                    sendPacket.run();
+                } finally {
+                    NMSAdapter.endChunkPacketSend(nmsWorld.getWorld().getName(), pair, lockHolder);
+                }
+            }
+        }
     }
 
     private static List<ServerPlayer> nearbyPlayers(ServerLevel serverLevel, ChunkPos coordIntPair) {
@@ -612,8 +628,9 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
 
     static void removeBeacon(BlockEntity beacon, LevelChunk levelChunk) {
         try {
+            Map<BlockPos, BlockEntity> blockEntities = levelChunk.getBlockEntities();
             if (levelChunk.loaded || levelChunk.level.isClientSide()) {
-                BlockEntity blockEntity = levelChunk.blockEntities.remove(beacon.getBlockPos());
+                BlockEntity blockEntity = blockEntities.remove(beacon.getBlockPos());
                 if (blockEntity != null) {
                     if (!levelChunk.level.isClientSide()) {
                         methodRemoveGameEventListener.invoke(levelChunk, beacon, levelChunk.level);

--- a/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/regen/PaperweightRegen.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/regen/PaperweightRegen.java
@@ -5,6 +5,7 @@ import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.queue.IChunkCache;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Lifecycle;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -20,6 +21,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.ProgressListener;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelSettings;
 import net.minecraft.world.level.biome.Biome;
@@ -39,6 +41,8 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -203,7 +207,50 @@ public class PaperweightRegen extends Regenerator {
         if (paperConfigField != null) {
             paperConfigField.set(freshWorld, originalServerWorld.paperConfig());
         }
+
+        if (FoliaUtil.isFoliaServer()) {
+            return initWorldForFolia(newWorldData);
+        }
+
         return true;
+    }
+
+    private boolean initWorldForFolia(PrimaryLevelData worldData) throws ExecutionException, InterruptedException {
+        MinecraftServer console = ((CraftServer) Bukkit.getServer()).getServer();
+
+        ChunkPos spawnChunk = new ChunkPos(
+                freshWorld.getChunkSource().randomState().sampler().findSpawnPosition()
+        );
+
+        setRandomSpawnSelection(spawnChunk);
+
+        CompletableFuture<Boolean> initFuture = new CompletableFuture<>();
+
+        Bukkit.getServer().getRegionScheduler().run(
+                WorldEditPlugin.getInstance(),
+                freshWorld.getWorld(),
+                spawnChunk.x, spawnChunk.z,
+                task -> {
+                    try {
+                        console.initWorld(freshWorld, worldData, worldData.worldGenOptions());
+                        initFuture.complete(true);
+                    } catch (Exception e) {
+                        initFuture.completeExceptionally(e);
+                    }
+                }
+        );
+
+        return initFuture.get();
+    }
+
+    private void setRandomSpawnSelection(ChunkPos spawnChunk) {
+        try {
+            Field randomSpawnField = ServerLevel.class.getDeclaredField("randomSpawnSelection");
+            randomSpawnField.setAccessible(true);
+            randomSpawnField.set(freshWorld, spawnChunk);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to set randomSpawnSelection for Folia world initialization", e);
+        }
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/IBukkitAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/IBukkitAdapter.java
@@ -1,6 +1,7 @@
 package com.fastasyncworldedit.bukkit.adapter;
 
 import com.fastasyncworldedit.bukkit.util.BukkitItemStack;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.NotABlockException;
@@ -388,7 +389,9 @@ public interface IBukkitAdapter {
      * @return list of {@link org.bukkit.entity.Entity}
      */
     default List<org.bukkit.entity.Entity> getEntities(org.bukkit.World world) {
-        return TaskManager.taskManager().sync(world::getEntities);
+        return FoliaUtil.isFoliaServer()
+                ? TaskManager.taskManager().syncWhenFree(world::getEntities)
+                : TaskManager.taskManager().sync(world::getEntities);
     }
 
     /**

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/FaweDelegateSchematicHandler.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/regions/plotsquared/FaweDelegateSchematicHandler.java
@@ -19,7 +19,7 @@ import com.plotsquared.core.plot.schematic.Schematic;
 import com.plotsquared.core.util.FileUtils;
 import com.plotsquared.core.util.SchematicHandler;
 import com.plotsquared.core.util.task.RunnableVal;
-import com.plotsquared.core.util.task.TaskManager;
+import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.jnbt.CompoundTag;
 import com.sk89q.jnbt.NBTInputStream;
 import com.sk89q.jnbt.NBTOutputStream;
@@ -91,7 +91,7 @@ public class FaweDelegateSchematicHandler {
             }
             if (schematic == null) {
                 if (whenDone != null) {
-                    TaskManager.runTask(whenDone);
+                    TaskManager.taskManager().task(whenDone);
                 }
                 return;
             }
@@ -110,14 +110,16 @@ public class FaweDelegateSchematicHandler {
                 if (actor != null) {
                     actor.sendMessage(TranslatableCaption.of("schematics.schematic_size_mismatch"));
                 }
-                TaskManager.runTask(whenDone);
+                if (whenDone != null) {
+                    TaskManager.taskManager().task(whenDone);
+                }
                 return;
             }
             if (((region.getMaximumPoint().x() - region.getMinimumPoint().x() + xOffset + 1) < WIDTH) || (
                     (region.getMaximumPoint().z() - region.getMinimumPoint().z() + zOffset + 1) < LENGTH) || (HEIGHT
                     > worldHeight)) {
                 if (whenDone != null) {
-                    TaskManager.runTask(whenDone);
+                    TaskManager.taskManager().task(whenDone);
                 }
                 return;
             }
@@ -158,7 +160,7 @@ public class FaweDelegateSchematicHandler {
                 clipboard.paste(editSession, to, true, false, true);
                 if (whenDone != null) {
                     whenDone.value = true;
-                    TaskManager.runTask(whenDone);
+                    TaskManager.taskManager().task(whenDone);
                 }
             }
         };
@@ -213,7 +215,7 @@ public class FaweDelegateSchematicHandler {
         if (tag == null) {
             LOGGER.warn("Cannot save empty tag");
             if (whenDone != null) {
-                TaskManager.runTask(whenDone);
+                TaskManager.taskManager().task(whenDone);
             }
             return;
         }

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/BukkitTaskManager.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/BukkitTaskManager.java
@@ -1,5 +1,6 @@
 package com.fastasyncworldedit.bukkit.util;
 
+import com.fastasyncworldedit.bukkit.util.scheduler.Scheduler;
 import com.fastasyncworldedit.core.util.TaskManager;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
@@ -9,45 +10,53 @@ import javax.annotation.Nonnull;
 public class BukkitTaskManager extends TaskManager {
 
     private final Plugin plugin;
+    private final Scheduler scheduler;
 
-    public BukkitTaskManager(final Plugin plugin) {
+    public BukkitTaskManager(final Plugin plugin, final Scheduler scheduler) {
         this.plugin = plugin;
+        this.scheduler = scheduler;
     }
 
     @Override
     public int repeat(@Nonnull final Runnable runnable, final int interval) {
-        return this.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(this.plugin, runnable, interval, interval);
+        this.scheduler.runTaskTimer(this.plugin, runnable, interval, interval);
+        return 0;
     }
 
     @Override
     public int repeatAsync(@Nonnull final Runnable runnable, final int interval) {
-        return this.plugin.getServer().getScheduler().scheduleAsyncRepeatingTask(this.plugin, runnable, interval, interval);
+        this.scheduler.runTaskTimer(this.plugin, runnable, interval, interval);
+        return 0;
     }
 
     @Override
     public void async(@Nonnull final Runnable runnable) {
-        this.plugin.getServer().getScheduler().runTaskAsynchronously(this.plugin, runnable).getTaskId();
+        this.scheduler.runTaskAsynchronously(this.plugin, runnable);
     }
 
     @Override
     public void task(@Nonnull final Runnable runnable) {
-        this.plugin.getServer().getScheduler().runTask(this.plugin, runnable).getTaskId();
+        this.scheduler.runTask(this.plugin, runnable);
     }
 
     @Override
     public void later(@Nonnull final Runnable runnable, final int delay) {
-        this.plugin.getServer().getScheduler().runTaskLater(this.plugin, runnable, delay).getTaskId();
+        this.scheduler.runTaskLater(this.plugin, runnable, delay);
     }
 
     @Override
     public void laterAsync(@Nonnull final Runnable runnable, final int delay) {
-        this.plugin.getServer().getScheduler().runTaskLaterAsynchronously(this.plugin, runnable, delay);
+        this.scheduler.runTaskLaterAsynchronously(this.plugin, runnable, delay);
     }
 
     @Override
     public void cancel(final int task) {
         if (task != -1) {
-            Bukkit.getScheduler().cancelTask(task);
+            try {
+                Bukkit.getScheduler().cancelTask(task);
+            } catch (Exception e) {
+                // Ignore errors on Folia - task cancellation by ID is not supported
+            }
         }
     }
 

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/scheduler/BukkitScheduler.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/scheduler/BukkitScheduler.java
@@ -1,0 +1,187 @@
+package com.fastasyncworldedit.bukkit.util.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Bukkit implementation of the Scheduler interface.
+ */
+public record BukkitScheduler(Plugin plugin) implements Scheduler {
+
+    @Override
+    public void runTaskTimer(Plugin plugin, Runnable runnable, long delay, long period) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTaskTimer(plugin, runnable, delay, period);
+    }
+
+    @Override
+    public void runTask(Plugin plugin, Runnable runnable) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTask(plugin, runnable);
+    }
+
+    @Override
+    public void runTaskAsynchronously(Plugin plugin, Runnable runnable) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, runnable);
+    }
+
+    @Override
+    public void runTaskLater(Plugin plugin, Runnable runnable, long delay) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTaskLater(plugin, runnable, delay);
+    }
+
+    @Override
+    public void runTaskLaterAsynchronously(Plugin plugin, Runnable runnable, long delay) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTaskLaterAsynchronously(plugin, runnable, delay);
+    }
+
+    @Override
+    public void runTaskTimer(Runnable runnable, long delay, long period) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTaskTimer(plugin, runnable, delay, period);
+    }
+
+    @Override
+    public void runTask(Runnable runnable) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTask(plugin, runnable);
+    }
+
+    @Override
+    public void runTaskAsynchronously(Runnable runnable) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, runnable);
+    }
+
+    @Override
+    public void runTaskLater(Runnable runnable, long delay) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTaskLater(plugin, runnable, delay);
+    }
+
+    @Override
+    public void runTaskLaterAsynchronously(Runnable runnable, long delay) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().runTaskLaterAsynchronously(plugin, runnable, delay);
+    }
+
+    @Override
+    public void scheduleSyncDelayedTask(Plugin plugin, Runnable runnable, long delay) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, runnable, delay);
+    }
+
+    @Override
+    public CancellableTask runTaskCancellable(Plugin plugin, Runnable runnable) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        BukkitTask task = plugin.getServer().getScheduler().runTask(plugin, runnable);
+        return new BukkitCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskLaterCancellable(Plugin plugin, Runnable runnable, long delay) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        BukkitTask task = plugin.getServer().getScheduler().runTaskLater(plugin, runnable, delay);
+        return new BukkitCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskTimerCancellable(Plugin plugin, Runnable runnable, long delay, long period) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        BukkitTask task = plugin.getServer().getScheduler().runTaskTimer(plugin, runnable, delay, period);
+        return new BukkitCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskCancellable(Runnable runnable) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        BukkitTask task = plugin.getServer().getScheduler().runTask(plugin, runnable);
+        return new BukkitCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskLaterCancellable(Runnable runnable, long delay) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        BukkitTask task = plugin.getServer().getScheduler().runTaskLater(plugin, runnable, delay);
+        return new BukkitCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskTimerCancellable(Runnable runnable, long delay, long period) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        BukkitTask task = plugin.getServer().getScheduler().runTaskTimer(plugin, runnable, delay, period);
+        return new BukkitCancellableTask(task);
+    }
+
+    /**
+     * Wrapper for BukkitTask to implement CancellableTask interface.
+     */
+    private record BukkitCancellableTask(BukkitTask task) implements CancellableTask {
+
+        @Override
+        public void cancel() {
+            if (task != null) {
+                task.cancel();
+            }
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return task == null || task.isCancelled();
+        }
+    }
+}

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/scheduler/FoliaScheduler.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/scheduler/FoliaScheduler.java
@@ -1,0 +1,279 @@
+package com.fastasyncworldedit.bukkit.util.scheduler;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import org.bukkit.plugin.Plugin;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Folia implementation of the Scheduler interface.
+ */
+public record FoliaScheduler(Plugin plugin) implements Scheduler {
+
+    @Override
+    public void runTaskTimer(Plugin plugin, Runnable runnable, long delay, long period) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        if (delay < 0 || period < 0) {
+            throw new IllegalArgumentException("Delay and period must be non-negative");
+        }
+
+        if (delay == 0) {
+            plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+            if (period > 0) {
+                plugin.getServer().getGlobalRegionScheduler().runAtFixedRate(plugin, scheduledTask -> runnable.run(), (int) period, (int) period);
+            }
+        } else {
+            plugin.getServer().getGlobalRegionScheduler().runAtFixedRate(plugin, scheduledTask -> runnable.run(), (int) delay, (int) period);
+        }
+    }
+
+    @Override
+    public void runTask(Plugin plugin, Runnable runnable) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+    }
+
+    @Override
+    public void runTaskAsynchronously(Plugin plugin, Runnable runnable) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+        plugin.getServer().getAsyncScheduler().runNow(plugin, scheduledTask -> runnable.run());
+    }
+
+    @Override
+    public void runTaskLater(Plugin plugin, Runnable runnable, long delay) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        if (delay < 0) {
+            throw new IllegalArgumentException("Delay must be non-negative");
+        }
+
+        if (delay == 0) {
+            plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+        } else {
+            plugin.getServer().getGlobalRegionScheduler().runDelayed(plugin, scheduledTask -> runnable.run(), delay);
+        }
+    }
+
+    @Override
+    public void runTaskLaterAsynchronously(Plugin plugin, Runnable runnable, long delay) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        if (delay < 0) {
+            throw new IllegalArgumentException("Delay must be non-negative");
+        }
+
+        if (delay == 0) {
+            plugin.getServer().getAsyncScheduler().runNow(plugin, scheduledTask -> runnable.run());
+        } else {
+            // Convert ticks to milliseconds for async scheduler
+            long delayMs = delay * 50L;
+            plugin.getServer().getAsyncScheduler().runDelayed(plugin, scheduledTask -> runnable.run(), delayMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public void runTaskTimer(Runnable runnable, long delay, long period) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        if (delay < 0 || period < 0) {
+            throw new IllegalArgumentException("Delay and period must be non-negative");
+        }
+
+        plugin.getServer().getGlobalRegionScheduler().runAtFixedRate(plugin, scheduledTask -> runnable.run(), (int) delay, (int) period);
+    }
+
+    @Override
+    public void runTask(Runnable runnable) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+    }
+
+    @Override
+    public void runTaskAsynchronously(Runnable runnable) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        plugin.getServer().getAsyncScheduler().runNow(plugin, scheduledTask -> runnable.run());
+    }
+
+    @Override
+    public void runTaskLater(Runnable runnable, long delay) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        if (delay < 0) {
+            throw new IllegalArgumentException("Delay must be non-negative");
+        }
+
+        if (delay == 0) {
+            plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+        } else {
+            plugin.getServer().getGlobalRegionScheduler().runDelayed(plugin, scheduledTask -> runnable.run(), delay);
+        }
+    }
+
+    @Override
+    public void runTaskLaterAsynchronously(Runnable runnable, long delay) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        if (delay < 0) {
+            throw new IllegalArgumentException("Delay must be non-negative");
+        }
+
+        if (delay == 0) {
+            plugin.getServer().getAsyncScheduler().runNow(plugin, scheduledTask -> runnable.run());
+        } else {
+            // Convert ticks to milliseconds for async scheduler
+            long delayMs = delay * 50L;
+            plugin.getServer().getAsyncScheduler().runDelayed(plugin, scheduledTask -> runnable.run(), delayMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public void scheduleSyncDelayedTask(Plugin plugin, Runnable runnable, long delay) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        if (delay < 0) {
+            throw new IllegalArgumentException("Delay must be non-negative");
+        }
+
+        if (delay == 0) {
+            plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+        } else {
+            plugin.getServer().getGlobalRegionScheduler().runDelayed(plugin, scheduledTask -> runnable.run(), delay);
+        }
+    }
+
+    @Override
+    public CancellableTask runTaskCancellable(Plugin plugin, Runnable runnable) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+
+        ScheduledTask task = plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+        return new FoliaCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskLaterCancellable(Plugin plugin, Runnable runnable, long delay) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+        if (delay < 0) {
+            throw new IllegalArgumentException("Delay must be non-negative");
+        }
+
+        ScheduledTask task;
+        if (delay == 0) {
+            task = plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+        } else {
+            task = plugin.getServer().getGlobalRegionScheduler().runDelayed(plugin, scheduledTask -> runnable.run(), delay);
+        }
+
+        return new FoliaCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskTimerCancellable(Plugin plugin, Runnable runnable, long delay, long period) {
+        if (plugin == null || runnable == null) {
+            throw new IllegalArgumentException("Plugin and runnable cannot be null");
+        }
+        if (delay < 0 || period < 0) {
+            throw new IllegalArgumentException("Delay and period must be non-negative");
+        }
+
+        ScheduledTask task = plugin.getServer().getGlobalRegionScheduler().runAtFixedRate(plugin, scheduledTask -> runnable.run(), (int) delay, (int) period);
+        return new FoliaCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskCancellable(Runnable runnable) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+
+        ScheduledTask task = plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+        return new FoliaCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskLaterCancellable(Runnable runnable, long delay) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+        if (delay < 0) {
+            throw new IllegalArgumentException("Delay must be non-negative");
+        }
+        ScheduledTask task;
+        if (delay == 0) {
+            task = plugin.getServer().getGlobalRegionScheduler().run(plugin, scheduledTask -> runnable.run());
+        } else {
+            task = plugin.getServer().getGlobalRegionScheduler().runDelayed(plugin, scheduledTask -> runnable.run(), delay);
+        }
+
+        return new FoliaCancellableTask(task);
+    }
+
+    @Override
+    public CancellableTask runTaskTimerCancellable(Runnable runnable, long delay, long period) {
+        if (runnable == null) {
+            throw new IllegalArgumentException("Runnable cannot be null");
+        }
+        if (delay < 0 || period < 0) {
+            throw new IllegalArgumentException("Delay and period must be non-negative");
+        }
+        ScheduledTask task = plugin.getServer().getGlobalRegionScheduler().runAtFixedRate(plugin, scheduledTask -> runnable.run(), (int) delay, (int) period);
+        return new FoliaCancellableTask(task);
+    }
+
+    /**
+     * Wrapper for Folia's ScheduledTask to implement CancellableTask interface.
+     */
+    private static class FoliaCancellableTask implements CancellableTask {
+
+        private final ScheduledTask task;
+        private volatile boolean cancelled = false;
+
+        public FoliaCancellableTask(ScheduledTask task) {
+            this.task = task;
+        }
+
+        @Override
+        public void cancel() {
+            if (!cancelled) {
+                cancelled = true;
+                if (task != null) {
+                    task.cancel();
+                }
+            }
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled || (task != null && task.isCancelled());
+        }
+    }
+}

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/scheduler/Scheduler.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/scheduler/Scheduler.java
@@ -1,0 +1,176 @@
+package com.fastasyncworldedit.bukkit.util.scheduler;
+
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Unified scheduler interface that works across both Bukkit and Folia servers.
+ * This interface provides a consistent API for scheduling tasks regardless of the server type.
+ */
+public interface Scheduler {
+
+    /**
+     * Schedules a repeating task that runs on the main thread.
+     *
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     * @param delay The initial delay in ticks
+     * @param period The period between executions in ticks
+     */
+    void runTaskTimer(Plugin plugin, Runnable runnable, long delay, long period);
+
+    /**
+     * Schedules a task to run on the main thread.
+     *
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     */
+    void runTask(Plugin plugin, Runnable runnable);
+
+    /**
+     * Schedules a task to run asynchronously.
+     *
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     */
+    void runTaskAsynchronously(Plugin plugin, Runnable runnable);
+
+    /**
+     * Schedules a delayed task to run on the main thread.
+     *
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     * @param delay The delay in ticks
+     */
+    void runTaskLater(Plugin plugin, Runnable runnable, long delay);
+
+    /**
+     * Schedules a delayed task to run asynchronously.
+     *
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     * @param delay The delay in ticks
+     */
+    void runTaskLaterAsynchronously(Plugin plugin, Runnable runnable, long delay);
+
+    /**
+     * Schedules a repeating task that runs on the main thread (uses library plugin).
+     *
+     * @param runnable The task to run
+     * @param delay The initial delay in ticks
+     * @param period The period between executions in ticks
+     */
+    void runTaskTimer(Runnable runnable, long delay, long period);
+
+    /**
+     * Schedules a task to run on the main thread (uses library plugin).
+     *
+     * @param runnable The task to run
+     */
+    void runTask(Runnable runnable);
+
+    /**
+     * Schedules a task to run asynchronously (uses library plugin).
+     *
+     * @param runnable The task to run
+     */
+    void runTaskAsynchronously(Runnable runnable);
+
+    /**
+     * Schedules a delayed task to run on the main thread (uses library plugin).
+     *
+     * @param runnable The task to run
+     * @param delay The delay in ticks
+     */
+    void runTaskLater(Runnable runnable, long delay);
+
+    /**
+     * Schedules a delayed task to run asynchronously (uses library plugin).
+     *
+     * @param runnable The task to run
+     * @param delay The delay in ticks
+     */
+    void runTaskLaterAsynchronously(Runnable runnable, long delay);
+
+    /**
+     * Legacy method for scheduling a delayed sync task.
+     *
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     * @param delay The delay in ticks
+     */
+    void scheduleSyncDelayedTask(Plugin plugin, Runnable runnable, long delay);
+
+    /**
+     * Runs a task and returns a cancellable task instance.
+     *
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     * @return Cancellable task instance
+     */
+    CancellableTask runTaskCancellable(Plugin plugin, Runnable runnable);
+
+    /**
+     * Runs a delayed task and returns a cancellable task instance.
+     *
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     * @param delay The delay in ticks
+     * @return Cancellable task instance
+     */
+    CancellableTask runTaskLaterCancellable(Plugin plugin, Runnable runnable, long delay);
+
+    /**
+     * Runs a repeating task and returns a cancellable task instance.
+     *
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     * @param delay The initial delay in ticks
+     * @param period The period between executions in ticks
+     * @return Cancellable task instance
+     */
+    CancellableTask runTaskTimerCancellable(Plugin plugin, Runnable runnable, long delay, long period);
+
+    /**
+     * Runs a task and returns a cancellable task instance (uses library plugin).
+     *
+     * @param runnable The task to run
+     * @return Cancellable task instance
+     */
+    CancellableTask runTaskCancellable(Runnable runnable);
+
+    /**
+     * Runs a delayed task and returns a cancellable task instance (uses library plugin).
+     *
+     * @param runnable The task to run
+     * @param delay The delay in ticks
+     * @return Cancellable task instance
+     */
+    CancellableTask runTaskLaterCancellable(Runnable runnable, long delay);
+
+    /**
+     * Runs a repeating task and returns a cancellable task instance (uses library plugin).
+     *
+     * @param runnable The task to run
+     * @param delay The initial delay in ticks
+     * @param period The period between executions in ticks
+     * @return Cancellable task instance
+     */
+    CancellableTask runTaskTimerCancellable(Runnable runnable, long delay, long period);
+
+    /**
+     * Interface for cancellable tasks that work across both Bukkit and Folia.
+     */
+    interface CancellableTask {
+
+        /**
+         * Cancels this task.
+         */
+        void cancel();
+
+        /**
+         * Checks if this task is cancelled.
+         * @return true if cancelled, false otherwise
+         */
+        boolean isCancelled();
+    }
+}

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitBlockCommandSender.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldedit.bukkit;
 
+import com.fastasyncworldedit.bukkit.FaweBukkit;
+import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.extension.platform.AbstractCommandBlockActor;
@@ -196,13 +198,28 @@ public class BukkitBlockCommandSender extends AbstractCommandBlockActor {
                     updateActive();
                 } else {
                     // we should update it eventually
-                    Bukkit.getScheduler().callSyncMethod(
-                            plugin,
-                            () -> {
-                                updateActive();
-                                return null;
-                            }
-                    );
+                    try {
+                        FaweBukkit faweBukkit = Fawe.platform();
+                        if (faweBukkit != null && faweBukkit.getScheduler() != null) {
+                            faweBukkit.getScheduler().runTask(plugin, this::updateActive);
+                        } else {
+                            Bukkit.getScheduler().callSyncMethod(
+                                    plugin,
+                                    () -> {
+                                        updateActive();
+                                        return null;
+                                    }
+                            );
+                        }
+                    } catch (Exception e) {
+                        Bukkit.getScheduler().callSyncMethod(
+                                plugin,
+                                () -> {
+                                    updateActive();
+                                    return null;
+                                }
+                        );
+                    }
                 }
                 return active;
             }

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntityProperties.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntityProperties.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.bukkit;
 
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.sk89q.worldedit.entity.metadata.EntityProperties;
 import org.bukkit.entity.AbstractVillager;
 import org.bukkit.entity.Ambient;
@@ -148,12 +149,24 @@ class BukkitEntityProperties implements EntityProperties {
 
     @Override
     public boolean isTamed() {
-        return entity instanceof Tameable && ((Tameable) entity).isTamed();
+        if (!(entity instanceof Tameable)) {
+            return false;
+        }
+        if (FoliaUtil.isFoliaServer()) {
+            return false;
+        }
+        return ((Tameable) entity).isTamed();
     }
 
     @Override
     public boolean isTagged() {
-        return entity instanceof LivingEntity && entity.getCustomName() != null;
+        if (!(entity instanceof LivingEntity)) {
+            return false;
+        }
+        if (FoliaUtil.isFoliaServer()) {
+            return false;
+        }
+        return entity.customName() != null;
     }
 
     @Override

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitPlayer.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit;
 
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.configuration.Settings;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.sk89q.util.StringUtil;
 import com.sk89q.wepif.VaultResolver;
@@ -242,6 +243,21 @@ public class BukkitPlayer extends AbstractPlayerActor {
         }
         org.bukkit.World finalWorld = world;
         //FAWE end
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                player.teleportAsync(new Location(
+                        finalWorld,
+                        pos.x(),
+                        pos.y(),
+                        pos.z(),
+                        yaw,
+                        pitch
+                )).get();
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
         return TaskManager.taskManager().sync(() -> player.teleport(new Location(
                 finalWorld,
                 pos.x(),
@@ -363,6 +379,14 @@ public class BukkitPlayer extends AbstractPlayerActor {
 
     @Override
     public boolean setLocation(com.sk89q.worldedit.util.Location location) {
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                player.teleportAsync(BukkitAdapter.adapt(location)).get();
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
         return player.teleport(BukkitAdapter.adapt(location));
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitServerInterface.java
@@ -19,7 +19,9 @@
 
 package com.sk89q.worldedit.bukkit;
 
+import com.fastasyncworldedit.bukkit.FaweBukkit;
 import com.fastasyncworldedit.bukkit.util.MinecraftVersion;
+import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.configuration.Settings;
 import com.fastasyncworldedit.core.extent.processor.PlacementStateProcessor;
 import com.fastasyncworldedit.core.extent.processor.lighting.RelighterFactory;
@@ -135,6 +137,15 @@ public class BukkitServerInterface extends AbstractPlatform implements MultiUser
 
     @Override
     public int schedule(long delay, long period, Runnable task) {
+        try {
+            FaweBukkit faweBukkit = Fawe.platform();
+            if (faweBukkit != null && faweBukkit.getScheduler() != null) {
+                faweBukkit.getScheduler().runTaskTimer(plugin, task, delay, period);
+                return 0;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         return Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, task, delay, period);
     }
 

--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/WorldEditPlugin.java
@@ -21,6 +21,7 @@ package com.sk89q.worldedit.bukkit;
 
 import com.fastasyncworldedit.bukkit.BukkitPermissionAttachmentManager;
 import com.fastasyncworldedit.bukkit.FaweBukkit;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.Fawe;
 import com.fastasyncworldedit.core.util.UpdateNotification;
 import com.fastasyncworldedit.core.util.WEManager;
@@ -457,7 +458,23 @@ public class WorldEditPlugin extends JavaPlugin {
         if (config != null) {
             config.unload();
         }
-        this.getServer().getScheduler().cancelTasks(this);
+        if (FoliaUtil.isFoliaServer()) {
+            return;
+        }
+        try {
+            FaweBukkit faweBukkit = Fawe.platform();
+            if (faweBukkit != null && faweBukkit.getScheduler() != null) {
+                try {
+                    this.getServer().getScheduler().cancelTasks(this);
+                } catch (Exception ignored) {
+                }
+            }
+        } catch (Exception e) {
+            try {
+                this.getServer().getScheduler().cancelTasks(this);
+            } catch (Exception ignored) {
+            }
+        }
     }
 
     /**

--- a/worldedit-bukkit/src/main/resources/plugin.yml
+++ b/worldedit-bukkit/src/main/resources/plugin.yml
@@ -9,6 +9,7 @@ website: https://modrinth.com/plugin/fastasyncworldedit/
 description: Blazingly fast world manipulation for builders, large networks and developers.
 authors: [ Empire92, MattBDev, IronApollo, dordsor21, NotMyFault ]
 loadbefore: [ WorldGuard, PlotSquared ]
+folia-supported: true
 database: false
 permissions:
   fawe.plotsquared:

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/FaweStreamChangeSet.java
@@ -155,6 +155,7 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
         }
         if (mode == 1 || mode == 4) { // small
             posDel = new FaweStreamPositionDelegate() {
+                final byte[] buffer = new byte[4];
                 int lx;
                 int ly;
                 int lz;
@@ -178,8 +179,6 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
                     out.write(b3);
                     out.write(b4);
                 }
-
-                final byte[] buffer = new byte[4];
 
                 @Override
                 public int readX(FaweInputStream in) throws IOException {
@@ -562,7 +561,10 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
 
     public Iterator<MutableFullBlockChange> getFullBlockIterator(BlockBag blockBag, int inventory, final boolean dir) throws
             IOException {
-        final FaweInputStream is = new FaweInputStream(getBlockIS());
+        final FaweInputStream is = getBlockIS();
+        if (is == null) {
+            return Collections.emptyIterator();
+        }
         final MutableFullBlockChange change = new MutableFullBlockChange(blockBag, inventory, dir);
         return new Iterator<MutableFullBlockChange>() {
             private MutableFullBlockChange last = read();
@@ -576,7 +578,6 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
                     return change;
                 } catch (EOFException ignored) {
                 } catch (Exception e) {
-                    e.printStackTrace();
                     e.printStackTrace();
                 }
                 try {
@@ -850,7 +851,7 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
 
             @Override
             public boolean accepts(final Change change) {
-                return change instanceof MutableTileChange;
+                return change instanceof MutableEntityChange;
             }
 
         }
@@ -1071,7 +1072,7 @@ public abstract class FaweStreamChangeSet extends AbstractChangeSet {
                 for (int i = 0; i < amount; i++) {
                     int x = posDel.readX(fis) + ox;
                     int y = posDel.readY(fis);
-                    int z = posDel.readZ(fis) + ox;
+                    int z = posDel.readZ(fis) + oz;
                     idDel.readCombined(fis, change);
                     summary.add(x, z, change.to);
                 }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkExtent.java
@@ -91,7 +91,7 @@ public interface IChunkExtent<T extends IChunk> extends Extent {
     @Override
     default void setBlockLight(int x, int y, int z, int value) {
         final IChunk chunk = getOrCreateChunk(x >> 4, z >> 4);
-        chunk.setSkyLight(x & 15, y, z & 15, value);
+        chunk.setBlockLight(x & 15, y, z & 15, value);
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
@@ -11,6 +11,7 @@ import com.fastasyncworldedit.core.queue.IQueueChunk;
 import com.fastasyncworldedit.core.queue.IQueueExtent;
 import com.fastasyncworldedit.core.queue.Trimable;
 import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.MemUtil;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.collection.CleanableThreadLocal;
@@ -106,7 +107,9 @@ public abstract class QueueHandler implements Trimable, Runnable {
 
     @Override
     public void run() {
-        if (!Fawe.isMainThread()) {
+        boolean isFolia = FoliaUtil.isFoliaServer();
+
+        if (!isFolia && !Fawe.isMainThread()) {
             throw new IllegalStateException("Not main thread");
         }
         if (!syncTasks.isEmpty()) {
@@ -328,7 +331,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
     }
 
     private <T> Future<T> sync(Runnable run, T value, Queue<FutureTask> queue) {
-        if (Fawe.isMainThread()) {
+        if (!FoliaUtil.isFoliaServer() && Fawe.isMainThread()) {
             run.run();
             return Futures.immediateFuture(value);
         }
@@ -339,7 +342,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
     }
 
     private <T> Future<T> sync(Runnable run, Queue<FutureTask> queue) {
-        if (Fawe.isMainThread()) {
+        if (!FoliaUtil.isFoliaServer() && Fawe.isMainThread()) {
             run.run();
             return Futures.immediateCancelledFuture();
         }
@@ -350,7 +353,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
     }
 
     private <T> Future<T> sync(Callable<T> call, Queue<FutureTask> queue) throws Exception {
-        if (Fawe.isMainThread()) {
+        if (!FoliaUtil.isFoliaServer() && Fawe.isMainThread()) {
             return Futures.immediateFuture(call.call());
         }
         final FutureTask<T> result = new FutureTask<>(call);
@@ -360,7 +363,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
     }
 
     private <T> Future<T> sync(Supplier<T> call, Queue<FutureTask> queue) {
-        if (Fawe.isMainThread()) {
+        if (!FoliaUtil.isFoliaServer() && Fawe.isMainThread()) {
             return Futures.immediateFuture(call.get());
         }
         final FutureTask<T> result = new FutureTask<>(call::get);

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/FoliaUtil.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/FoliaUtil.java
@@ -1,0 +1,33 @@
+package com.fastasyncworldedit.core.util;
+
+/**
+ * Utility class for Folia server detection and compatibility.
+ */
+public class FoliaUtil {
+
+    private static final Boolean FOLIA_DETECTED = detectFolia();
+
+    /**
+     * Check if we're running on a Folia server.
+     *
+     * @return true if running on Folia
+     */
+    public static boolean isFoliaServer() {
+        return FOLIA_DETECTED;
+    }
+
+    /**
+     * Detect if Folia is available by checking for the RegionizedServer class.
+     * This method is called once during class initialization for performance.
+     *
+     * @return true if Folia is detected
+     */
+    private static boolean detectFolia() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/TaskManager.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/TaskManager.java
@@ -223,7 +223,6 @@ public abstract class TaskManager {
         }
     }
 
-
     /**
      * Run a task later on the main thread.
      *
@@ -326,7 +325,7 @@ public abstract class TaskManager {
             return function.value;
         }
         try {
-            return Fawe.instance().getQueueHandler().sync((Supplier<T>) function).get();
+            return Fawe.instance().getQueueHandler().syncWhenFree((Supplier<T>) function).get();
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }
@@ -342,7 +341,7 @@ public abstract class TaskManager {
             return supplier.get();
         }
         try {
-            return Fawe.instance().getQueueHandler().sync(supplier).get();
+            return Fawe.instance().getQueueHandler().syncWhenFree(supplier).get();
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }
@@ -363,7 +362,7 @@ public abstract class TaskManager {
      * - Usually wait time is around 25ms<br>
      */
     public <T> T sync(final Supplier<T> function) {
-        if (Fawe.isMainThread()) {
+        if (Fawe.isMainThread() || FoliaUtil.isFoliaServer()) {
             return function.get();
         }
         try {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/wrappers/WorldWrapper.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/wrappers/WorldWrapper.java
@@ -4,6 +4,7 @@ import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.fastasyncworldedit.core.queue.IChunkGet;
 import com.fastasyncworldedit.core.queue.implementation.packet.ChunkPacket;
 import com.fastasyncworldedit.core.util.ExtentTraverser;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.task.RunnableVal;
 import com.sk89q.jnbt.CompoundTag;
@@ -42,6 +43,7 @@ import com.sk89q.worldedit.world.generation.StructureType;
 import com.sk89q.worldedit.world.weather.WeatherType;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -261,7 +263,14 @@ public class WorldWrapper extends AbstractWorld {
     }
 
     @Override
-    public Collection<BaseItemStack> getBlockDrops(final BlockVector3 position) {
+    public Collection<BaseItemStack> getBlockDrops(BlockVector3 position) {
+        if (FoliaUtil.isFoliaServer()) {
+            try {
+                return parent.getBlockDrops(position);
+            } catch (Exception e) {
+                return new ArrayList<>();
+            }
+        }
         return TaskManager.taskManager().sync(() -> parent.getBlockDrops(position));
     }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/platform/PlatformManager.java
@@ -22,6 +22,7 @@ package com.sk89q.worldedit.extension.platform;
 import com.fastasyncworldedit.core.configuration.Caption;
 import com.fastasyncworldedit.core.function.pattern.PatternTraverser;
 import com.fastasyncworldedit.core.internal.exception.FaweException;
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.wrappers.LocationMaskedPlayerWrapper;
 import com.fastasyncworldedit.core.wrappers.WorldWrapper;
 import com.google.common.collect.Maps;
@@ -438,7 +439,7 @@ public class PlatformManager {
                         player.runAction(() -> reset(superPickaxe)
                                 .actPrimary(queryCapability(Capability.WORLD_EDITING),
                                         getConfiguration(), player, session, location, event.getFace()
-                                ), false, true);
+                                ), false, !FoliaUtil.isFoliaServer());
                         //FAWE end
                         event.setCancelled(true);
                         return;
@@ -451,7 +452,7 @@ public class PlatformManager {
                     player.runAction(() -> reset((DoubleActionBlockTool) tool)
                             .actSecondary(queryCapability(Capability.WORLD_EDITING),
                                     getConfiguration(), player, session, location, event.getFace()
-                            ), false, true);
+                            ), false, !FoliaUtil.isFoliaServer());
                     //FAWE end
                     event.setCancelled(true);
                 }
@@ -470,7 +471,7 @@ public class PlatformManager {
                             blockTool.actPrimary(queryCapability(Capability.WORLD_EDITING),
                                     getConfiguration(), player, session, location, event.getFace()
                             );
-                        }, false, true);
+                        }, false, !FoliaUtil.isFoliaServer());
                         //FAWE end
                         event.setCancelled(true);
                     }
@@ -509,10 +510,17 @@ public class PlatformManager {
                     Tool tool = session.getTool(player);
                     if (tool instanceof DoubleActionTraceTool && tool.canUse(player)) {
                         //FAWE start - run async
-                        player.runAsyncIfFree(() -> reset((DoubleActionTraceTool) tool)
-                                .actSecondary(queryCapability(Capability.WORLD_EDITING),
-                                        getConfiguration(), player, session
-                                ));
+                        if (FoliaUtil.isFoliaServer()) {
+                            player.runIfFree(() -> reset((DoubleActionTraceTool) tool)
+                                    .actSecondary(queryCapability(Capability.WORLD_EDITING),
+                                            getConfiguration(), player, session
+                                    ));
+                        } else {
+                            player.runAsyncIfFree(() -> reset((DoubleActionTraceTool) tool)
+                                    .actSecondary(queryCapability(Capability.WORLD_EDITING),
+                                            getConfiguration(), player, session
+                                    ));
+                        }
                         //FAWE end
                         event.setCancelled(true);
                         return;

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SurvivalModeExtent.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/world/SurvivalModeExtent.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.extent.world;
 
+import com.fastasyncworldedit.core.util.FoliaUtil;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.task.RunnableVal;
 import com.sk89q.worldedit.WorldEditException;
@@ -99,14 +100,20 @@ public class SurvivalModeExtent extends AbstractDelegateExtent {
             Collection<BaseItemStack> drops = world.getBlockDrops(location);
             boolean canSet = super.setBlock(location, block);
             if (canSet) {
-                TaskManager.taskManager().sync(new RunnableVal<>() {
-                    @Override
-                    public void run(Object value) {
-                        for (BaseItemStack stack : drops) {
-                            world.dropItem(location.toVector3(), stack);
-                        }
+                if (FoliaUtil.isFoliaServer()) {
+                    for (BaseItemStack stack : drops) {
+                        world.dropItem(location.toVector3(), stack);
                     }
-                });
+                } else {
+                    TaskManager.taskManager().sync(new RunnableVal<>() {
+                        @Override
+                        public void run(Object value) {
+                            for (BaseItemStack stack : drops) {
+                                world.dropItem(location.toVector3(), stack);
+                            }
+                        }
+                    });
+                }
 
                 return true;
             } else {


### PR DESCRIPTION
This PR implements Folia support in FastAsyncWorldEdit and even reintroduces `//regen` into Folia, which was thought to be impossible or extraordinarily difficult to achieve. I have gone ahead and tested this comprehensively on a 100-200 player Duels server against Folia that creates and removes schematics at all times. Before this, various commands, including extensions (e.g., copying an entity), have been tested and verified to work, along with some basic testing across every possible NMS version FastAsyncWorldEdit supports. Let me know if any changes are absolutely required!

Misc. change: For fresh users, the plugin fails to compile. I went ahead and resolved this in the very first change by migrating to Adoptium.

Additional note: against FAWE, capturing states is required against reflection and cannot be directly referenced

Supersedes: #2682 & #2309
Resolves: #2297

This was also done for WorldEdit: https://github.com/EngineHub/WorldEdit/pull/2848