### PR TITLE
fix: reobfuscated jar should not contain mapping information

### DIFF
--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -171,6 +171,9 @@ tasks.register<ShadowJar>("reobfShadowJar") {
          if (key == "FAWE-Plugin-Jar-Type") {
              value = "spigot"
          }
+         if (key == "paperweight-mappings-namespace") {
+             exclude()
+         }
      }
     }
     exclude("META-INF/INDEX.LIST", "META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "module-info.class")


### PR DESCRIPTION
## Overview
Follow-up PR. Drops the `paperweight-mappings-namespace` manifest entry for the reobfuscated JARs, which prevented the FAWE-Spigot JARs to be remapped by Paper on startup (therefor fail)

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
