### PR TITLE
fix: return compound tag instead of end tag for empty Ops value

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/LinOps.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/LinOps.java
@@ -54,13 +54,14 @@ import java.util.stream.StreamSupport;
 public class LinOps implements DynamicOps<LinTag<?>> {
 
     static final DynamicOps<LinTag<?>> INSTANCE = new LinOps();
+    private static final LinTag<?> EMPTY_TAG = LinCompoundTag.of(Map.of());
 
     private LinOps() {
     }
 
     @Override
     public LinTag<?> empty() {
-        return LinEndTag.instance();
+        return EMPTY_TAG;
     }
 
     @Override
@@ -70,7 +71,7 @@ public class LinOps implements DynamicOps<LinTag<?>> {
 
     @Override
     public LinTag<?> emptyMap() {
-        return LinCompoundTag.builder().build();
+        return EMPTY_TAG;
     }
 
     @Override


### PR DESCRIPTION
## Overview
NbtOps returns a EndTag for the `empty` entry, which doesn't work with Lin (does make sense tbf) and fails when, for example, appending `empty` to a map. Switched to an empty compound tag which works and should work for other cases as well.

I don't really know under which circumstances this is actually used - possibly some Codec haven't been able to test.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
