### PR TITLE
fix: ThreadUnsafeCharBlocks#reset using clear without null check

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/ThreadUnsafeCharBlocks.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/ThreadUnsafeCharBlocks.java
@@ -450,10 +450,10 @@ public class ThreadUnsafeCharBlocks implements IChunkSet, IBlocks {
         biomes = new BiomeType[sectionCount][];
         light = new char[sectionCount][];
         skyLight = new char[sectionCount][];
-        tiles.clear();
-        entities.clear();
-        entityRemoves.clear();
-        heightMaps.clear();
+        tiles = null;
+        entities = null;
+        entityRemoves = null;
+        heightMaps = null;
         return this;
     }
 


### PR DESCRIPTION
## Overview
I discovered this while rewriting my logic that captures a paste and prevents a world flush.
This is a minimal fix I can also change it to clear conditionally and mark the maps with MonotonicNonNull or Nullable.
[CharSetBlocks's reset also null assigns the biomes etc.](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/fe2e6524b4fd9af1949b5f22736515c569a9e0c9/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/blocks/CharSetBlocks.java#L337), which could also be done here.


## Description
Replace the map clear calls in ThreadUnsafeCharBlocks with null assignment to allow resetting chunk sets without all kinds of data such as tile entities and entities.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
~~- [ ] New public fields and methods are annotated with `@since TODO`.~~
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).