### PR TITLE
fix: adjust initialization of item registry (regression)

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemTypes.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemTypes.java
@@ -1156,7 +1156,7 @@ public final class ItemTypes {
     @Nullable
     public static final ItemType GOLDEN_CHESTPLATE = init();
     @Nullable
-    public static final ItemType GOLDEN_DANDELION = get("minecraft:golden_dandelion");
+    public static final ItemType GOLDEN_DANDELION = init();
     @Nullable
     public static final ItemType GOLDEN_HELMET = init();
     @Nullable


### PR DESCRIPTION
## Overview

Fixes #3529

## Description
regression from cherrypicking upstream 26.1/2 changes. Could possibly update the is `isHoldingPickAxe` implementation to use `ItemCategories.PICKAXES`, but the `Set#contains` check would be much heavier than a simple object comparison. 

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
