### PR TITLE
Use older Piston version for Java 21 compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ guice = "7.0.0"
 ## Internal
 text-adapter = "3.0.6"
 text = "3.0.4"
-piston = "0.6.0"
+piston = "0.5.11"
 
 # Tests
 mockito = "5.23.0"

--- a/worldedit-bukkit/build.gradle.kts
+++ b/worldedit-bukkit/build.gradle.kts
@@ -27,25 +27,14 @@ repositories {
     }
     mavenCentral()
     maven {
-        name = "JitPack"
-        url = uri("https://jitpack.io")
-        content {
-            includeGroup("com.github.Zrips")
-            includeGroup("com.github.MilkBowl")
-            includeGroup("com.github.TechFortress")
-        }
-    }
-    maven {
-        name = "GriefDefender"
-        url = uri("https://repo.glaremasters.me/repository/bloodshot/")
+        // mirroring + caching from unstable third-party repositories for community plugins (partially limited by routing rules)
+        // (currently Residence, GriefPrevention, GriefDefender, Towny)
+        name = "IntellectualSites Repository"
+        url = uri("https://repo.intellectualsites.dev/repository/maven-all/")
     }
     maven {
         name = "OSS Sonatype Snapshots"
         url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-    maven {
-        name = "Glaremasters"
-        url = uri("https://repo.glaremasters.me/repository/towny/")
     }
     flatDir { dir(File("src/main/resources")) }
 }


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

## Description
<!-- Please describe what this pull request does. -->

To still support Java 21, we need to use an older Piston version.
From a quick look, it doesn't seem like we're missing out on anything important.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
