### PR TITLE
chore: mark 26.1.2 as supported in 26.1 adapter

### DIFF
--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/v26_1/PaperweightAdapter.java
@@ -228,7 +228,7 @@ public final class PaperweightAdapter implements BukkitImplAdapter<Tag> {
         var unused = CraftServer.class.cast(Bukkit.getServer());
 
         int dataVersion = SharedConstants.getCurrentVersion().dataVersion().version();
-        if (dataVersion != Constants.DATA_VERSION_MC_26_1 && dataVersion != Constants.DATA_VERSION_MC_26_1_1) {
+        if (dataVersion != Constants.DATA_VERSION_MC_26_1 && dataVersion != Constants.DATA_VERSION_MC_26_1_1 && dataVersion != Constants.DATA_VERSION_MC_26_1_2) {
             logger.warning(WRONG_VERSION);
         }
 

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/Constants.java
@@ -148,4 +148,9 @@ public final class Constants {
      * The DataVersion for Minecraft 26.1.1.
      */
     public static final int DATA_VERSION_MC_26_1_1 = 4788;
+
+    /**
+     * The DataVersion for Minecraft 26.1.2.
+     */
+    public static final int DATA_VERSION_MC_26_1_2 = 4790;
 }


### PR DESCRIPTION
## Overview
chore: mark 26.1.2 as supported in 26.1 adapter
https://mcsrc.dev/1/26.1.2/net/minecraft/SharedConstants#L16

I believe this was an oversight since it is already marked as supported in the build script.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
~~- [ ] New public fields and methods are annotated with `@since TODO`.~~
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
