### PR TITLE
Fix curves in extended negative world heights

### DIFF
--- a/worldedit-core/build.gradle.kts
+++ b/worldedit-core/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     // Tests
     testRuntimeOnly(libs.log4j.core)
     testImplementation(libs.parallelgzip)
+    testImplementation(libs.sparsebitset)
 }
 
 tasks.test {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
@@ -576,7 +576,7 @@ public class LocalBlockVectorSet implements BlockVector3Set {
 
         @Override
         public boolean add(BlockVector3 blockVector3) {
-            return set.add(blockVector3);
+            return add(blockVector3.x(), blockVector3.y(), blockVector3.z());
         }
 
         @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/math/LocalBlockVectorSet.java
@@ -591,7 +591,11 @@ public class LocalBlockVectorSet implements BlockVector3Set {
 
         @Override
         public boolean addAll(@Nonnull Collection<? extends BlockVector3> c) {
-            return set.addAll(c);
+            boolean result = false;
+            for (BlockVector3 vector : c) {
+                result |= add(vector);
+            }
+            return result;
         }
 
         @Override

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/math/LocalBlockVectorSetTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/math/LocalBlockVectorSetTest.java
@@ -23,6 +23,8 @@ import com.fastasyncworldedit.core.util.collection.BlockVector3Set;
 import com.sk89q.worldedit.math.BlockVector3;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LocalBlockVectorSetTest {
@@ -45,6 +47,17 @@ class LocalBlockVectorSetTest {
         assertTrue(set.add(originalPosition));
         assertTrue(set.add(positionOutsideLocalRange));
         assertTrue(set.contains(originalPosition));
+        assertTrue(set.contains(positionOutsideLocalRange));
+    }
+
+    @Test
+    void upgradesWhenBulkAddingVectorsOutsideLocalRange() {
+        BlockVector3Set set = LocalBlockVectorSet.wrapped();
+        BlockVector3 positionInsideLocalRange = BlockVector3.at(-38, 128, -20);
+        BlockVector3 positionOutsideLocalRange = BlockVector3.at(-38, -357, -20);
+
+        assertTrue(set.addAll(List.of(positionInsideLocalRange, positionOutsideLocalRange)));
+        assertTrue(set.contains(positionInsideLocalRange));
         assertTrue(set.contains(positionOutsideLocalRange));
     }
 

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/math/LocalBlockVectorSetTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/math/LocalBlockVectorSetTest.java
@@ -1,0 +1,51 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.fastasyncworldedit.core.math;
+
+import com.fastasyncworldedit.core.util.collection.BlockVector3Set;
+import com.sk89q.worldedit.math.BlockVector3;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalBlockVectorSetTest {
+
+    @Test
+    void upgradesWhenBlockVectorIsOutsideLocalRange() {
+        BlockVector3Set set = LocalBlockVectorSet.wrapped();
+        BlockVector3 position = BlockVector3.at(-38, -357, -20);
+
+        assertTrue(set.add(position));
+        assertTrue(set.contains(position));
+    }
+
+    @Test
+    void retainsExistingVectorsWhenUpgraded() {
+        BlockVector3Set set = LocalBlockVectorSet.wrapped();
+        BlockVector3 originalPosition = BlockVector3.at(-38, 128, -20);
+        BlockVector3 positionOutsideLocalRange = BlockVector3.at(-38, -357, -20);
+
+        assertTrue(set.add(originalPosition));
+        assertTrue(set.add(positionOutsideLocalRange));
+        assertTrue(set.contains(originalPosition));
+        assertTrue(set.contains(positionOutsideLocalRange));
+    }
+
+}


### PR DESCRIPTION
## Overview

Fixes #3606

## Description

`LocalBlockVectorSet.wrapped()` is designed to upgrade to `BlockVectorSet` when a position falls outside its local coordinate range. However, its `add(BlockVector3)` overload delegated directly to the underlying set and bypassed the upgrade logic in `add(int, int, int)`. `EditSession#drawSpline` uses the vector overload, causing curves below the vanilla world height to throw an `IndexOutOfBoundsException`.

This delegates vector additions through the upgrade-aware overload and adds regression coverage for the coordinates reported in the issue, including preservation of entries added before an upgrade.

### Testing

- `./gradlew :worldedit-core:test --tests com.fastasyncworldedit.core.math.LocalBlockVectorSetTest --rerun-tasks --no-daemon --no-configure-on-demand`
- `./gradlew :worldedit-core:build --no-daemon --no-configure-on-demand`

### Submitter Checklist

- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`. No public API was added.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).