### PR TITLE
Fix lost-wakeup race and non-atomic close() in AbstractChangeSet

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -109,7 +109,7 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
      * <ul>
      *     <li>Synchronizing on {@code this} would let a losing caller correctly block until the
      *     winner finishes, but risks deadlock: {@link #flush()} can block in
-     *     {@link #drainQueue(boolean)}'s {@code workerSemaphore.acquire()} waiting for another
+     *     {@link #drainQueue(boolean)}'s {@code workerSemaphore.acquireUninterruptibly()} waiting for another
      *     thread's in-flight drain to finish, and that other thread may be running a queued write
      *     task that itself synchronizes on {@code this} (e.g. subclasses' lazy stream getters,
      *     such as {@code DiskStorageHistory#getBlockOS}). If this thread already held

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -64,6 +65,10 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     private final AtomicInteger lastException = new AtomicInteger();
     private final Semaphore workerSemaphore = new Semaphore(1, false);
     private final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
+    // Guards close() so that concurrent callers only trigger a single flush; deliberately
+    // separate from the `closed` field below, which is read/written directly by subclasses
+    // (e.g. RollbackOptimizedHistory) and must keep its existing type/visibility/semantics.
+    private final AtomicBoolean closing = new AtomicBoolean();
     protected volatile boolean closed;
 
     public AbstractChangeSet(World world) {
@@ -99,9 +104,19 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
 
     @Override
     public void close() throws IOException {
-        if (!closed) {
-            flush();
-            closed = true;
+        if (closed) {
+            return;
+        }
+        // Ensure only one concurrent caller runs the flush-and-mark-closed sequence; the CAS
+        // atomically decides a single "winner" thread, so no two threads can ever both pass the
+        // `!closed` check and both call flush() as could happen with the old check-then-act code.
+        // Callers that lose the race simply return; `closed` is still guaranteed to become true.
+        if (closing.compareAndSet(false, true)) {
+            try {
+                flush();
+            } finally {
+                closed = true;
+            }
         }
     }
 
@@ -455,16 +470,19 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
 
     private void drainQueue(boolean ignoreRunningState) {
         if (!workerSemaphore.tryAcquire()) {
-            if (ignoreRunningState) {
-                // ignoreRunningState means we want to block
-                // even if another thread is already draining
-                try {
-                    workerSemaphore.acquire();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            } else {
+            if (!ignoreRunningState) {
                 return; // another thread is draining the queue already, ignore
+            }
+            // ignoreRunningState means we want to block
+            // even if another thread is already draining
+            try {
+                workerSemaphore.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                // The permit was never acquired, so this thread must neither drain (that would
+                // break the single-drainer guarantee processSet() relies on) nor fall through to
+                // the release() below, which would hand out a permit that was never held.
+                return;
             }
         }
         try {
@@ -474,6 +492,14 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
             }
         } finally {
             workerSemaphore.release();
+        }
+        // A task may have been enqueued in the window between the final poll() above returning
+        // null and the release() completing. A producer in that window saw availablePermits() == 0
+        // in triggerWorker() and skipped scheduling a drain, so its task would sit in the queue
+        // with no worker to run it and its future would never complete. Now that the permit is
+        // free again, re-check and schedule a worker for anything left behind.
+        if (!queue.isEmpty()) {
+            triggerWorker();
         }
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -495,17 +495,17 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
             if (!ignoreRunningState) {
                 return; // another thread is draining the queue already, ignore
             }
-            // ignoreRunningState means we want to block
-            // even if another thread is already draining
-            try {
-                workerSemaphore.acquire();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                // The permit was never acquired, so this thread must neither drain (that would
-                // break the single-drainer guarantee processSet() relies on) nor fall through to
-                // the release() below, which would hand out a permit that was never held.
-                return;
-            }
+            // ignoreRunningState means we want to block even if another thread is already
+            // draining. The wait must be uninterruptible: this path is only reached from
+            // flush(), whose contract (and close()'s, which flushes before setting `closed`)
+            // is that pending write tasks have been drained when it returns. An interruptible
+            // acquire that returns early on interrupt would let close() mark the changeset
+            // closed with tasks still queued, silently losing history (flush() swallows
+            // exceptions, so nothing would surface). acquireUninterruptibly() keeps waiting
+            // through interrupts and preserves the thread's interrupt status for callers to
+            // observe afterwards. The wait is bounded by the concurrent drainer's finite
+            // queue, the same bound the previous blocking acquire() had.
+            workerSemaphore.acquireUninterruptibly();
         }
         try {
             Runnable next;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -48,7 +48,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -65,10 +64,11 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     private final AtomicInteger lastException = new AtomicInteger();
     private final Semaphore workerSemaphore = new Semaphore(1, false);
     private final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
-    // Guards close() so that concurrent callers only trigger a single flush; deliberately
-    // separate from the `closed` field below, which is read/written directly by subclasses
-    // (e.g. RollbackOptimizedHistory) and must keep its existing type/visibility/semantics.
-    private final AtomicBoolean closing = new AtomicBoolean();
+    // Dedicated lock for close(), deliberately never `this`: see close()'s javadoc for why.
+    // Also deliberately separate from the `closed` field below, which is read/written directly by
+    // subclasses (e.g. RollbackOptimizedHistory) and must keep its existing type/visibility/
+    // semantics.
+    private final Object closeLock = new Object();
     protected volatile boolean closed;
 
     public AbstractChangeSet(World world) {
@@ -102,21 +102,43 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
         }
     }
 
+    /**
+     * Synchronizes on a dedicated lock object rather than {@code this}, and rather than a
+     * lock-free compare-and-set. Both alternatives were considered and rejected:
+     *
+     * <ul>
+     *     <li>Synchronizing on {@code this} would let a losing caller correctly block until the
+     *     winner finishes, but risks deadlock: {@link #flush()} can block in
+     *     {@link #drainQueue(boolean)}'s {@code workerSemaphore.acquire()} waiting for another
+     *     thread's in-flight drain to finish, and that other thread may be running a queued write
+     *     task that itself synchronizes on {@code this} (e.g. subclasses' lazy stream getters,
+     *     such as {@code DiskStorageHistory#getBlockOS}). If this thread already held
+     *     {@code this}'s monitor while waiting on the semaphore, and that other thread needed
+     *     {@code this}'s monitor to make progress and release the semaphore, that's an AB-BA
+     *     deadlock.</li>
+     *     <li>A compare-and-set on an {@code AtomicBoolean} avoids that deadlock but only
+     *     guarantees a single flush runs - a losing caller returns from close() immediately
+     *     rather than waiting for the winner, so close() could return before the changeset is
+     *     actually flushed.</li>
+     * </ul>
+     *
+     * <p>A private lock object that nothing else in the class hierarchy ever synchronizes on
+     * gives both properties at once: losing callers block until the winner's synchronized block
+     * exits (at which point {@code closed} is already {@code true}, so they return immediately
+     * without re-running {@link #flush()}), and there is no path by which this lock can
+     * participate in a cycle with {@code this}'s monitor or {@code workerSemaphore}.</p>
+     */
     @Override
     public void close() throws IOException {
         if (closed) {
             return;
         }
-        // Ensure only one concurrent caller runs the flush-and-mark-closed sequence; the CAS
-        // atomically decides a single "winner" thread, so no two threads can ever both pass the
-        // `!closed` check and both call flush() as could happen with the old check-then-act code.
-        // Callers that lose the race simply return; `closed` is still guaranteed to become true.
-        if (closing.compareAndSet(false, true)) {
-            try {
-                flush();
-            } finally {
-                closed = true;
+        synchronized (closeLock) {
+            if (closed) {
+                return;
             }
+            flush();
+            closed = true;
         }
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSet.java
@@ -491,37 +491,51 @@ public abstract class AbstractChangeSet implements ChangeSet, IBatchProcessor {
     }
 
     private void drainQueue(boolean ignoreRunningState) {
-        if (!workerSemaphore.tryAcquire()) {
+        // A task may be enqueued in the window between a poll() returning null (queue observed
+        // empty) and this method's release() completing: a producer arriving in that window sees
+        // availablePermits() == 0 in triggerWorker() and skips scheduling a drain, so its task
+        // would otherwise sit in the queue with no worker to run it.
+        //
+        // ignoreRunningState callers (flush(), and therefore close()) loop here until a release()
+        // is immediately followed by an empty queue, so this method never returns to them with a
+        // straggler still pending. Returning early and merely re-scheduling an async worker (as a
+        // prior version of this method did) would let flush()/close() return - and the caller
+        // proceed to finalize or log the changeset - while that worker was still about to run on
+        // a different thread, against a resource the caller now considers closed.
+        //
+        // Non-blocking callers (an async worker triggered via triggerWorker()) don't need that
+        // guarantee: they just re-trigger another async worker for anything left behind and
+        // return promptly, exactly as before.
+        while (true) {
+            if (!workerSemaphore.tryAcquire()) {
+                if (!ignoreRunningState) {
+                    return; // another thread is draining the queue already, ignore
+                }
+                // The wait must be uninterruptible: an interruptible acquire that returns early
+                // on interrupt would let close() mark the changeset closed with tasks still
+                // queued, silently losing history (flush() swallows exceptions, so nothing would
+                // surface). acquireUninterruptibly() keeps waiting through interrupts and
+                // preserves the thread's interrupt status for callers to observe afterwards. The
+                // wait is bounded by the concurrent drainer's finite queue.
+                workerSemaphore.acquireUninterruptibly();
+            }
+            try {
+                Runnable next;
+                while ((next = queue.poll()) != null) { // process all tasks in the queue
+                    next.run();
+                }
+            } finally {
+                workerSemaphore.release();
+            }
+            if (queue.isEmpty()) {
+                return;
+            }
             if (!ignoreRunningState) {
-                return; // another thread is draining the queue already, ignore
+                triggerWorker();
+                return;
             }
-            // ignoreRunningState means we want to block even if another thread is already
-            // draining. The wait must be uninterruptible: this path is only reached from
-            // flush(), whose contract (and close()'s, which flushes before setting `closed`)
-            // is that pending write tasks have been drained when it returns. An interruptible
-            // acquire that returns early on interrupt would let close() mark the changeset
-            // closed with tasks still queued, silently losing history (flush() swallows
-            // exceptions, so nothing would surface). acquireUninterruptibly() keeps waiting
-            // through interrupts and preserves the thread's interrupt status for callers to
-            // observe afterwards. The wait is bounded by the concurrent drainer's finite
-            // queue, the same bound the previous blocking acquire() had.
-            workerSemaphore.acquireUninterruptibly();
-        }
-        try {
-            Runnable next;
-            while ((next = queue.poll()) != null) { // process all tasks in the queue
-                next.run();
-            }
-        } finally {
-            workerSemaphore.release();
-        }
-        // A task may have been enqueued in the window between the final poll() above returning
-        // null and the release() completing. A producer in that window saw availablePermits() == 0
-        // in triggerWorker() and skipped scheduling a drain, so its task would sit in the queue
-        // with no worker to run it and its future would never complete. Now that the permit is
-        // free again, re-check and schedule a worker for anything left behind.
-        if (!queue.isEmpty()) {
-            triggerWorker();
+            // ignoreRunningState: loop back and drain again rather than handing off to an async
+            // worker, so this method doesn't return until the queue is truly empty.
         }
     }
 

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSetConcurrencyTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSetConcurrencyTest.java
@@ -155,6 +155,69 @@ class AbstractChangeSetConcurrencyTest {
     }
 
     /**
+     * Stress test for the specific completeness contract {@code close()} (via {@code flush()})
+     * must uphold: every task enqueued before {@code close()} is called must have finished
+     * running by the time {@code close()} <em>returns</em> - not merely "eventually", and not
+     * left to a background async worker scheduled after the fact. Prior to fixing
+     * {@code drainQueue()}'s post-release handling, a straggler task landing in the queue during
+     * the narrow (last {@code poll()} returned null … {@code release()} completes) window was
+     * handed off to an async re-trigger and could run on another thread after {@code close()} had
+     * already returned - and after a caller like {@code RollbackOptimizedHistory.close()} had
+     * already logged the (not-yet-fully-flushed) edit to the database.
+     *
+     * <p>Same honesty caveat as {@link #addWriteTaskFuturesAllCompleteUnderContention()}: hitting
+     * that exact window isn't forced deterministically here, but keeping producers and async
+     * drain workers both active up to the moment {@code close()} is called gives it a real,
+     * non-contrived opportunity to occur, and the assertion below - checking {@code isDone()}
+     * immediately, with no timeout tolerance for asynchronous completion - is the one that would
+     * actually fail if it did.</p>
+     */
+    @Test
+    void closeDoesNotReturnWithAnyPreviouslyEnqueuedTaskStillPending() throws Exception {
+        TestChangeSet changeSet = new TestChangeSet();
+
+        int producerThreads = 16;
+        int tasksPerThread = 200;
+        List<Future<?>> writeTaskFutures = Collections.synchronizedList(new ArrayList<>());
+
+        Fawe faweMock = newFaweMockWithAsyncPool(8);
+        ExecutorService producers = newFaweAwareFixedThreadPool(producerThreads, faweMock);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<?>> producerHandles = new ArrayList<>();
+
+        for (int t = 0; t < producerThreads; t++) {
+            producerHandles.add(producers.submit(() -> {
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int i = 0; i < tasksPerThread; i++) {
+                    Future<?> future = changeSet.addWriteTask(() -> {
+                    }, false);
+                    writeTaskFutures.add(future);
+                }
+            }));
+        }
+
+        startLatch.countDown();
+        // Wait for all producers to finish *submitting* (not necessarily executing) their tasks,
+        // so every future below was genuinely enqueued before close() is called - while async
+        // drain workers are very likely still actively processing the queue concurrently.
+        for (Future<?> handle : producerHandles) {
+            handle.get(15, TimeUnit.SECONDS);
+        }
+
+        changeSet.close();
+
+        for (Future<?> future : writeTaskFutures) {
+            assertTrue(future.isDone(), "a task enqueued before close() was called must have "
+                    + "finished by the time close() returns, not merely eventually");
+        }
+    }
+
+    /**
      * Concurrent close() calls must be safe: no exceptions, and the instance ends up closed.
      * Does not attempt to prove flush() only ran once (that's covered by close()'s
      * synchronized-on-closeLock guard), just that racing close() is safe and idempotent from

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSetConcurrencyTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSetConcurrencyTest.java
@@ -1,0 +1,241 @@
+package com.fastasyncworldedit.core.history.changeset;
+
+import com.fastasyncworldedit.core.Fawe;
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
+import com.fastasyncworldedit.core.queue.implementation.QueueHandler;
+import com.sk89q.worldedit.extent.inventory.BlockBag;
+import com.sk89q.worldedit.history.change.Change;
+import com.sk89q.worldedit.world.biome.BiomeType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for the write-worker queue lost-wakeup race and non-atomic {@code close()} in
+ * {@link AbstractChangeSet}.
+ */
+class AbstractChangeSetConcurrencyTest {
+
+    private final List<ExecutorService> poolsToShutdown = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        poolsToShutdown.forEach(ExecutorService::shutdownNow);
+        poolsToShutdown.clear();
+    }
+
+    /**
+     * {@link AbstractChangeSet#triggerWorker()} dispatches drain work via
+     * {@code Fawe.instance().getQueueHandler().async(...)}. There is no live Fawe platform in unit
+     * tests, so every thread that may reach that code path needs {@code Fawe.instance()} stubbed.
+     * Mockito's static mocks are thread-confined (a {@link MockedStatic} registered on one thread
+     * has no effect on calls made from another thread), so a single {@code mockStatic()} call in
+     * the test thread is not enough here - producer threads and the emulated async-drain-worker
+     * pool both call into {@code Fawe.instance()} directly. To cover every thread, this creates a
+     * {@link ThreadFactory} whose threads open the {@link MockedStatic} scope for their entire
+     * lifetime (wrapping the pool's internal work loop) before ever executing a submitted task.
+     */
+    private ExecutorService newFaweAwareFixedThreadPool(int threads, Fawe faweMock) {
+        ThreadFactory factory = runnable -> new Thread(() -> {
+            try (MockedStatic<Fawe> faweStatic = Mockito.mockStatic(Fawe.class)) {
+                faweStatic.when(Fawe::instance).thenReturn(faweMock);
+                runnable.run();
+            }
+        });
+        ExecutorService pool = Executors.newFixedThreadPool(threads, factory);
+        poolsToShutdown.add(pool);
+        return pool;
+    }
+
+    /**
+     * Creates the mocked {@code Fawe}/{@code QueueHandler} pair and the Fawe-aware pool that backs
+     * {@code QueueHandler.async(...)}. The async-drain-worker pool must itself be Fawe-aware too:
+     * {@code drainQueue}'s lost-wakeup re-check can call {@code triggerWorker()} - and therefore
+     * {@code Fawe.instance()} - again from a drain-worker thread, not just from producer threads.
+     */
+    private Fawe newFaweMockWithAsyncPool(int asyncPoolThreads) {
+        Fawe faweMock = Mockito.mock(Fawe.class);
+        QueueHandler queueHandlerMock = Mockito.mock(QueueHandler.class);
+        when(faweMock.getQueueHandler()).thenReturn(queueHandlerMock);
+        ExecutorService asyncPool = newFaweAwareFixedThreadPool(asyncPoolThreads, faweMock);
+        when(queueHandlerMock.async(any(Runnable.class))).thenAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            return asyncPool.submit(task);
+        });
+        return faweMock;
+    }
+
+    /**
+     * Stress the write-worker queue: many threads race to enqueue write tasks while workers drain
+     * them. Prior to the lost-wakeup fix, a drainer could observe the queue as empty and release
+     * its permit at the same moment a producer added a task and found the permit still "held",
+     * skipping the scheduling of a new worker; the produced task's future would then never
+     * complete. With the fix, every returned future must complete promptly.
+     */
+    @Test
+    void addWriteTaskFuturesAllCompleteUnderContention() throws Exception {
+        TestChangeSet changeSet = new TestChangeSet();
+
+        int producerThreads = 16;
+        int tasksPerThread = 200;
+        AtomicInteger executedCount = new AtomicInteger();
+        List<Future<?>> writeTaskFutures = Collections.synchronizedList(new ArrayList<>());
+
+        // Async-drain-worker pool emulating FAWE's real QueueHandler executor (where
+        // drainQueue(false) actually runs), plus the producer pool that calls addWriteTask(...).
+        // Both need Fawe.instance() stubbed - see newFaweAwareFixedThreadPool's javadoc.
+        Fawe faweMock = newFaweMockWithAsyncPool(8);
+        ExecutorService producers = newFaweAwareFixedThreadPool(producerThreads, faweMock);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<?>> producerHandles = new ArrayList<>();
+
+        for (int t = 0; t < producerThreads; t++) {
+            producerHandles.add(producers.submit(() -> {
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int i = 0; i < tasksPerThread; i++) {
+                    // completeNow = false forces tasks through the async queue/drainQueue path
+                    // that contains the fix, rather than running synchronously.
+                    Future<?> future = changeSet.addWriteTask(executedCount::incrementAndGet, false);
+                    writeTaskFutures.add(future);
+                }
+            }));
+        }
+
+        startLatch.countDown();
+        for (Future<?> handle : producerHandles) {
+            handle.get(15, TimeUnit.SECONDS);
+        }
+
+        int expected = producerThreads * tasksPerThread;
+        assertEquals(expected, writeTaskFutures.size());
+
+        // The core assertion: none of these futures should hang. On the unfixed code this
+        // occasionally times out under enough contention because a task got stranded in the
+        // queue with no worker left to drain it.
+        for (Future<?> future : writeTaskFutures) {
+            future.get(10, TimeUnit.SECONDS);
+        }
+
+        assertEquals(expected, executedCount.get());
+    }
+
+    /**
+     * Concurrent close() calls must be safe: no exceptions, and the instance ends up closed.
+     * Does not attempt to prove flush() only ran once (that's covered by close()'s CAS guard),
+     * just that racing close() is safe and idempotent from the outside.
+     */
+    @Test
+    void concurrentCloseIsSafeAndIdempotent() throws Exception {
+        TestChangeSet changeSet = new TestChangeSet();
+
+        Fawe faweMock = newFaweMockWithAsyncPool(4);
+
+        int threads = 8;
+        ExecutorService pool = newFaweAwareFixedThreadPool(threads, faweMock);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threads; i++) {
+            futures.add(pool.submit(() -> {
+                try {
+                    startLatch.await();
+                    changeSet.close();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+        }
+
+        startLatch.countDown();
+        for (Future<?> future : futures) {
+            future.get(10, TimeUnit.SECONDS);
+        }
+
+        assertTrue(changeSet.closed);
+    }
+
+    /**
+     * Minimal concrete {@link AbstractChangeSet} for exercising queue/close concurrency without
+     * any platform/world dependencies. {@link NullChangeSet} is not usable here since it overrides
+     * {@code close()} as a no-op, bypassing the exact logic under test.
+     */
+    private static class TestChangeSet extends AbstractChangeSet {
+
+        TestChangeSet() {
+            super(null);
+        }
+
+        @Override
+        public void add(int x, int y, int z, int combinedFrom, int combinedTo) {
+        }
+
+        @Override
+        public void addTileCreate(FaweCompoundTag tag) {
+        }
+
+        @Override
+        public void addTileRemove(FaweCompoundTag tag) {
+        }
+
+        @Override
+        public void addEntityRemove(FaweCompoundTag tag) {
+        }
+
+        @Override
+        public void addEntityCreate(FaweCompoundTag tag) {
+        }
+
+        @Override
+        public void addBiomeChange(int x, int y, int z, BiomeType from, BiomeType to) {
+        }
+
+        @Override
+        public ChangeExchangeCoordinator getCoordinatedChanges(BlockBag blockBag, int mode, boolean dir) {
+            return null;
+        }
+
+        @Override
+        public Iterator<Change> getIterator(boolean redo) {
+            return Collections.emptyIterator();
+        }
+
+        @Override
+        public boolean isRecordingChanges() {
+            return false;
+        }
+
+        @Override
+        public void setRecordChanges(boolean recordChanges) {
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+    }
+
+}

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSetConcurrencyTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/history/changeset/AbstractChangeSetConcurrencyTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -21,16 +22,26 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
- * Regression tests for the write-worker queue lost-wakeup race and non-atomic {@code close()} in
- * {@link AbstractChangeSet}.
+ * Concurrency tests for the write-worker queue and {@code close()} in {@link AbstractChangeSet}.
+ *
+ * <p>Honesty note on what these tests prove: the lost-wakeup window in the pre-fix
+ * {@code drainQueue()} is a narrow interleaving that this stress test does <em>not</em> reliably
+ * hit — it passes against the unfixed code too. It is a contention smoke test guarding the
+ * queue/close paths against gross regressions (hangs, dropped tasks, exceptions), not a
+ * deterministic reproduction of the race. The lost-wakeup and close-atomicity fixes rest on the
+ * reasoning documented in {@code AbstractChangeSet} itself. The interrupt test below <em>is</em>
+ * deterministic for the behavior it checks.</p>
  */
 class AbstractChangeSetConcurrencyTest {
 
@@ -132,9 +143,10 @@ class AbstractChangeSetConcurrencyTest {
         int expected = producerThreads * tasksPerThread;
         assertEquals(expected, writeTaskFutures.size());
 
-        // The core assertion: none of these futures should hang. On the unfixed code this
-        // occasionally times out under enough contention because a task got stranded in the
-        // queue with no worker left to drain it.
+        // The core assertion: none of these futures should hang. On the unfixed code a task
+        // could in principle be stranded in the queue with no worker left to drain it (the
+        // lost-wakeup window), though in practice this test does not reliably hit that narrow
+        // interleaving - see the class javadoc. A timeout here still catches gross regressions.
         for (Future<?> future : writeTaskFutures) {
             future.get(10, TimeUnit.SECONDS);
         }
@@ -144,8 +156,9 @@ class AbstractChangeSetConcurrencyTest {
 
     /**
      * Concurrent close() calls must be safe: no exceptions, and the instance ends up closed.
-     * Does not attempt to prove flush() only ran once (that's covered by close()'s CAS guard),
-     * just that racing close() is safe and idempotent from the outside.
+     * Does not attempt to prove flush() only ran once (that's covered by close()'s
+     * synchronized-on-closeLock guard), just that racing close() is safe and idempotent from
+     * the outside.
      */
     @Test
     void concurrentCloseIsSafeAndIdempotent() throws Exception {
@@ -175,6 +188,76 @@ class AbstractChangeSetConcurrencyTest {
         }
 
         assertTrue(changeSet.closed);
+    }
+
+    /**
+     * Deterministic regression test for the interrupted-close hole: a thread that calls
+     * {@code close()} while another worker holds the drain permit, and that is interrupted,
+     * must still wait for the queue to be drained before {@code close()} returns — and must
+     * observe its interrupt flag afterwards. Prior to the {@code acquireUninterruptibly} fix,
+     * the interrupted closer returned from the semaphore wait early, {@code flush()} swallowed
+     * the situation, and {@code close()} marked the changeset closed with tasks still queued.
+     *
+     * <p>Both outcomes are checked deterministically: pre-fix, {@code close()} returns almost
+     * immediately (the interrupted acquire throws at once when the flag is already set), which
+     * the short-timeout {@code get} below converts into a test failure; post-fix, {@code close()}
+     * is still blocked at that point and completes only after the in-flight drainer is
+     * released.</p>
+     */
+    @Test
+    void interruptedCloseStillDrainsQueue() throws Exception {
+        TestChangeSet changeSet = new TestChangeSet();
+        Fawe faweMock = newFaweMockWithAsyncPool(2);
+
+        CountDownLatch drainerStarted = new CountDownLatch(1);
+        CountDownLatch releaseDrainer = new CountDownLatch(1);
+        AtomicInteger executed = new AtomicInteger();
+
+        ExecutorService submitter = newFaweAwareFixedThreadPool(1, faweMock);
+        // First task occupies the single drain permit until released.
+        submitter.submit(() -> changeSet.addWriteTask(() -> {
+            drainerStarted.countDown();
+            try {
+                releaseDrainer.await(20, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            executed.incrementAndGet();
+        }, false)).get(10, TimeUnit.SECONDS);
+        assertTrue(drainerStarted.await(10, TimeUnit.SECONDS), "drain worker never started");
+
+        // Second task sits in the queue behind the blocked drainer; triggerWorker skips
+        // scheduling because the permit is held.
+        submitter.submit(() -> changeSet.addWriteTask(executed::incrementAndGet, false))
+                .get(10, TimeUnit.SECONDS);
+
+        AtomicBoolean interruptFlagPreserved = new AtomicBoolean();
+        ExecutorService closer = newFaweAwareFixedThreadPool(1, faweMock);
+        Future<?> closeResult = closer.submit(() -> {
+            // Arrive at the semaphore wait with the interrupt flag already set: the pre-fix
+            // interruptible acquire() throws immediately in that state.
+            Thread.currentThread().interrupt();
+            try {
+                changeSet.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            interruptFlagPreserved.set(Thread.interrupted());
+        });
+
+        try {
+            closeResult.get(2, TimeUnit.SECONDS);
+            fail("close() returned before pending write tasks were drained (pre-fix behavior)");
+        } catch (TimeoutException expectedWhileDrainerHoldsPermit) {
+            // Correct: close() is waiting uninterruptibly for the in-flight drainer.
+        }
+
+        releaseDrainer.countDown();
+        closeResult.get(15, TimeUnit.SECONDS);
+
+        assertEquals(2, executed.get(), "close() must not return with queued tasks undrained");
+        assertTrue(changeSet.closed);
+        assertTrue(interruptFlagPreserved.get(), "the interrupt flag must survive close()");
     }
 
     /**


### PR DESCRIPTION
Part of Phase 1 (concurrency hardening) of the `com.fastasyncworldedit.core.history` improvement plan. One of five independent PRs; this one only touches `AbstractChangeSet`.

## The bugs

1. **Lost wakeup.** `drainQueue()` polled until the queue was empty and only then released its permit. A producer that enqueued in the window between the final `poll()` and the `release()` saw `availablePermits() == 0` in `triggerWorker()` and skipped scheduling a worker. The task then sat in the queue with nothing to drain it, and the `CompletableFuture` returned by `addWriteTask()` / `postProcessSet()` never completed.
2. **Permit released without being acquired.** When the blocking `acquire()` path was interrupted, the `InterruptedException` was caught but execution fell through into the drain and its `finally { release(); }`. That pushes the semaphore above its single permit and lets two workers drain concurrently, breaking the single-drainer guarantee `processSet()` relies on. (Found while fixing #1 — same method, same invariant.)
3. **Non-atomic `close()`.** A check-then-act on `closed` let two callers both observe `false` and both run `flush()`.

## The fix (revised after code review — see commits 4e3489e5f and bda8f63cc)

- Re-check the queue after releasing the permit and schedule a worker for anything left behind.
- **`close()` synchronizes on a dedicated private `closeLock`**, not a CAS. The original CAS guaranteed a single flush but let a losing caller return from `close()` *before* the winner finished flushing — violating `Closeable` semantics for callers like `RollbackOptimizedHistory.close()`, which logs to the rollback DB immediately after `super.close()`. Synchronizing on `this` instead would fix that but risks an AB-BA deadlock: `flush()` can block on the drain semaphore while the thread holding it runs a queued write task that itself synchronizes on `this` (subclasses' lazy stream getters do). A dedicated lock object that nothing else in the hierarchy touches gives both properties: losing callers block until the winner finishes, with no possible lock-ordering cycle.
- **`drainQueue(true)`'s blocking wait is now uninterruptible** (`acquireUninterruptibly()`), not interruptible-with-early-return. An interrupted closer used to return early with the queue still undrained while `close()` marked the changeset closed anyway — silent history loss, since `flush()` swallows exceptions and nothing surfaced. The interrupt flag is preserved for the caller to observe afterwards.

## Verification

- `:worldedit-core:compileJava` / `compileTestJava` pass.
- `AbstractChangeSetConcurrencyTest`: 3/3 pass with the fix.
- The original two tests (lost-wakeup stress test, concurrent-close stress test) also pass against pre-fix code, so they do *not* reproduce those races — the windows are narrow interleavings a stress test doesn't reliably hit. Treat them as smoke tests, not proof. This is stated explicitly in the test's class javadoc.
- **`interruptedCloseStillDrainsQueue` (added in bda8f63cc) is a deterministic regression test** for the interrupt hole: it fails against the pre-fix code with `close() returned before pending write tasks were drained`, and passes with the fix, including asserting the interrupt flag survives.

## Notes

- Not rebased on any sibling PR; mergeable independently.
- Builds inside a `git worktree` additionally need the Grgit fix from #3593; deliberately not included (CI uses a normal checkout).
- **Requesting a second reviewer specifically on 4e3489e5f and bda8f63cc before merge** — see the PR comment below for what to double-check (deadlock reasoning across subclasses I didn't audit, and whether any caller actually relies on close() being interruptible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
