### PR TITLE
Fix Inconsistent Entity Pasting with #FullCopy

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/RandomFullClipboardPattern.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/pattern/RandomFullClipboardPattern.java
@@ -66,7 +66,7 @@ public class RandomFullClipboardPattern extends AbstractPattern {
         Clipboard clipboard = holder.getClipboard();
         Transform newTransform = holder.getTransform();
         if (newTransform.isIdentity()) {
-            clipboard.paste(extent, set, false);
+            clipboard.paste(extent, set, false, true, false);
         } else {
             newTransform = MutatingOperationTransformHolder.transform(newTransform, true);
             clipboard.paste(extent, set, false, newTransform);


### PR DESCRIPTION
## Overview
When using the command //brush scatter #fullcopy[#copy][true], entities are not pasted if the clipboard has NOT been transformed (flipped/rotated). This means that without rotation or flipping enabled, entities never paste properly, but if either flip or rotation are enabled then entities sometimes paste properly

## Description
Passes true for pasteEntities when identity transform is detected (as this issue does not occur with a non-identity transform)

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
