### PR TITLE
fix: wrap LinOps in RegistryOps

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/LinValueInput.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/LinValueInput.java
@@ -214,7 +214,7 @@ public class LinValueInput implements ValueInput {
         ValueInputContext(HolderLookup.Provider lookup) {
             this(
                     lookup,
-                    LinOps.INSTANCE,
+                    lookup.createSerializationContext(LinOps.INSTANCE),
                     new EmptyValueInput(lookup, new EmptyValueInputList(), new EmptyTypedInputList()),
                     new EmptyValueInputList(),
                     new EmptyTypedInputList()


### PR DESCRIPTION
## Overview
wraps the LinOps in LinValueInput in a RegistryOps for registry access when reading using registry-backed codecs.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
