### PR TITLE
fix: 1.21.9 and 1.21.11 adapters throw invalid bit count when calling unpack

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/PaperweightPlatformAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/PaperweightPlatformAdapter.java
@@ -40,7 +40,6 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
@@ -449,35 +448,35 @@ public final class PaperweightPlatformAdapter extends NMSAdapter {
                 bitArray.fromRaw(blocksCopy);
             }
 
-            final long[] bits = Arrays.copyOfRange(blockStates, 0, blockBitArrayEnd);
-            List<net.minecraft.world.level.block.state.BlockState> palette;
-            if (bitsPerEntry < 9) {
-                palette = new ArrayList<>();
-                for (int i = 0; i < num_palette; i++) {
-                    int ordinal = paletteToBlock[i];
-                    blockToPalette[ordinal] = Integer.MAX_VALUE;
-                    final BlockState state = BlockTypesCache.states[ordinal];
-                    palette.add(((PaperweightBlockMaterial) state.getMaterial()).getState());
-                }
-            } else {
-                palette = List.of();
+            // Create empty container and populate it manually
+            // This avoids unpack() validation issues with global palettes
+            PalettedContainerFactory factory = PalettedContainerFactory.create(registryAccess);
+            final PalettedContainer<net.minecraft.world.level.block.state.BlockState> blockStatePalettedContainer =
+                    factory.createForBlockStates();
+
+            // Populate the container by setting each block position
+            for (int i = 0; i < 4096; i++) {
+                int x = i & 15;
+                int y = i >> 8;
+                int z = (i >> 4) & 15;
+
+                char ordinal = set[i];
+                ordinal = (char) Math.max(ordinal, BlockTypesCache.ReservedIDs.AIR);
+                final BlockState state = BlockTypesCache.states[ordinal];
+                net.minecraft.world.level.block.state.BlockState nmsState =
+                        ((PaperweightBlockMaterial) state.getMaterial()).getState();
+
+                blockStatePalettedContainer.set(x, y, z, nmsState);
             }
 
-            // Create palette with data
-            var strategy = Strategy.createForBlockStates(Block.BLOCK_STATE_REGISTRY);
-            var packedData = new PalettedContainerRO.PackedData<>(palette, Optional.of(LongStream.of(bits)), bitsPerEntry);
-            DataResult<PalettedContainer<net.minecraft.world.level.block.state.BlockState>> result;
-            if (PaperLib.isPaper()) {
-                result = PalettedContainer.unpack(strategy, packedData, Blocks.AIR.defaultBlockState(), null);
-            } else {
-                //noinspection unchecked
-                result = (DataResult<PalettedContainer<net.minecraft.world.level.block.state.BlockState>>)
-                        palettedContainerUnpackSpigot.invokeExact(strategy, packedData);
+            for (int i = 0; i < num_palette; i++) {
+                blockToPalette[paletteToBlock[i]] = Integer.MAX_VALUE;
             }
+
             if (biomes == null) {
                 biomes = PalettedContainerFactory.create(registryAccess).createForBiomes();
             }
-            return new LevelChunkSection(result.getOrThrow(), biomes);
+            return new LevelChunkSection(blockStatePalettedContainer, biomes);
         } catch (Throwable e) {
             throw new RuntimeException("Failed to create block palette", e);
         } finally {


### PR DESCRIPTION
## Overview
Pasting clipboards in some chunks throw a validation error when calling "unpack":
```
[21:26:34 ERROR]: [com.fastasyncworldedit.bukkit.adapter.AbstractBukkitGetBlocks] Error performing chunk call at chunk -764,798
java.lang.RuntimeException: Failed to create block palette
        at FastAsyncWorldEdit-Paper-2.15.0.jar/com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_9.PaperweightPlatformAdapter.newChunkSection(PaperweightPlatformAdapter.java:493) ~[FastAsyncWorldEdit-Paper-2.15.0.jar:?]
        at FastAsyncWorldEdit-Paper-2.15.0.jar/com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_9.PaperweightGetBlocks.internalCall(PaperweightGetBlocks.java:549) ~[FastAsyncWorldEdit-Paper-2.15.0.jar:?]
        at FastAsyncWorldEdit-Paper-2.15.0.jar/com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_9.PaperweightGetBlocks.internalCall(PaperweightGetBlocks.java:96) ~[FastAsyncWorldEdit-Paper-2.15.0.jar:?]
        at FastAsyncWorldEdit-Paper-2.15.0.jar/com.fastasyncworldedit.bukkit.adapter.AbstractBukkitGetBlocks.tryInternalCall(AbstractBukkitGetBlocks.java:135) ~[FastAsyncWorldEdit-Paper-2.15.0.jar:?]
        at FastAsyncWorldEdit-Paper-2.15.0.jar/com.fastasyncworldedit.bukkit.adapter.AbstractBukkitGetBlocks.call(AbstractBukkitGetBlocks.java:92) ~[FastAsyncWorldEdit-Paper-2.15.0.jar:?]
        at FastAsyncWorldEdit-Paper-2.15.0.jar/com.fastasyncworldedit.core.queue.implementation.chunk.ChunkHolder.call(ChunkHolder.java:1090) ~[FastAsyncWorldEdit-Paper-2.15.0.jar:?]
        at FastAsyncWorldEdit-Paper-2.15.0.jar/com.fastasyncworldedit.core.queue.implementation.chunk.ChunkHolder.call(ChunkHolder.java:1052) ~[FastAsyncWorldEdit-Paper-2.15.0.jar:?]
        at FastAsyncWorldEdit-Paper-2.15.0.jar/com.fastasyncworldedit.core.queue.implementation.chunk.ChunkHolder.call(ChunkHolder.java:37) ~[FastAsyncWorldEdit-Paper-2.15.0.jar:?]
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.IllegalStateException: Invalid bit count, calculated 0, but container declared 15
        at com.mojang.serialization.DataResult$Error.getOrThrow(DataResult.java:287) ~[datafixerupper-8.0.16.jar:?]
        at com.mojang.serialization.DataResult.getOrThrow(DataResult.java:81) ~[datafixerupper-8.0.16.jar:?]
        at FastAsyncWorldEdit-Paper-2.15.0.jar/com.sk89q.worldedit.bukkit.adapter.impl.fawe.v1_21_9.PaperweightPlatformAdapter.newChunkSection(PaperweightPlatformAdapter.java:491) ~[FastAsyncWorldEdit-Paper-2.15.0.jar:?]
        ... 11 more
```

## Description
On the Bakery network we had someone find an issue where specific chunks cannot be pasted into, in this case chunk -764,798 (but there were others, i.e -769 798), and it throws the error above. Restarts does not fix it, but it happened after updating to 1.21.10. All our servers are all on 1.21.10, we saw this same error when using FAWE `FastAsyncWorldEdit-Paper-2.14.1-SNAPSHOT-1197.jar` which used the `v1_21_9` adapter, and when using `FastAsyncWorldEdit-Paper-2.15.0.jar` which used the `v1_21_11` adapter.

Tried various approaches to fix `unpack()`:
- Populate palette with actual blocks -> "calculated 9, but declared 15" (290 blocks = 9 bits, not 15)
- Don't adjust bitsPerEntry -> "Missing Palette entry for index 311" (bit data has registry ID 311, palette only has indices 0-289)
- Use deprecated constructor (like 1.21.6) -> API removed in 1.21.9+

So the solution proposed here is to replace the `PalettedContainer.unpack()` call with manual population, which does require 4096 individual `set` calls instead of bulk palette creation.

I am not sure if this is the correct change to make or not. I've tested extensively and it fixes the error mentioned above.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
