### PR TITLE
chore: don't send build update notification for release JARs

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/UpdateNotification.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/util/UpdateNotification.java
@@ -62,7 +62,7 @@ public class UpdateNotification {
                     "This is not an official build distributed via https://ci.athion.net/job/FastAsyncWorldEdit/");
             return;
         }
-        if (Settings.settings().ENABLED_COMPONENTS.SNAPSHOT_UPDATE_NOTIFICATIONS) {
+        if (Settings.settings().ENABLED_COMPONENTS.SNAPSHOT_UPDATE_NOTIFICATIONS && installedVersion.build > 0) {
             checkLatestBuild().orTimeout(10, TimeUnit.SECONDS).whenComplete((build, throwable) -> {
                 if (throwable != null) {
                     LOGGER.error("Failed to check for latest build", throwable);
@@ -76,14 +76,14 @@ public class UpdateNotification {
                 LOGGER.warn(CONSOLE_NOTIFICATION_OUTDATED_BUILD, difference, installedVersion.build, lastBuild, LINK_DOWNLOAD_JENKINS);
             });
         }
-        if (Settings.settings().ENABLED_COMPONENTS.RELEASE_UPDATE_NOTIFICATIONS) {
+        if (Settings.settings().ENABLED_COMPONENTS.RELEASE_UPDATE_NOTIFICATIONS && installedVersion.semver != null) {
             checkLatestRelease().orTimeout(10, TimeUnit.SECONDS).whenComplete((version, throwable) -> {
                 if (throwable != null) {
                     LOGGER.error("Failed to check for latest release", throwable);
                     return;
                 }
                 lastRelease = version;
-                if (installedVersion.semver != null && hasUpdateSemver(installedVersion.semver, version)) {
+                if (hasUpdateSemver(installedVersion.semver, version)) {
                     LOGGER.warn(CONSOLE_NOTIFICATION_OUTDATED_RELEASE,
                             StringUtil.joinString(lastRelease, ".", 0),
                             StringUtil.joinString(installedVersion.semver, ".", 0),


### PR DESCRIPTION
## Overview
Should not notify the user that they are 1234 builds behind when downloading a release version from modrinth or github anymore.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
