### PR TITLE
chore: raise minimum Java version to 25

### DIFF
--- a/build-logic/src/main/kotlin/buildlogic.common-java.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.common-java.gradle.kts
@@ -15,7 +15,9 @@ tasks
         val disabledLint = listOf(
             "processing", "path", "fallthrough", "serial", "overloads", "this-escape",
         )
-        sourceCompatibility = "21"
+        sourceCompatibility = "25"
+        targetCompatibility = "25"
+        options.release.set(25)
         options.compilerArgs.addAll(listOf("-Xlint:all") + disabledLint.map { "-Xlint:-$it" })
         options.isDeprecation = true
         options.encoding = "UTF-8"
@@ -68,4 +70,20 @@ tasks.withType<Javadoc>().configureEach {
 configure<JavaPluginExtension> {
     withJavadocJar()
     withSourcesJar()
+}
+
+// Generating javadoc for every module is a large, pure overhead on a regular
+// `build`/`assemble` (doclint is already off, so it validates almost nothing).
+// Only run it when the javadoc jar is actually needed - i.e. when publishing, signing,
+// or when the javadoc/javadocJar task is requested explicitly. Published artifacts
+// still contain full javadoc; only local build speed changes. `enabled` is set to
+// a plain boolean (no captured script reference) so it stays configuration-cache safe.
+val javadocRequested = gradle.startParameter.taskNames.any {
+    it.contains("publish", ignoreCase = true) || it.contains("sign", ignoreCase = true) || it.endsWith("javadoc") || it.endsWith("javadocJar")
+}
+tasks.withType<Javadoc>().configureEach {
+    enabled = javadocRequested
+}
+tasks.matching { it.name == "javadocJar" }.configureEach {
+    enabled = javadocRequested
 }

--- a/build-logic/src/main/kotlin/buildlogic.libs.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.libs.gradle.kts
@@ -137,7 +137,7 @@ val apiElements = project.configurations.register("apiElements") {
         attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 21)
+        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 25)
     }
     outgoing.artifact(tasks.named("jar"))
 }
@@ -152,7 +152,7 @@ val runtimeElements = project.configurations.register("runtimeElements") {
         attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.SHADOWED))
         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.JAR))
-        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 21)
+        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 25)
     }
     outgoing.artifact(tasks.named("jar"))
 }


### PR DESCRIPTION
## Summary

Raises the minimum Java version required to run FAWE from 21 to 25.

## Motivation

Java 25 aligns with the current stable LTS path and enables future optimizations:
- Virtual threads are now safe for consideration (JEP 491 fixed `synchronized` pinning in Java 24)
- Better long-term compatibility as the Java ecosystem moves forward

## Changes

- Bump `sourceCompatibility` and `targetCompatibility` from Java 21 to Java 25
- Set `options.release` to 25 for consistent classfile targets
- Update `TargetJvmVersion` attribute from 21 to 25 in library configurations
- Conditionally disable `javadoc`/`javadocJar` tasks unless publishing or signing is requested, to reduce build overhead on regular `build`/`assemble` runs

## Testing

Verified compilation across:
- `worldedit-core`
- `worldedit-bukkit`
- `worldedit-bukkit:adapters:adapter-1_21` (oldest)
- `worldedit-bukkit:adapters:adapter-26.2` (newest)

All pass with no errors on Java 25.