### PR TITLE
Fix partial stream state in MemoryOptimizedHistory lazy getters; harden lazy init

### DIFF
--- a/worldedit-core/build.gradle.kts
+++ b/worldedit-core/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     // Tests
     testRuntimeOnly(libs.log4j.core)
     testImplementation(libs.parallelgzip)
+    testRuntimeOnly(libs.lz4Java) { isTransitive = false }
 }
 
 tasks.test {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistory.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistory.java
@@ -152,12 +152,18 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
                 return idsStreamZip;
             }
             setOrigin(x, z);
-            idsStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-            // Fully initialise (including the header) before publishing to the volatile field:
-            // callers on the fast path read idsStreamZip without holding the lock, so publishing
-            // early would let them write block data before writeHeader has run.
-            FaweOutputStream stream = getCompressedOS(idsStream);
+            // Build the buffer and its wrapper into locals and only publish both fields together
+            // once construction has fully succeeded. Two things this guards against:
+            //  1. If getCompressedOS()/writeHeader() throws, idsStream must not be left non-null
+            //     while idsStreamZip stays null - flush()/close() gate on idsStream != null and
+            //     then dereference idsStreamZip, which would NPE.
+            //  2. Callers on the fast path read the volatile idsStreamZip without holding the
+            //     lock, so publishing it before writeHeader has run would let them write block
+            //     data ahead of the header.
+            FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            FaweOutputStream stream = getCompressedOS(buffer);
             writeHeader(stream, x, y, z);
+            idsStream = buffer;
             idsStreamZip = stream;
             return stream;
         }
@@ -180,9 +186,13 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
             if (biomeStreamZip != null) {
                 return biomeStreamZip;
             }
-            biomeStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-            biomeStreamZip = getCompressedOS(biomeStream);
-            return biomeStreamZip;
+            // See getBlockOS() for why buffer/wrapper must be published together: an exception
+            // from getCompressedOS() must not leave biomeStream non-null with biomeStreamZip null.
+            FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            FaweOutputStream stream = getCompressedOS(buffer);
+            biomeStream = buffer;
+            biomeStreamZip = stream;
+            return stream;
         }
     }
 
@@ -205,8 +215,12 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
             if (entCStreamZip != null) {
                 return entCStreamZip;
             }
-            entCStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-            return entCStreamZip = new NBTOutputStream(getCompressedOS(entCStream));
+            // See getBlockOS() for why buffer/wrapper must be published together.
+            FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            NBTOutputStream stream = new NBTOutputStream(getCompressedOS(buffer));
+            entCStream = buffer;
+            entCStreamZip = stream;
+            return stream;
         }
     }
 
@@ -219,8 +233,12 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
             if (entRStreamZip != null) {
                 return entRStreamZip;
             }
-            entRStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-            return entRStreamZip = new NBTOutputStream(getCompressedOS(entRStream));
+            // See getBlockOS() for why buffer/wrapper must be published together.
+            FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            NBTOutputStream stream = new NBTOutputStream(getCompressedOS(buffer));
+            entRStream = buffer;
+            entRStreamZip = stream;
+            return stream;
         }
     }
 
@@ -233,8 +251,12 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
             if (tileCStreamZip != null) {
                 return tileCStreamZip;
             }
-            tileCStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-            return tileCStreamZip = new NBTOutputStream(getCompressedOS(tileCStream));
+            // See getBlockOS() for why buffer/wrapper must be published together.
+            FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            NBTOutputStream stream = new NBTOutputStream(getCompressedOS(buffer));
+            tileCStream = buffer;
+            tileCStreamZip = stream;
+            return stream;
         }
     }
 
@@ -247,8 +269,12 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
             if (tileRStreamZip != null) {
                 return tileRStreamZip;
             }
-            tileRStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-            return tileRStreamZip = new NBTOutputStream(getCompressedOS(tileRStream));
+            // See getBlockOS() for why buffer/wrapper must be published together.
+            FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            NBTOutputStream stream = new NBTOutputStream(getCompressedOS(buffer));
+            tileRStream = buffer;
+            tileRStreamZip = stream;
+            return stream;
         }
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistory.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistory.java
@@ -23,27 +23,27 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
 
     private byte[][] ids;
     private FastByteArrayOutputStream idsStream;
-    private FaweOutputStream idsStreamZip;
+    private volatile FaweOutputStream idsStreamZip;
 
     private byte[][] biomes;
     private FastByteArrayOutputStream biomeStream;
-    private FaweOutputStream biomeStreamZip;
+    private volatile FaweOutputStream biomeStreamZip;
 
     private byte[][] entC;
     private FastByteArrayOutputStream entCStream;
-    private NBTOutputStream entCStreamZip;
+    private volatile NBTOutputStream entCStreamZip;
 
     private byte[][] entR;
     private FastByteArrayOutputStream entRStream;
-    private NBTOutputStream entRStreamZip;
+    private volatile NBTOutputStream entRStreamZip;
 
     private byte[][] tileC;
     private FastByteArrayOutputStream tileCStream;
-    private NBTOutputStream tileCStreamZip;
+    private volatile NBTOutputStream tileCStreamZip;
 
     private byte[][] tileR;
     private FastByteArrayOutputStream tileRStream;
-    private NBTOutputStream tileRStreamZip;
+    private volatile NBTOutputStream tileRStreamZip;
 
     public MemoryOptimizedHistory(World world) {
         super(world);
@@ -148,11 +148,18 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
             return idsStreamZip;
         }
         synchronized (this) {
+            if (idsStreamZip != null) {
+                return idsStreamZip;
+            }
             setOrigin(x, z);
             idsStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-            idsStreamZip = getCompressedOS(idsStream);
-            writeHeader(idsStreamZip, x, y, z);
-            return idsStreamZip;
+            // Fully initialise (including the header) before publishing to the volatile field:
+            // callers on the fast path read idsStreamZip without holding the lock, so publishing
+            // early would let them write block data before writeHeader has run.
+            FaweOutputStream stream = getCompressedOS(idsStream);
+            writeHeader(stream, x, y, z);
+            idsStreamZip = stream;
+            return stream;
         }
     }
 
@@ -170,6 +177,9 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
             return biomeStreamZip;
         }
         synchronized (this) {
+            if (biomeStreamZip != null) {
+                return biomeStreamZip;
+            }
             biomeStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
             biomeStreamZip = getCompressedOS(biomeStream);
             return biomeStreamZip;
@@ -191,8 +201,13 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
         if (entCStreamZip != null) {
             return entCStreamZip;
         }
-        entCStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-        return entCStreamZip = new NBTOutputStream(getCompressedOS(entCStream));
+        synchronized (this) {
+            if (entCStreamZip != null) {
+                return entCStreamZip;
+            }
+            entCStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            return entCStreamZip = new NBTOutputStream(getCompressedOS(entCStream));
+        }
     }
 
     @Override
@@ -200,8 +215,13 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
         if (entRStreamZip != null) {
             return entRStreamZip;
         }
-        entRStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-        return entRStreamZip = new NBTOutputStream(getCompressedOS(entRStream));
+        synchronized (this) {
+            if (entRStreamZip != null) {
+                return entRStreamZip;
+            }
+            entRStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            return entRStreamZip = new NBTOutputStream(getCompressedOS(entRStream));
+        }
     }
 
     @Override
@@ -209,8 +229,13 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
         if (tileCStreamZip != null) {
             return tileCStreamZip;
         }
-        tileCStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-        return tileCStreamZip = new NBTOutputStream(getCompressedOS(tileCStream));
+        synchronized (this) {
+            if (tileCStreamZip != null) {
+                return tileCStreamZip;
+            }
+            tileCStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            return tileCStreamZip = new NBTOutputStream(getCompressedOS(tileCStream));
+        }
     }
 
     @Override
@@ -218,8 +243,13 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
         if (tileRStreamZip != null) {
             return tileRStreamZip;
         }
-        tileRStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
-        return tileRStreamZip = new NBTOutputStream(getCompressedOS(tileRStream));
+        synchronized (this) {
+            if (tileRStreamZip != null) {
+                return tileRStreamZip;
+            }
+            tileRStream = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
+            return tileRStreamZip = new NBTOutputStream(getCompressedOS(tileRStream));
+        }
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistory.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistory.java
@@ -18,6 +18,12 @@ import java.io.IOException;
  * - No disk usage
  * - High CPU usage
  * - Low memory usage
+ *
+ * <p>Threading: today every caller reaches the lazy {@code get*OS()} getters through
+ * {@link com.fastasyncworldedit.core.history.changeset.AbstractChangeSet#processSet}, which is
+ * {@code synchronized} on this same instance, so lazy initialisation is already mutually exclusive.
+ * The double-checked locking below does not rely on that: it keeps the getters correct in isolation
+ * so a future caller outside {@code processSet} cannot silently reintroduce a lost-update bug.</p>
  */
 public class MemoryOptimizedHistory extends FaweStreamChangeSet {
 
@@ -54,22 +60,24 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
         super.flush();
         synchronized (this) {
             try {
-                if (idsStream != null) {
+                // Gate on the wrapper field, not the buffer field: it is the one being dereferenced,
+                // so this cannot NPE regardless of how the pair was published.
+                if (idsStreamZip != null) {
                     idsStreamZip.flush();
                 }
-                if (biomeStream != null) {
+                if (biomeStreamZip != null) {
                     biomeStreamZip.flush();
                 }
-                if (entCStream != null) {
+                if (entCStreamZip != null) {
                     entCStreamZip.flush();
                 }
-                if (entRStream != null) {
+                if (entRStreamZip != null) {
                     entRStreamZip.flush();
                 }
-                if (tileCStream != null) {
+                if (tileCStreamZip != null) {
                     tileCStreamZip.flush();
                 }
-                if (tileRStream != null) {
+                if (tileRStreamZip != null) {
                     tileRStreamZip.flush();
                 }
             } catch (IOException e) {
@@ -83,37 +91,39 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
         super.close();
         synchronized (this) {
             try {
-                if (idsStream != null) {
+                // Gate on the wrapper field, not the buffer field: it is the one being dereferenced,
+                // so this cannot NPE regardless of how the pair was published.
+                if (idsStreamZip != null) {
                     idsStreamZip.close();
                     ids = idsStream.toByteArrays();
                     idsStream = null;
                     idsStreamZip = null;
                 }
-                if (biomeStream != null) {
+                if (biomeStreamZip != null) {
                     biomeStreamZip.close();
                     biomes = biomeStream.toByteArrays();
                     biomeStream = null;
                     biomeStreamZip = null;
                 }
-                if (entCStream != null) {
+                if (entCStreamZip != null) {
                     entCStreamZip.close();
                     entC = entCStream.toByteArrays();
                     entCStream = null;
                     entCStreamZip = null;
                 }
-                if (entRStream != null) {
+                if (entRStreamZip != null) {
                     entRStreamZip.close();
                     entR = entRStream.toByteArrays();
                     entRStream = null;
                     entRStreamZip = null;
                 }
-                if (tileCStream != null) {
+                if (tileCStreamZip != null) {
                     tileCStreamZip.close();
                     tileC = tileCStream.toByteArrays();
                     tileCStream = null;
                     tileCStreamZip = null;
                 }
-                if (tileRStream != null) {
+                if (tileRStreamZip != null) {
                     tileRStreamZip.close();
                     tileR = tileRStream.toByteArrays();
                     tileRStream = null;
@@ -151,18 +161,25 @@ public class MemoryOptimizedHistory extends FaweStreamChangeSet {
             if (idsStreamZip != null) {
                 return idsStreamZip;
             }
-            setOrigin(x, z);
             // Build the buffer and its wrapper into locals and only publish both fields together
-            // once construction has fully succeeded. Two things this guards against:
-            //  1. If getCompressedOS()/writeHeader() throws, idsStream must not be left non-null
-            //     while idsStreamZip stays null - flush()/close() gate on idsStream != null and
-            //     then dereference idsStreamZip, which would NPE.
-            //  2. Callers on the fast path read the volatile idsStreamZip without holding the
-            //     lock, so publishing it before writeHeader has run would let them write block
-            //     data ahead of the header.
+            // once construction has fully succeeded. getCompressedOS()/writeHeader() can throw, and
+            // flush()/close() must not then find a half-built stream pair. writeHeader() also calls
+            // setOrigin(x, z), so publishing after it means a failed construction leaves the origin
+            // untouched as well.
             FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(Settings.settings().HISTORY.BUFFER_SIZE);
             FaweOutputStream stream = getCompressedOS(buffer);
-            writeHeader(stream, x, y, z);
+            try {
+                writeHeader(stream, x, y, z);
+            } catch (Throwable t) {
+                // The compressed stream is constructed but will never be published, so nothing else
+                // can ever close it. Release it here rather than leaking it plus its buffer.
+                try {
+                    stream.close();
+                } catch (Throwable suppressed) {
+                    t.addSuppressed(suppressed);
+                }
+                throw t;
+            }
             idsStream = buffer;
             idsStreamZip = stream;
             return stream;

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistoryConcurrencyTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistoryConcurrencyTest.java
@@ -11,9 +11,11 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -57,7 +59,7 @@ class MemoryOptimizedHistoryConcurrencyTest {
         for (int i = 0; i < THREADS; i++) {
             Thread thread = new Thread(() -> {
                 try {
-                    barrier.await();
+                    barrier.await(10, TimeUnit.SECONDS);
                     Object stream = getter.call();
                     synchronized (distinctInstances) {
                         distinctInstances.add(stream);
@@ -73,7 +75,11 @@ class MemoryOptimizedHistoryConcurrencyTest {
             thread.start();
         }
 
-        done.await();
+        boolean completed = done.await(30, TimeUnit.SECONDS);
+        if (!completed) {
+            fail("Timed out waiting for racing threads to finish (possible barrier deadlock or hang - "
+                    + (THREADS - done.getCount()) + "/" + THREADS + " threads finished)");
+        }
         assertTrue(failures.isEmpty(), () -> "Threads failed unexpectedly: " + failures);
         assertEquals(
                 1,

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistoryConcurrencyTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistoryConcurrencyTest.java
@@ -1,0 +1,85 @@
+package com.fastasyncworldedit.core.history;
+
+import com.sk89q.worldedit.world.World;
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Regression test for broken double-checked locking in {@link MemoryOptimizedHistory}'s lazy
+ * stream getters. Prior to the fix, concurrent callers of {@code getBlockOS} / {@code
+ * getTileCreateOS} (and siblings) could race past the outer null-check and each construct their
+ * own backing stream, silently discarding one caller's buffer.
+ *
+ * <p>This is a race detector rather than a deterministic reproduction: each test gates many
+ * threads on a {@link CyclicBarrier} so they call the getter at roughly the same instant, and
+ * is repeated to make the offending interleaving likely to surface.
+ */
+class MemoryOptimizedHistoryConcurrencyTest {
+
+    private static final int THREADS = 16;
+    private static final int ITERATIONS = 20;
+
+    @RepeatedTest(ITERATIONS)
+    void getBlockOSReturnsSingleInstanceUnderConcurrency() throws Exception {
+        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
+        assertSingleInstanceAcrossThreads(() -> history.getBlockOS(0, 0, 0), "FaweOutputStream");
+    }
+
+    @RepeatedTest(ITERATIONS)
+    void getTileCreateOSReturnsSingleInstanceUnderConcurrency() throws Exception {
+        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
+        assertSingleInstanceAcrossThreads(history::getTileCreateOS, "NBTOutputStream");
+    }
+
+    /**
+     * Invokes {@code getter} from {@link #THREADS} threads released simultaneously and asserts
+     * that every thread observed the very same instance.
+     */
+    private static void assertSingleInstanceAcrossThreads(Callable<?> getter, String streamName)
+            throws InterruptedException {
+        Set<Object> distinctInstances = Collections.newSetFromMap(new IdentityHashMap<>());
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+        CyclicBarrier barrier = new CyclicBarrier(THREADS);
+        CountDownLatch done = new CountDownLatch(THREADS);
+
+        for (int i = 0; i < THREADS; i++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    barrier.await();
+                    Object stream = getter.call();
+                    synchronized (distinctInstances) {
+                        distinctInstances.add(stream);
+                    }
+                } catch (Throwable t) {
+                    // Recorded rather than rethrown: an exception on a worker thread would
+                    // otherwise leave the set empty and masquerade as a race failure.
+                    failures.add(t);
+                } finally {
+                    done.countDown();
+                }
+            });
+            thread.start();
+        }
+
+        done.await();
+        assertTrue(failures.isEmpty(), () -> "Threads failed unexpectedly: " + failures);
+        assertEquals(
+                1,
+                distinctInstances.size(),
+                "Expected exactly one distinct " + streamName + " instance across all threads"
+        );
+    }
+
+}

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistoryConcurrencyTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistoryConcurrencyTest.java
@@ -1,8 +1,11 @@
 package com.fastasyncworldedit.core.history;
 
 import com.sk89q.worldedit.world.World;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.RepeatedTest;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -13,10 +16,16 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 /**
  * Regression test for broken double-checked locking in {@link MemoryOptimizedHistory}'s lazy
@@ -40,9 +49,33 @@ class MemoryOptimizedHistoryConcurrencyTest {
     }
 
     @RepeatedTest(ITERATIONS)
+    void getBiomeOSReturnsSingleInstanceUnderConcurrency() throws Exception {
+        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
+        assertSingleInstanceAcrossThreads(history::getBiomeOS, "FaweOutputStream");
+    }
+
+    @RepeatedTest(ITERATIONS)
+    void getEntityCreateOSReturnsSingleInstanceUnderConcurrency() throws Exception {
+        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
+        assertSingleInstanceAcrossThreads(history::getEntityCreateOS, "NBTOutputStream");
+    }
+
+    @RepeatedTest(ITERATIONS)
+    void getEntityRemoveOSReturnsSingleInstanceUnderConcurrency() throws Exception {
+        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
+        assertSingleInstanceAcrossThreads(history::getEntityRemoveOS, "NBTOutputStream");
+    }
+
+    @RepeatedTest(ITERATIONS)
     void getTileCreateOSReturnsSingleInstanceUnderConcurrency() throws Exception {
         MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
         assertSingleInstanceAcrossThreads(history::getTileCreateOS, "NBTOutputStream");
+    }
+
+    @RepeatedTest(ITERATIONS)
+    void getTileRemoveOSReturnsSingleInstanceUnderConcurrency() throws Exception {
+        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
+        assertSingleInstanceAcrossThreads(history::getTileRemoveOS, "NBTOutputStream");
     }
 
     /**
@@ -61,6 +94,7 @@ class MemoryOptimizedHistoryConcurrencyTest {
                 try {
                     barrier.await(10, TimeUnit.SECONDS);
                     Object stream = getter.call();
+                    assertNotNull(stream, "getter returned null");
                     synchronized (distinctInstances) {
                         distinctInstances.add(stream);
                     }
@@ -72,6 +106,10 @@ class MemoryOptimizedHistoryConcurrencyTest {
                     done.countDown();
                 }
             });
+            // Daemon: if a getter deadlocks (exactly the failure mode this test guards against),
+            // the thread hangs past the done.await() timeout below rather than keeping the whole
+            // build alive.
+            thread.setDaemon(true);
             thread.start();
         }
 
@@ -86,6 +124,36 @@ class MemoryOptimizedHistoryConcurrencyTest {
                 distinctInstances.size(),
                 "Expected exactly one distinct " + streamName + " instance across all threads"
         );
+    }
+
+    /**
+     * Deterministic regression test for a partial-state bug distinct from the DCL race above:
+     * every lazy getter used to assign its {@code *Stream} buffer field before constructing the
+     * wrapping compressed/NBT stream, which can throw. A failure there left the buffer field
+     * non-null while the wrapper field ({@code *StreamZip}) stayed null - and {@code flush()}/
+     * {@code close()} gate on the buffer field being non-null before dereferencing the wrapper
+     * field, so they would then throw {@link NullPointerException}. The getters now build both
+     * into locals and publish them together, so a failed construction leaves neither field set.
+     *
+     * <p>Forces the failure deterministically with a spy that makes {@code getCompressedOS()}
+     * throw on the first call, rather than trying to trigger a real compression-library
+     * failure.</p>
+     */
+    @Test
+    void getBlockOSFailureLeavesNoPartialStateForFlushOrClose() throws Exception {
+        MemoryOptimizedHistory history = spy(new MemoryOptimizedHistory(mock(World.class)));
+        doThrow(new IOException("forced failure for test")).when(history).getCompressedOS(any(OutputStream.class));
+
+        assertThrows(IOException.class, () -> history.getBlockOS(0, 0, 0),
+                "getBlockOS() should propagate the forced failure");
+
+        // The real regression check: flush()/close() must not NPE on the partially-constructed
+        // state. Both methods catch IOException internally and don't declare NPE, so pre-fix this
+        // would surface as an uncaught NullPointerException escaping flush()/close().
+        assertDoesNotThrow(history::flush,
+                "flush() must not NPE when getBlockOS() failed before publishing its stream");
+        assertDoesNotThrow(history::close,
+                "close() must not NPE when getBlockOS() failed before publishing its stream");
     }
 
 }

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistoryConcurrencyTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/MemoryOptimizedHistoryConcurrencyTest.java
@@ -1,11 +1,16 @@
 package com.fastasyncworldedit.core.history;
 
+import com.fastasyncworldedit.core.internal.io.FaweOutputStream;
 import com.sk89q.worldedit.world.World;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -15,6 +20,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,60 +28,112 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
- * Regression test for broken double-checked locking in {@link MemoryOptimizedHistory}'s lazy
- * stream getters. Prior to the fix, concurrent callers of {@code getBlockOS} / {@code
- * getTileCreateOS} (and siblings) could race past the outer null-check and each construct their
- * own backing stream, silently discarding one caller's buffer.
+ * Tests for the lazy stream getters in {@link MemoryOptimizedHistory}.
  *
- * <p>This is a race detector rather than a deterministic reproduction: each test gates many
- * threads on a {@link CyclicBarrier} so they call the getter at roughly the same instant, and
- * is repeated to make the offending interleaving likely to surface.
+ * <p>The bulk of this class covers a deterministic, single-threaded bug: every getter used to
+ * assign its {@code *Stream} buffer field before constructing the wrapping compressed/NBT stream,
+ * which can throw. A failure there left the buffer field non-null while the wrapper field
+ * ({@code *StreamZip}) stayed null, and {@code flush()}/{@code close()} then dereferenced the
+ * wrapper - so an {@link IOException} during history setup surfaced later as a
+ * {@link NullPointerException} escaping {@code close()}.</p>
+ *
+ * <p>The single {@link RepeatedTest} below covers the double-checked-locking hardening. It is
+ * deliberately the only one of its kind: all production callers currently reach these getters
+ * through {@code AbstractChangeSet#processSet}, which is {@code synchronized} on the same
+ * instance, so the interleaving it looks for is not reachable today and the test documents the
+ * getters' standalone contract rather than guarding a live regression. Repeating it for all six
+ * getters would cost ~2000 threads per CI run for no extra signal.</p>
  */
 class MemoryOptimizedHistoryConcurrencyTest {
 
     private static final int THREADS = 16;
-    private static final int ITERATIONS = 20;
+    private static final int ITERATIONS = 5;
 
+    @FunctionalInterface
+    private interface StreamGetter {
+
+        Object get(MemoryOptimizedHistory history) throws IOException;
+
+    }
+
+    private static Stream<Arguments> allStreamGetters() {
+        return Stream.of(
+                arguments("getBlockOS", (StreamGetter) history -> history.getBlockOS(0, 0, 0)),
+                arguments("getBiomeOS", (StreamGetter) MemoryOptimizedHistory::getBiomeOS),
+                arguments("getEntityCreateOS", (StreamGetter) MemoryOptimizedHistory::getEntityCreateOS),
+                arguments("getEntityRemoveOS", (StreamGetter) MemoryOptimizedHistory::getEntityRemoveOS),
+                arguments("getTileCreateOS", (StreamGetter) MemoryOptimizedHistory::getTileCreateOS),
+                arguments("getTileRemoveOS", (StreamGetter) MemoryOptimizedHistory::getTileRemoveOS)
+        );
+    }
+
+    /**
+     * Regression test for the partial-state bug, across all six getters. Forces the failure
+     * deterministically with a spy that makes {@code getCompressedOS()} throw, rather than trying
+     * to trigger a real compression-library failure.
+     *
+     * <p>Against the pre-fix code every parameter fails with
+     * {@code Cannot invoke FaweOutputStream.flush() because *StreamZip is null}.</p>
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allStreamGetters")
+    void getterFailureLeavesNoPartialStateForFlushOrClose(String name, StreamGetter getter) throws IOException {
+        MemoryOptimizedHistory history = spy(new MemoryOptimizedHistory(mock(World.class)));
+        doThrow(new IOException("forced failure for test")).when(history).getCompressedOS(any(OutputStream.class));
+
+        assertThrows(IOException.class, () -> getter.get(history), name + "() should propagate the forced failure");
+
+        // The real regression check: flush()/close() must not NPE on the partially-constructed
+        // state. Both catch IOException internally and don't declare NPE, so pre-fix this surfaced
+        // as an uncaught NullPointerException escaping flush()/close().
+        assertDoesNotThrow(history::flush, "flush() must not NPE when " + name + "() failed before publishing");
+        assertDoesNotThrow(history::close, "close() must not NPE when " + name + "() failed before publishing");
+    }
+
+    /**
+     * {@code getBlockOS} is the only getter that does further work ({@code writeHeader}) after
+     * successfully constructing the compressed stream. If that work throws, the stream is never
+     * published, so nothing else can ever close it - it must be closed on the way out instead of
+     * being leaked along with its buffer.
+     */
+    @Test
+    void getBlockOSClosesCompressedStreamWhenHeaderWriteFails() throws IOException {
+        MemoryOptimizedHistory history = spy(new MemoryOptimizedHistory(mock(World.class)));
+        List<FaweOutputStream> constructed = new ArrayList<>();
+        doAnswer(invocation -> {
+            FaweOutputStream real = spy((FaweOutputStream) invocation.callRealMethod());
+            constructed.add(real);
+            return real;
+        }).when(history).getCompressedOS(any(OutputStream.class));
+        doThrow(new IOException("forced header failure"))
+                .when(history).writeHeader(any(OutputStream.class), anyInt(), anyInt(), anyInt());
+
+        assertThrows(IOException.class, () -> history.getBlockOS(0, 0, 0));
+
+        assertEquals(1, constructed.size(), "expected exactly one compressed stream to be constructed");
+        verify(constructed.get(0)).close();
+        assertDoesNotThrow(history::flush, "flush() must not NPE after a failed header write");
+        assertDoesNotThrow(history::close, "close() must not NPE after a failed header write");
+    }
+
+    /**
+     * Documents the getters' standalone lazy-init contract: concurrent callers must all observe
+     * the same instance. See the class javadoc for why only {@code getBlockOS} is covered.
+     */
     @RepeatedTest(ITERATIONS)
-    void getBlockOSReturnsSingleInstanceUnderConcurrency() throws Exception {
+    void getBlockOSReturnsSingleInstanceUnderConcurrency() throws InterruptedException {
         MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
         assertSingleInstanceAcrossThreads(() -> history.getBlockOS(0, 0, 0), "FaweOutputStream");
-    }
-
-    @RepeatedTest(ITERATIONS)
-    void getBiomeOSReturnsSingleInstanceUnderConcurrency() throws Exception {
-        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
-        assertSingleInstanceAcrossThreads(history::getBiomeOS, "FaweOutputStream");
-    }
-
-    @RepeatedTest(ITERATIONS)
-    void getEntityCreateOSReturnsSingleInstanceUnderConcurrency() throws Exception {
-        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
-        assertSingleInstanceAcrossThreads(history::getEntityCreateOS, "NBTOutputStream");
-    }
-
-    @RepeatedTest(ITERATIONS)
-    void getEntityRemoveOSReturnsSingleInstanceUnderConcurrency() throws Exception {
-        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
-        assertSingleInstanceAcrossThreads(history::getEntityRemoveOS, "NBTOutputStream");
-    }
-
-    @RepeatedTest(ITERATIONS)
-    void getTileCreateOSReturnsSingleInstanceUnderConcurrency() throws Exception {
-        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
-        assertSingleInstanceAcrossThreads(history::getTileCreateOS, "NBTOutputStream");
-    }
-
-    @RepeatedTest(ITERATIONS)
-    void getTileRemoveOSReturnsSingleInstanceUnderConcurrency() throws Exception {
-        MemoryOptimizedHistory history = new MemoryOptimizedHistory(mock(World.class));
-        assertSingleInstanceAcrossThreads(history::getTileRemoveOS, "NBTOutputStream");
     }
 
     /**
@@ -124,36 +182,6 @@ class MemoryOptimizedHistoryConcurrencyTest {
                 distinctInstances.size(),
                 "Expected exactly one distinct " + streamName + " instance across all threads"
         );
-    }
-
-    /**
-     * Deterministic regression test for a partial-state bug distinct from the DCL race above:
-     * every lazy getter used to assign its {@code *Stream} buffer field before constructing the
-     * wrapping compressed/NBT stream, which can throw. A failure there left the buffer field
-     * non-null while the wrapper field ({@code *StreamZip}) stayed null - and {@code flush()}/
-     * {@code close()} gate on the buffer field being non-null before dereferencing the wrapper
-     * field, so they would then throw {@link NullPointerException}. The getters now build both
-     * into locals and publish them together, so a failed construction leaves neither field set.
-     *
-     * <p>Forces the failure deterministically with a spy that makes {@code getCompressedOS()}
-     * throw on the first call, rather than trying to trigger a real compression-library
-     * failure.</p>
-     */
-    @Test
-    void getBlockOSFailureLeavesNoPartialStateForFlushOrClose() throws Exception {
-        MemoryOptimizedHistory history = spy(new MemoryOptimizedHistory(mock(World.class)));
-        doThrow(new IOException("forced failure for test")).when(history).getCompressedOS(any(OutputStream.class));
-
-        assertThrows(IOException.class, () -> history.getBlockOS(0, 0, 0),
-                "getBlockOS() should propagate the forced failure");
-
-        // The real regression check: flush()/close() must not NPE on the partially-constructed
-        // state. Both methods catch IOException internally and don't declare NPE, so pre-fix this
-        // would surface as an uncaught NullPointerException escaping flush()/close().
-        assertDoesNotThrow(history::flush,
-                "flush() must not NPE when getBlockOS() failed before publishing its stream");
-        assertDoesNotThrow(history::close,
-                "close() must not NPE when getBlockOS() failed before publishing its stream");
     }
 
 }


### PR DESCRIPTION
Part of Phase 1 of the `com.fastasyncworldedit.core.history` improvement plan. Touches `MemoryOptimizedHistory` only.

> **Rewritten after review.** This PR was originally titled and described as fixing a data-loss race. That framing was wrong and has been corrected — see [Correction](#correction) at the bottom. The lead item below is a real, deterministic, single-threaded bug.

## The bug

Every lazy stream getter assigned its `*Stream` buffer field **before** constructing the wrapping compressed/NBT stream, which can throw:

```java
idsStream    = new FastByteArrayOutputStream(...);   // published
idsStreamZip = getCompressedOS(idsStream);           // ← throws
```

`flush()` and `close()` gated on the **buffer** field being non-null and then unconditionally dereferenced the **wrapper** field. So an `IOException` during history setup left a half-built pair, and `FaweStreamChangeSet.add()` swallows that `IOException` with a `printStackTrace()` — meaning the edit carries on and the failure resurfaces much later as an uncaught `NullPointerException` escaping `close()`, after `super.close()` has already run.

Secondary, in `getBlockOS()` only: if `writeHeader()` throws, the compressed stream has been constructed but is never published, so nothing can ever close it. It leaked along with its ~520KB buffer.

## The fix

- **Publish together.** Each getter builds buffer + wrapper into locals and assigns both fields only once construction has fully succeeded, so a failure leaves neither set.
- **Gate on the wrapper.** `flush()`/`close()` now test the `*StreamZip` field they actually dereference, rather than the buffer field. Correct regardless of how the pair was published.
- **Close on failure.** `getBlockOS()` closes the compressed stream if `writeHeader()` throws.
- **Dropped a redundant `setOrigin(x, z)`** in `getBlockOS()` — `writeHeader()` already calls it, and removing it means a failed construction no longer mutates the origin either.

## Also included: lazy-init hardening

The six `*Zip` fields are now `volatile` and all six getters use check → synchronize → re-check. Four of them (the NBT getters) previously had no locking at all, and `getBlockOS`/`getBiomeOS` had an outer check with no re-check inside the lock — so in isolation, 16 concurrent callers each got their own stream (the new `getBlockOSReturnsSingleInstanceUnderConcurrency` test shows exactly that against pre-fix code: `expected: <1> but was: <16>`).

**This is hardening, not a live bug fix.** See the correction below.

## Verification

`:worldedit-core:test` — **183/183 pass**, whole module.

The 12 tests in `MemoryOptimizedHistoryConcurrencyTest` **all fail cleanly against pre-fix code** and all pass with the fix:

| Test | Pre-fix failure |
|---|---|
| `getterFailureLeavesNoPartialStateForFlushOrClose` ×6 getters | `NullPointerException: Cannot invoke ...flush() because "*StreamZip" is null` |
| `getBlockOSClosesCompressedStreamWhenHeaderWriteFails` | `WantedButNotInvoked: faweOutputStream.close()` |
| `getBlockOSReturnsSingleInstanceUnderConcurrency` ×5 | `expected: <1> but was: <16>` |

This replaces the previous test suite, which had two problems the review caught: it repeated a 16-thread race detector across all six getters (~1900 threads per CI run), and its pre-fix failure mode was **heap exhaustion crashing the test JVM**, not a clean assertion. Both are fixed — one race test remains, and every failure above is a clean assertion.

`testRuntimeOnly(libs.lz4Java)` is still needed: lz4-java is `compileOnly` for main, so the test JVM otherwise hits `NoClassDefFoundError: LZ4BlockOutputStream` via `getCompressedOS()`.

## Correction

The original description claimed the DCL race could silently discard recorded changes in production. **That is not reachable**, and the claim should not have shipped:

- Every production caller reaches these getters via `FaweStreamChangeSet.add`/`addTile*`/`addEntity*`/`addBiomeChange`, all of which are only invoked from `AbstractChangeSet.processSet(...)` — which is `public final synchronized` on the *same* instance the getters lock. The unguarded fast-path read is therefore a reentrant read already under the monitor.
- Draining is additionally serialised by `workerSemaphore` (1 permit).
- The alternative `HistoryExtent` path is unsynchronised but `EditSessionBuilder` makes the two paths mutually exclusive (`combineStages` → processor; else → `HistoryExtent`), and that path is driven by a single `EditSession` thread.

The `volatile`/DCL work is kept because the getters should be correct in isolation rather than by accident of a caller's lock, and the class javadoc now states that contract explicitly. But it fixes a latent footgun, not an observed bug.

## Notes

- Rebased onto current `main` (was based on `995c825da`, before the Gradle deprecation fixes in #3592).
- Not rebased on any sibling PR; mergeable independently.
- Building inside a `git worktree` additionally needs the Grgit fix from #3593; deliberately not included.
- Pre-existing, **not** addressed here — worth a follow-up: the getters never consult `AbstractChangeSet.closed`, so a late write task after `close()` constructs a fresh buffer that `ids` will never include, silently losing that history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
