### PR TITLE
Fix signs displaying JSON text on Minecraft 1.21.5+

### DIFF
--- a/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
+++ b/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
@@ -46,7 +46,7 @@ public class SignBlock extends LegacyBaseBlockWrapper {
 
     private String[] text;
 
-    private static final String EMPTY =  "{\"text\":\"\"}";
+    private static final String EMPTY_JSON = "{\"text\":\"\"}";
 
     /**
      * Construct the sign with text.
@@ -57,22 +57,36 @@ public class SignBlock extends LegacyBaseBlockWrapper {
     public SignBlock(BlockState blockState, String[] text) {
         super(blockState);
         if (text == null) {
-            this.text = new String[]{EMPTY, EMPTY, EMPTY, EMPTY};
+            String empty = emptyText();
+            this.text = new String[]{empty, empty, empty, empty};
             return;
         }
-        for (int i = 0; i < text.length; i++) {
-            if (text[i].isEmpty()) {
-                text[i] = EMPTY;
-            } else {
-                text[i] = "{\"text\":" + GsonUtil.stringValue(text[i]) + "}";
+        if (usesJsonText()) {
+            for (int i = 0; i < text.length; i++) {
+                if (text[i].isEmpty()) {
+                    text[i] = EMPTY_JSON;
+                } else {
+                    text[i] = "{\"text\":" + GsonUtil.stringValue(text[i]) + "}";
+                }
             }
         }
         this.text = text;
     }
 
     private boolean isLegacy() {
-        int dataVersion = WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING).getDataVersion();
-        return dataVersion < Constants.DATA_VERSION_MC_1_20;
+        return dataVersion() < Constants.DATA_VERSION_MC_1_20;
+    }
+
+    private boolean usesJsonText() {
+        return dataVersion() < Constants.DATA_VERSION_MC_1_21_5;
+    }
+
+    private int dataVersion() {
+        return WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING).getDataVersion();
+    }
+
+    private String emptyText() {
+        return usesJsonText() ? EMPTY_JSON : "";
     }
 
     /**
@@ -136,7 +150,8 @@ public class SignBlock extends LegacyBaseBlockWrapper {
 
         Tag<?, ?> t;
 
-        text = new String[]{EMPTY, EMPTY, EMPTY, EMPTY};
+        String empty = emptyText();
+        text = new String[]{empty, empty, empty, empty};
 
         t = values.get("id");
         if (!(t instanceof StringTag) || !((StringTag) t).getValue().equals(getNbtId())) {

--- a/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
+++ b/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
@@ -46,7 +46,6 @@ public class SignBlock extends LegacyBaseBlockWrapper {
 
     private static final String EMPTY_JSON = "{\"text\":\"\"}";
 
-    private final boolean legacy;
     private final boolean usesJsonText;
     private final String emptyText;
     private String[] text;
@@ -61,7 +60,6 @@ public class SignBlock extends LegacyBaseBlockWrapper {
         super(blockState);
         int dataVersion = WorldEdit.getInstance().getPlatformManager()
                 .queryCapability(Capability.WORLD_EDITING).getDataVersion();
-        this.legacy = dataVersion < Constants.DATA_VERSION_MC_1_20;
         this.usesJsonText = dataVersion < Constants.DATA_VERSION_MC_1_21_5;
         this.emptyText = usesJsonText ? EMPTY_JSON : "";
         if (text == null) {
@@ -116,17 +114,10 @@ public class SignBlock extends LegacyBaseBlockWrapper {
     @Deprecated
     public CompoundTag getNbtData() {
         Map<String, Tag<?, ?>> values = new HashMap<>();
-        if (legacy) {
-            values.put("Text1", new StringTag(text[0]));
-            values.put("Text2", new StringTag(text[1]));
-            values.put("Text3", new StringTag(text[2]));
-            values.put("Text4", new StringTag(text[3]));
-        } else {
-            ListTag<?, ?> messages = new ListTag<>(StringTag.class, Arrays.stream(text).map(StringTag::new).collect(Collectors.toList()));
-            Map<String, Tag<?, ?>> frontTextTag = new HashMap<>();
-            frontTextTag.put("messages", messages);
-            values.put("front_text", new CompoundTag(frontTextTag));
-        }
+        ListTag<?, ?> messages = new ListTag<>(StringTag.class, Arrays.stream(text).map(StringTag::new).collect(Collectors.toList()));
+        Map<String, Tag<?, ?>> frontTextTag = new HashMap<>();
+        frontTextTag.put("messages", messages);
+        values.put("front_text", new CompoundTag(frontTextTag));
         return new CompoundTag(values);
     }
 
@@ -148,33 +139,11 @@ public class SignBlock extends LegacyBaseBlockWrapper {
             throw new RuntimeException(String.format("'%s' tile entity expected", getNbtId()));
         }
 
-        if (legacy) {
-            t = values.get("Text1");
-            if (t instanceof StringTag) {
-                text[0] = ((StringTag) t).getValue();
-            }
-
-            t = values.get("Text2");
-            if (t instanceof StringTag) {
-                text[1] = ((StringTag) t).getValue();
-            }
-
-            t = values.get("Text3");
-            if (t instanceof StringTag) {
-                text[2] = ((StringTag) t).getValue();
-            }
-
-            t = values.get("Text4");
-            if (t instanceof StringTag) {
-                text[3] = ((StringTag) t).getValue();
-            }
-        } else {
-            CompoundTag frontTextTag = (CompoundTag) values.get("front_text");
-            ListTag<?, ?> messagesTag = frontTextTag.getListTag("messages");
-            for (int i = 0; i < messagesTag.getValue().size(); i++) {
-                StringTag tag = (StringTag) messagesTag.getValue().get(i);
-                text[i] = tag.getValue();
-            }
+        CompoundTag frontTextTag = (CompoundTag) values.get("front_text");
+        ListTag<?, ?> messagesTag = frontTextTag.getListTag("messages");
+        for (int i = 0; i < messagesTag.getValue().size(); i++) {
+            StringTag tag = (StringTag) messagesTag.getValue().get(i);
+            text[i] = tag.getValue();
         }
     }
 

--- a/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
+++ b/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
@@ -44,10 +44,12 @@ import java.util.stream.Collectors;
 @Deprecated
 public class SignBlock extends LegacyBaseBlockWrapper {
 
-    private String[] text;
-    private final int dataVersion;
-
     private static final String EMPTY_JSON = "{\"text\":\"\"}";
+
+    private final boolean legacy;
+    private final boolean usesJsonText;
+    private final String emptyText;
+    private String[] text;
 
     /**
      * Construct the sign with text.
@@ -57,14 +59,16 @@ public class SignBlock extends LegacyBaseBlockWrapper {
      */
     public SignBlock(BlockState blockState, String[] text) {
         super(blockState);
-        this.dataVersion = WorldEdit.getInstance().getPlatformManager()
+        int dataVersion = WorldEdit.getInstance().getPlatformManager()
                 .queryCapability(Capability.WORLD_EDITING).getDataVersion();
+        this.legacy = dataVersion < Constants.DATA_VERSION_MC_1_20;
+        this.usesJsonText = dataVersion < Constants.DATA_VERSION_MC_1_21_5;
+        this.emptyText = usesJsonText ? EMPTY_JSON : "";
         if (text == null) {
-            String empty = emptyText();
-            this.text = new String[]{empty, empty, empty, empty};
+            this.text = new String[]{emptyText, emptyText, emptyText, emptyText};
             return;
         }
-        if (usesJsonText()) {
+        if (usesJsonText) {
             for (int i = 0; i < text.length; i++) {
                 if (text[i].isEmpty()) {
                     text[i] = EMPTY_JSON;
@@ -74,18 +78,6 @@ public class SignBlock extends LegacyBaseBlockWrapper {
             }
         }
         this.text = text;
-    }
-
-    private boolean isLegacy() {
-        return dataVersion < Constants.DATA_VERSION_MC_1_20;
-    }
-
-    private boolean usesJsonText() {
-        return dataVersion < Constants.DATA_VERSION_MC_1_21_5;
-    }
-
-    private String emptyText() {
-        return usesJsonText() ? EMPTY_JSON : "";
     }
 
     /**
@@ -124,7 +116,7 @@ public class SignBlock extends LegacyBaseBlockWrapper {
     @Deprecated
     public CompoundTag getNbtData() {
         Map<String, Tag<?, ?>> values = new HashMap<>();
-        if (isLegacy()) {
+        if (legacy) {
             values.put("Text1", new StringTag(text[0]));
             values.put("Text2", new StringTag(text[1]));
             values.put("Text3", new StringTag(text[2]));
@@ -149,15 +141,14 @@ public class SignBlock extends LegacyBaseBlockWrapper {
 
         Tag<?, ?> t;
 
-        String empty = emptyText();
-        text = new String[]{empty, empty, empty, empty};
+        text = new String[]{emptyText, emptyText, emptyText, emptyText};
 
         t = values.get("id");
         if (!(t instanceof StringTag) || !((StringTag) t).getValue().equals(getNbtId())) {
             throw new RuntimeException(String.format("'%s' tile entity expected", getNbtId()));
         }
 
-        if (isLegacy()) {
+        if (legacy) {
             t = values.get("Text1");
             if (t instanceof StringTag) {
                 text[0] = ((StringTag) t).getValue();

--- a/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
+++ b/worldedit-core/src/legacy/java/com/sk89q/worldedit/blocks/SignBlock.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 public class SignBlock extends LegacyBaseBlockWrapper {
 
     private String[] text;
+    private final int dataVersion;
 
     private static final String EMPTY_JSON = "{\"text\":\"\"}";
 
@@ -56,6 +57,8 @@ public class SignBlock extends LegacyBaseBlockWrapper {
      */
     public SignBlock(BlockState blockState, String[] text) {
         super(blockState);
+        this.dataVersion = WorldEdit.getInstance().getPlatformManager()
+                .queryCapability(Capability.WORLD_EDITING).getDataVersion();
         if (text == null) {
             String empty = emptyText();
             this.text = new String[]{empty, empty, empty, empty};
@@ -74,15 +77,11 @@ public class SignBlock extends LegacyBaseBlockWrapper {
     }
 
     private boolean isLegacy() {
-        return dataVersion() < Constants.DATA_VERSION_MC_1_20;
+        return dataVersion < Constants.DATA_VERSION_MC_1_20;
     }
 
     private boolean usesJsonText() {
-        return dataVersion() < Constants.DATA_VERSION_MC_1_21_5;
-    }
-
-    private int dataVersion() {
-        return WorldEdit.getInstance().getPlatformManager().queryCapability(Capability.WORLD_EDITING).getDataVersion();
+        return dataVersion < Constants.DATA_VERSION_MC_1_21_5;
     }
 
     private String emptyText() {

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/blocks/SignBlockTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/blocks/SignBlockTest.java
@@ -33,7 +33,6 @@ import com.sk89q.worldedit.util.test.ResourceLockKeys;
 import com.sk89q.worldedit.world.block.BlockState;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -72,9 +71,13 @@ class SignBlockTest {
         WorldEdit.getInstance().getPlatformManager().unregister(platform);
     }
 
-    @Test
-    void usesJsonStringsBeforeMinecraft1215() {
-        dataVersion.set(Constants.DATA_VERSION_MC_1_21_4);
+    @ParameterizedTest
+    @ValueSource(ints = {
+            Constants.DATA_VERSION_MC_1_21,
+            Constants.DATA_VERSION_MC_1_21_4
+    })
+    void usesJsonStringsBeforeMinecraft1215(int dataVersion) {
+        this.dataVersion.set(dataVersion);
 
         assertArrayEquals(
                 new String[]{EMPTY_JSON, HELLO_JSON, EMPTY_JSON, EMPTY_JSON},

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/blocks/SignBlockTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/blocks/SignBlockTest.java
@@ -1,0 +1,144 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.blocks;
+
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.ListTag;
+import com.sk89q.jnbt.StringTag;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.event.platform.PlatformsRegisteredEvent;
+import com.sk89q.worldedit.extension.platform.Capability;
+import com.sk89q.worldedit.extension.platform.Platform;
+import com.sk89q.worldedit.extension.platform.PlatformManager;
+import com.sk89q.worldedit.extension.platform.Preference;
+import com.sk89q.worldedit.internal.Constants;
+import com.sk89q.worldedit.util.test.ResourceLockKeys;
+import com.sk89q.worldedit.world.block.BlockState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ResourceLock(ResourceLockKeys.WORLDEDIT_PLATFORM)
+@SuppressWarnings("deprecation")
+class SignBlockTest {
+
+    private static final String EMPTY_JSON = "{\"text\":\"\"}";
+    private static final String HELLO_JSON = "{\"text\":\"Hello\"}";
+
+    private final AtomicInteger dataVersion = new AtomicInteger();
+    private final Platform platform = mock(Platform.class);
+
+    @BeforeEach
+    void setUpPlatform() {
+        when(platform.getCapabilities()).thenReturn(Map.of(Capability.WORLD_EDITING, Preference.NORMAL));
+        when(platform.getDataVersion()).thenAnswer(__ -> dataVersion.get());
+        when(platform.getVersion()).thenReturn("test");
+
+        PlatformManager platformManager = WorldEdit.getInstance().getPlatformManager();
+        platformManager.register(platform);
+        WorldEdit.getInstance().getEventBus().post(new PlatformsRegisteredEvent());
+    }
+
+    @AfterEach
+    void tearDownPlatform() {
+        WorldEdit.getInstance().getPlatformManager().unregister(platform);
+    }
+
+    @Test
+    void usesJsonStringsBeforeMinecraft1215() {
+        dataVersion.set(Constants.DATA_VERSION_MC_1_21_4);
+
+        assertArrayEquals(
+                new String[]{EMPTY_JSON, HELLO_JSON, EMPTY_JSON, EMPTY_JSON},
+                messages(new SignBlock(mock(BlockState.class), new String[]{"", "Hello", "", ""}))
+        );
+        assertArrayEquals(
+                new String[]{EMPTY_JSON, EMPTY_JSON, EMPTY_JSON, EMPTY_JSON},
+                messages(new SignBlock(mock(BlockState.class), null))
+        );
+
+        SignBlock loadedSign = new SignBlock(mock(BlockState.class), null);
+        loadedSign.setNbtData(signNbt(HELLO_JSON));
+        assertArrayEquals(
+                new String[]{HELLO_JSON, EMPTY_JSON, EMPTY_JSON, EMPTY_JSON},
+                messages(loadedSign)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {
+            Constants.DATA_VERSION_MC_1_21_5,
+            Constants.DATA_VERSION_MC_1_21_10,
+            Constants.DATA_VERSION_MC_1_21_11,
+            Constants.DATA_VERSION_MC_26_1_2
+    })
+    void usesLiteralStringsFromMinecraft1215(int dataVersion) {
+        this.dataVersion.set(dataVersion);
+
+        assertArrayEquals(
+                new String[]{"", "Hello", "", ""},
+                messages(new SignBlock(mock(BlockState.class), new String[]{"", "Hello", "", ""}))
+        );
+        assertArrayEquals(
+                new String[]{"", "", "", ""},
+                messages(new SignBlock(mock(BlockState.class), null))
+        );
+
+        SignBlock loadedSign = new SignBlock(mock(BlockState.class), null);
+        loadedSign.setNbtData(signNbt("Hello"));
+        assertArrayEquals(
+                new String[]{"Hello", "", "", ""},
+                messages(loadedSign)
+        );
+    }
+
+    private static String[] messages(SignBlock sign) {
+        CompoundTag frontText = (CompoundTag) sign.getNbtData().getValue().get("front_text");
+        ListTag<?, ?> messages = frontText.getListTag("messages");
+        return messages.getValue().stream()
+                .map(StringTag.class::cast)
+                .map(StringTag::getValue)
+                .toArray(String[]::new);
+    }
+
+    private static CompoundTag signNbt(String... messages) {
+        return new CompoundTag(Map.of(
+                "id", new StringTag("minecraft:sign"),
+                "front_text", new CompoundTag(Map.of(
+                        "messages", new ListTag<>(
+                                StringTag.class,
+                                Arrays.stream(messages).map(StringTag::new).toList()
+                        )
+                ))
+        ));
+    }
+
+}

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/blocks/SignBlockTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/blocks/SignBlockTest.java
@@ -58,7 +58,7 @@ class SignBlockTest {
 
     @BeforeEach
     void setUpPlatform() {
-        when(platform.getCapabilities()).thenReturn(Map.of(Capability.WORLD_EDITING, Preference.NORMAL));
+        when(platform.getCapabilities()).thenReturn(Map.of(Capability.WORLD_EDITING, Preference.PREFERRED));
         when(platform.getDataVersion()).thenAnswer(__ -> dataVersion.get());
         when(platform.getVersion()).thenReturn("test");
 


### PR DESCRIPTION
## Overview

Fixes #3379

## Description

Minecraft 1.21.5 changed the representation of text components in sign NBT. A string now represents a literal
text component instead of JSON-encoded text. `SignBlock` continued wrapping each line in JSON inside the NBT
string, which caused commands such as `//set spruce_sign` to display the JSON source on the sign.

This change preserves the JSON-in-string representation before Minecraft 1.21.5 and writes literal strings on
Minecraft 1.21.5 and newer. It also uses the version-appropriate empty value when constructing signs or loading
incomplete sign NBT.

Regression tests cover Minecraft 1.21.4, the 1.21.5 format boundary, 1.21.10, 1.21.11, and 26.1.2.

### Testing

- `./gradlew :worldedit-core:check --no-configure-on-demand`
- Paper integration tests on 1.21.4, 1.21.5, 1.21.10, 1.21.11, and 26.1.2

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
