### PR TITLE
Set Java toolchain to version 21 in build.gradle.kts for bukkit adapter modules for versions: 1.21.4, 1.21.5, 1.21.6, 1.21.9

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_21_4/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/build.gradle.kts
@@ -10,3 +10,9 @@ dependencies {
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21.4-R0.1-20250609.101859-227")
     compileOnly(libs.paperLib)
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}

--- a/worldedit-bukkit/adapters/adapter-1_21_5/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/build.gradle.kts
@@ -9,3 +9,9 @@ dependencies {
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21.5-R0.1-20250618.110345-108")
     compileOnly(libs.paperLib)
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}

--- a/worldedit-bukkit/adapters/adapter-1_21_6/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/build.gradle.kts
@@ -9,3 +9,9 @@ dependencies {
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21.8-R0.1-20250829.204528-51")
     compileOnly(libs.paperLib)
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}

--- a/worldedit-bukkit/adapters/adapter-1_21_9/build.gradle.kts
+++ b/worldedit-bukkit/adapters/adapter-1_21_9/build.gradle.kts
@@ -9,3 +9,9 @@ dependencies {
     the<PaperweightUserDependenciesExtension>().paperDevBundle("1.21.10-R0.1-20251007.183616-3")
     compileOnly(libs.paperLib)
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}


### PR DESCRIPTION
Set Java toolchain to version 21 in build.gradle.kts for bukkit adapter modules: 1.21.4, 1.21.5, 1.21.6, 1.21.9

These modules just won't compile with java 25

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
