### PR TITLE
chore: update WorldGuard to v7.0.16

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ snakeyaml = "2.2"
 
 # Plugins
 dummypermscompat = "1.10"
-worldguard-bukkit = "7.0.15"
+worldguard-bukkit = "7.0.16"
 griefprevention = "18.0.0"
 griefdefender = "2.1.0-SNAPSHOT"
 residence = "6.0.0.1"

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/ItemUtil.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/ItemUtil.java
@@ -12,8 +12,7 @@ import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-
-import static com.google.gson.internal.$Gson$Preconditions.checkNotNull;
+import java.util.Objects;
 
 public class ItemUtil {
 
@@ -28,8 +27,7 @@ public class ItemUtil {
     private SoftReference<Int2ObjectOpenHashMap<WeakReference<Tag>>> hashToNMSTag = new SoftReference<>(new Int2ObjectOpenHashMap<>());
 
     public ItemUtil() throws Exception {
-        this.adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
-        checkNotNull(adapter);
+        this.adapter = Objects.requireNonNull(WorldEditPlugin.getInstance().getBukkitImplAdapter());
         Class<?> classCraftItemStack = BukkitReflectionUtils.getCbClass("inventory.CraftItemStack");
         Class<?> classNMSItem = BukkitReflectionUtils.getNmsClass("ItemStack");
         this.methodAsNMSCopy = ReflectionUtils.setAccessible(classCraftItemStack.getDeclaredMethod("asNMSCopy", ItemStack.class));


### PR DESCRIPTION
## Overview

Supersedes / closes #3499

## Description
New WG versions seems to provide a newer Gson version. Could've simply excluded that, but given the method was deprecated either way we can simply update to Objects#requireNonNull.
(The whole class should be removed in the future either way, we have adapters for that kind of stuff)

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
