### PR TITLE
Properly handle incomplete selection in RegionCommands

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/platform/binding/ProvideBindings.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extension/platform/binding/ProvideBindings.java
@@ -11,7 +11,6 @@ import com.fastasyncworldedit.core.util.ExtentTraverser;
 import com.fastasyncworldedit.core.util.TextureUtil;
 import com.fastasyncworldedit.core.util.image.ImageUtil;
 import com.sk89q.worldedit.EditSession;
-import com.sk89q.worldedit.IncompleteRegionException;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.command.argument.Arguments;
@@ -21,7 +20,6 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extension.input.InputParseException;
 import com.sk89q.worldedit.extension.platform.Actor;
 import com.sk89q.worldedit.extent.Extent;
-import com.sk89q.worldedit.internal.annotation.Selection;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.session.request.Request;
 import com.sk89q.worldedit.world.World;
@@ -87,16 +85,6 @@ public class ProvideBindings extends Bindings {
         }
         Request.request().setEditSession(editSession);
         return editSession;
-    }
-
-    @Selection
-    @Binding
-    public Region selection(LocalSession localSession) {
-        try {
-            return localSession.getSelection();
-        } catch (IncompleteRegionException ignore) {
-            return null;
-        }
     }
 
     @Binding

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java
@@ -136,6 +136,7 @@ public class RegionCommands {
     @CommandPermissions("worldedit.region.set")
     @Logging(REGION)
     @Preload(Preload.PreloadCheck.PRELOAD)
+    @Confirm(Confirm.Processor.REGION)
     public void air(Actor actor, EditSession editSession, @Selection Region region) throws WorldEditException {
         set(actor, editSession, region, BlockTypes.AIR);
     }
@@ -161,6 +162,7 @@ public class RegionCommands {
             desc = "Get the light at a position"
     )
     @CommandPermissions("worldedit.light.fix")
+    @Confirm(Confirm.Processor.REGION)
     public void fixLighting(Actor actor, LocalSession session, @Selection Region selection) throws WorldEditException {
         int count = FaweAPI.fixLighting(session.getSelectionWorld(), selection, null, RelightMode.ALL);
         actor.print(Caption.of("fawe.info.lighting.propagate.selection", count));
@@ -172,6 +174,7 @@ public class RegionCommands {
             desc = "Removing lighting in a selection"
     )
     @CommandPermissions("worldedit.light.remove")
+    @Confirm(Confirm.Processor.REGION)
     public void removeLighting(Actor actor, LocalSession session, @Selection Region selection) {
         int count = FaweAPI.fixLighting(session.getSelectionWorld(), selection, null, RelightMode.NONE);
         actor.print(Caption.of("fawe.info.updated.lighting.selection", count));
@@ -207,6 +210,7 @@ public class RegionCommands {
             desc = "Set block lighting in a selection"
     )
     @CommandPermissions("worldedit.light.set")
+    @Confirm(Confirm.Processor.REGION)
     public void setlighting(Actor actor, EditSession editSession, @Selection Region region) {
         actor.print(Caption.of("fawe.info.light-blocks"));
     }
@@ -217,6 +221,7 @@ public class RegionCommands {
             desc = "Set sky lighting in a selection"
     )
     @CommandPermissions("worldedit.light.set")
+    @Confirm(Confirm.Processor.REGION)
     public void setskylighting(Actor actor, @Selection Region region) {
         actor.print(Caption.of("fawe.info.light-blocks"));
     }
@@ -228,6 +233,7 @@ public class RegionCommands {
     )
     @CommandPermissions("worldedit.region.line")
     @Logging(REGION)
+    @Confirm(Confirm.Processor.REGION)
     @SynchronousSettingExpected
     public int line(
             Actor actor, EditSession editSession,
@@ -376,6 +382,7 @@ public class RegionCommands {
     )
     @Logging(REGION)
     @CommandPermissions("worldedit.region.center")
+    @Confirm(Confirm.Processor.REGION)
     @SynchronousSettingExpected
     public int center(
             Actor actor, EditSession editSession, @Selection Region region,
@@ -632,6 +639,7 @@ public class RegionCommands {
     )
     @CommandPermissions("worldedit.region.stack")
     @Preload(Preload.PreloadCheck.PRELOAD)
+    @Confirm(Confirm.Processor.REGION)
     @SynchronousSettingExpected
     @Logging(ORIENTATION_REGION)
     public int stack(


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #3387

## Description
<!-- Please describe what this pull request does. -->

There are 2 problems here:

1. Without the Confirm annotation, we never check if the selection is present. The changed commands all work on regions and should therefore also properly handle confirmation.
2. Our custom binding returns null instead of throwing `IncompleteRegionException`. I didn't find any reason for this binding to exist, so I think removing it make the most sense.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
