### PR TITLE
Remove block entities on server thread

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
@@ -347,6 +347,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         // Remove existing tiles. Create a copy so that we can remove blocks
         Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
         List<BlockEntity> beacons = null;
+        List<BlockEntity> tilesToRemove = new ArrayList<>();
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
                 final BlockPos pos = entry.getKey();
@@ -366,13 +367,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             beacons = new ArrayList<>();
                         }
                         beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
-                    }
+                    tilesToRemove.add(tile);
                 }
             }
         }
@@ -594,17 +591,33 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
 
-            // Call beacon deactivate events here synchronously
+            // Remove tiles synchronously
+            if (!tilesToRemove.isEmpty()) {
+                syncTasks = new Runnable[5];
+                final List<BlockEntity> finalTilesToRemove = tilesToRemove;
+                syncTasks[4] = () -> {
+                    for (BlockEntity tile : finalTilesToRemove) {
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
+                    }
+                };
+            }
+
+            // Call beacon deactivate events and remove it here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
-
-                syncTasks = new Runnable[4];
+                if (syncTasks == null) {
+                    syncTasks = new Runnable[4];
+                }
 
                 syncTasks[3] = () -> {
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
+                        PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
                     }
                 };
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/PaperweightGetBlocks.java
@@ -344,6 +344,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         // Remove existing tiles. Create a copy so that we can remove blocks
         Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
         List<BlockEntity> beacons = null;
+        List<BlockEntity> tilesToRemove = new ArrayList<>();
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
                 final BlockPos pos = entry.getKey();
@@ -363,13 +364,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             beacons = new ArrayList<>();
                         }
                         beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
-                    }
+                    tilesToRemove.add(tile);
                 }
             }
         }
@@ -591,7 +588,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
 
-            // Call beacon deactivate events here synchronously
+            // Remove tiles synchronously
+            if (!tilesToRemove.isEmpty()) {
+                final List<BlockEntity> finalTilesToRemove = tilesToRemove;
+                syncTasks.add(() -> {
+                    for (BlockEntity tile : finalTilesToRemove) {
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
+                    }
+                });
+            }
+
+            // Call beacon deactivate events and remove it here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
@@ -600,6 +610,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
+                        PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
                     }
                 });
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
@@ -345,6 +345,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         // Remove existing tiles. Create a copy so that we can remove blocks
         Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
         List<BlockEntity> beacons = null;
+        List<BlockEntity> tilesToRemove = new ArrayList<>();
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
                 final BlockPos pos = entry.getKey();
@@ -364,13 +365,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             beacons = new ArrayList<>();
                         }
                         beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
-                    }
+                    tilesToRemove.add(tile);
                 }
             }
         }
@@ -590,7 +587,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
 
-            // Call beacon deactivate events here synchronously
+            // Remove tiles synchronously
+            if (!tilesToRemove.isEmpty()) {
+                final List<BlockEntity> finalTilesToRemove = tilesToRemove;
+                syncTasks.add(() -> {
+                    for (BlockEntity tile : finalTilesToRemove) {
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
+                    }
+                });
+            }
+
+            // Call beacon deactivate events and remove it here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
@@ -598,6 +608,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
+                        PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
                     }
                 });
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
@@ -345,6 +345,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         // Remove existing tiles. Create a copy so that we can remove blocks
         Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
         List<BlockEntity> beacons = null;
+        List<BlockEntity> tilesToRemove = new ArrayList<>();
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
                 final BlockPos pos = entry.getKey();
@@ -364,13 +365,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             beacons = new ArrayList<>();
                         }
                         beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
-                    }
+                    tilesToRemove.add(tile);
                 }
             }
         }
@@ -590,7 +587,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
 
-            // Call beacon deactivate events here synchronously
+            // Remove tiles synchronously
+            if (!tilesToRemove.isEmpty()) {
+                final List<BlockEntity> finalTilesToRemove = tilesToRemove;
+                syncTasks.add(() -> {
+                    for (BlockEntity tile : finalTilesToRemove) {
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
+                    }
+                });
+            }
+
+            // Call beacon deactivate events and remove it here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
@@ -598,6 +608,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
+                        PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
                     }
                 });
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
@@ -349,6 +349,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         // Remove existing tiles. Create a copy so that we can remove blocks
         Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
         List<BlockEntity> beacons = null;
+        List<BlockEntity> tilesToRemove = new ArrayList<>();
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
                 final BlockPos pos = entry.getKey();
@@ -368,13 +369,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             beacons = new ArrayList<>();
                         }
                         beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
-                    }
+                    tilesToRemove.add(tile);
                 }
             }
         }
@@ -594,7 +591,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
 
-            // Call beacon deactivate events here synchronously
+            // Remove tiles synchronously
+            if (!tilesToRemove.isEmpty()) {
+                final List<BlockEntity> finalTilesToRemove = tilesToRemove;
+                syncTasks.add(() -> {
+                    for (BlockEntity tile : finalTilesToRemove) {
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
+                    }
+                });
+            }
+
+            // Call beacon deactivate events and remove it here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
@@ -602,6 +612,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
+                        PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
                     }
                 });
             }

--- a/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightGetBlocks.java
@@ -348,6 +348,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         // Remove existing tiles. Create a copy so that we can remove blocks
         Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
         List<BlockEntity> beacons = null;
+        List<BlockEntity> tilesToRemove = new ArrayList<>();
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
                 final BlockPos pos = entry.getKey();
@@ -367,13 +368,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             beacons = new ArrayList<>();
                         }
                         beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
-                    }
+                    tilesToRemove.add(tile);
                 }
             }
         }
@@ -595,7 +592,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
 
-            // Call beacon deactivate events here synchronously
+            // Remove tiles synchronously
+            if (!tilesToRemove.isEmpty()) {
+                final List<BlockEntity> finalTilesToRemove = tilesToRemove;
+                syncTasks.add(() -> {
+                    for (BlockEntity tile : finalTilesToRemove) {
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
+                    }
+                });
+            }
+
+            // Call beacon deactivate events and remove it here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
@@ -604,6 +614,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
+                        PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
                     }
                 });
             }

--- a/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v26_1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-26.1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v26_1/PaperweightGetBlocks.java
@@ -347,6 +347,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
         // Remove existing tiles. Create a copy so that we can remove blocks
         Map<BlockPos, BlockEntity> chunkTiles = new HashMap<>(nmsChunk.getBlockEntities());
         List<BlockEntity> beacons = null;
+        List<BlockEntity> tilesToRemove = new ArrayList<>();
         if (!chunkTiles.isEmpty()) {
             for (Map.Entry<BlockPos, BlockEntity> entry : chunkTiles.entrySet()) {
                 final BlockPos pos = entry.getKey();
@@ -366,13 +367,9 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             beacons = new ArrayList<>();
                         }
                         beacons.add(tile);
-                        PaperweightPlatformAdapter.removeBeacon(tile, nmsChunk);
                         continue;
                     }
-                    nmsChunk.removeBlockEntity(tile.getBlockPos());
-                    if (createCopy) {
-                        copy.storeTile(tile);
-                    }
+                    tilesToRemove.add(tile);
                 }
             }
         }
@@ -594,7 +591,20 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
             int bx = chunkX << 4;
             int bz = chunkZ << 4;
 
-            // Call beacon deactivate events here synchronously
+            // Remove tiles synchronously
+            if (!tilesToRemove.isEmpty()) {
+                final List<BlockEntity> finalTilesToRemove = tilesToRemove;
+                syncTasks.add(() -> {
+                    for (BlockEntity tile : finalTilesToRemove) {
+                        nmsChunk.removeBlockEntity(tile.getBlockPos());
+                        if (createCopy) {
+                            copy.storeTile(tile);
+                        }
+                    }
+                });
+            }
+
+            // Call beacon deactivate events and remove it here synchronously
             // list will be null on spigot, so this is an implicit isPaper check
             if (beacons != null && !beacons.isEmpty()) {
                 final List<BlockEntity> finalBeacons = beacons;
@@ -603,6 +613,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                     for (BlockEntity beacon : finalBeacons) {
                         BeaconBlockEntity.playSound(beacon.getLevel(), beacon.getBlockPos(), SoundEvents.BEACON_DEACTIVATE);
                         new BeaconDeactivatedEvent(CraftBlock.at(beacon.getLevel(), beacon.getBlockPos())).callEvent();
+                        PaperweightPlatformAdapter.removeBeacon(beacon, nmsChunk);
                     }
                 });
             }


### PR DESCRIPTION
## Overview
Fix unsafe async block entity removal in Paperweight chunk write adapters.

## Description

This PR fixes an issue where PaperweightGetBlocks#internalCall could remove block entities directly while running on FAWE queue worker threads.

Previously, when an edit replaced blocks in a chunk, existing block entities were removed immediately during chunk processing via LevelChunk#removeBlockEntity or the Paper beacon removal path. As the backing `blockEntities` map is not designed for concurrent writes, this can cause backing map corruption.

### Existing Issues

After removing BEs in the final sync tasks, this may spam logs like `Block entity A @ BlockPos state Block{B}[facing=north,type=single,waterlogged=false] invalid for ticking:` as the removal happens after the chunk section swap.

I am not sure whether the preferred long-term fix is to:

- keep this approach as the minimal thread-safety fix,
- move block entity removal into an earlier synchronous phase before the section swap,

Feedback would be appreciated here, especially around the expected ordering between block entity removal, beacon deactivation events, and the chunk section replacement performed by internalCall.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
