### PR TITLE
Disable global megabuffer

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Functions.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/expression/Functions.java
@@ -133,17 +133,18 @@ public final class Functions {
         map.put("swap", lookup.findStatic(Functions.class, "swap",
                 methodType(double.class, Variable.class, Variable.class)
         ));
-        map.put("gmegabuf", lookup.findStatic(Functions.class, "gmegabuf",
-                methodType(double.class, double.class)
-        ));
-        map.put("gmegabuf", lookup.findStatic(Functions.class, "gmegabuf",
-                methodType(double.class, double.class, double.class)
-        ));
-        map.put("gclosest", lookup.findStatic(Functions.class, "gclosest",
-                methodType(double.class, double.class, double.class, double.class, double.class,
-                        double.class, double.class
-                )
-        ));
+        // FAWE - disable global megabuffer methods
+        // map.put("gmegabuf", lookup.findStatic(Functions.class, "gmegabuf",
+        //         methodType(double.class, double.class)
+        // ));
+        // map.put("gmegabuf", lookup.findStatic(Functions.class, "gmegabuf",
+        //         methodType(double.class, double.class, double.class)
+        // ));
+        // map.put("gclosest", lookup.findStatic(Functions.class, "gclosest",
+        //         methodType(double.class, double.class, double.class, double.class, double.class,
+        //                 double.class, double.class
+        //         )
+        // ));
         map.put("random", lookup.findStatic(Functions.class, "random",
                 methodType(double.class)
         ));
@@ -263,6 +264,11 @@ public final class Functions {
     }
 
     private static double[] getSubBuffer(Int2ObjectMap<double[]> megabuf, int key) {
+        // avoid taking up more than 128 MiB (ignoring overhead)
+        if (megabuf.size() > 16384) {
+            megabuf.clear(); // make elements unreachable as soon as possible
+            throw new ExpressionException(-1, "memory limit reached");
+        }
         return megabuf.computeIfAbsent(key, k -> new double[1024]);
     }
 


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

The global megabuffer is subject to race conditions in FAWE. If at all, it should be implemented in a way that is thread-safe and player(or other context)-scoped.

The megabuffer also only grows, which is also a terrible design.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
