### PR TITLE
fix: release drafter v7

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,8 +10,8 @@ on:
 jobs:
   update_release_draft:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+    permissions:
+      contents: write # required for creating draft releases
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,5 @@
 name: draft release
+
 on:
   push:
     branches:
@@ -7,11 +8,20 @@ on:
     types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
-    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     permissions:
-      contents: write # required for creating draft releases
+      contents: write # to create a GitHub release (release-drafter/release-drafter)
+
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - name: Generate GitHub Release Draft
+        id: release-drafter
+        uses: release-drafter/release-drafter@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,5 +13,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
-  pull_request_target:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -17,7 +13,7 @@ jobs:
     permissions:
       contents: write # to create a GitHub release (release-drafter/release-drafter)
 
-    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+    if: ${{ github.repository_owner == 'IntellectualSites' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub Release Draft


### PR DESCRIPTION
## Overview
fix release-drafter v7 changing gh token usage

> If you were using a specific access token using env.GITHUB_TOKEN: $MY_CUSTOM_TOKEN, migrate to the new token: input [...]
see https://github.com/release-drafter/release-drafter/pull/1475

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
~~- [ ] New public fields and methods are annotated with `@since TODO`.~~
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).