### PR TITLE
Improve palette mapping performance by avoiding max

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSAdapter.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/NMSAdapter.java
@@ -86,12 +86,14 @@ public class NMSAdapter implements FAWEPlatformAdapterImpl {
             System.arraycopy(adapter.getIbdToOrdinal(), 0, paletteToBlock, 0, adapter.getIbdToOrdinal().length);
             System.arraycopy(adapter.getOrdinalToIbdID(), 0, blockToPalette, 0, adapter.getOrdinalToIbdID().length);
         }
+        int oldVal = blockToPalette[BlockTypesCache.ReservedIDs.__RESERVED__];
+        blockToPalette[BlockTypesCache.ReservedIDs.__RESERVED__] = blockToPalette[BlockTypesCache.ReservedIDs.AIR];
         for (int i = 0; i < 4096; i++) {
             int ordinal = set[i];
-            ordinal = Math.max(ordinal, BlockTypesCache.ReservedIDs.AIR);
             int palette = blockToPalette[ordinal];
             blocksCopy[i] = palette;
         }
+        blockToPalette[BlockTypesCache.ReservedIDs.__RESERVED__] = oldVal;
     }
 
     @Override


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

Small performance improvement: Instead of calculating the maximum 4096 times, we can just temporarily set the mapping for \_\_RESERVED__ to the same as AIR.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
