### PR TITLE
Run edit-completion tasks on a dedicated executor

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
@@ -787,11 +787,11 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                         }
                         if (callback == null) {
                             if (finalizer != null) {
-                                queueHandler.async(finalizer, null);
+                                queueHandler.completion(finalizer, null);
                             }
                             return null;
                         } else {
-                            return queueHandler.async(callback, null);
+                            return queueHandler.completion(callback, null);
                         }
                     } catch (Throwable e) {
                         LOGGER.error("Error performing final chunk calling at {},{}", chunkX, chunkZ, e);

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/AbstractBukkitGetBlocks.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/adapter/AbstractBukkitGetBlocks.java
@@ -159,10 +159,13 @@ public abstract class AbstractBukkitGetBlocks<ServerLevel, LevelChunk> extends C
                             task.run();
                         }
                     }
+                    // Completion executor, not the secondary pool: this future is the tail of the chain blocked on in
+                    // SingleThreadQueueExtent flushes. If it required a free secondary-pool worker, edits running *on* the
+                    // secondary pool (e.g. plugins submitting via QueueHandler#async) could starve it and deadlock.
                     if (callback != null) {
-                        return queueHandler.async(callback, null);
+                        return queueHandler.completion(callback, null);
                     } else if (finalizer != null) {
-                        return queueHandler.async(finalizer, null);
+                        return queueHandler.completion(finalizer, null);
                     }
                     return null;
                 } catch (Throwable e) {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
@@ -14,6 +14,7 @@ import com.fastasyncworldedit.core.queue.implementation.chunk.ChunkCache;
 import com.fastasyncworldedit.core.util.MemUtil;
 import com.fastasyncworldedit.core.util.TaskManager;
 import com.fastasyncworldedit.core.util.collection.CleanableThreadLocal;
+import com.fastasyncworldedit.core.util.task.FaweBasicThreadFactory;
 import com.fastasyncworldedit.core.util.task.FaweForkJoinWorkerThreadFactory;
 import com.fastasyncworldedit.core.wrappers.WorldWrapper;
 import com.google.common.util.concurrent.Futures;
@@ -33,6 +34,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -76,6 +78,26 @@ public abstract class QueueHandler implements Trimable, Runnable {
      */
     private final ThreadPoolExecutor blockingExecutor = FaweCache.INSTANCE.newBlockingExecutor(
             "FAWE QueueHandler Blocking Executor - %d");
+    /**
+     * Executor for edit "completion" tasks, e.g. sending updated chunks to players and running the caller-supplied
+     * finalizer. Completion tasks form the tail of the future chains waited on when flushing a
+     * {@link com.fastasyncworldedit.core.queue.implementation.SingleThreadQueueExtent}, so they must be guaranteed to run
+     * even while the primary and secondary pools are saturated with (possibly blocked) edit tasks. This executor grows on
+     * demand instead of queueing behind a bounded set of workers, preventing thread-starvation deadlocks when edits are
+     * performed on the secondary pool (e.g. by plugins submitting whole edits via {@link #async(Runnable)}).
+     * <p>
+     * Submission cannot be rejected: if a worker cannot be started (executor shutdown, or the JVM being unable to create
+     * further threads) the task runs on the submitting thread rather than throwing, preserving the guarantee above.
+     */
+    private final ThreadPoolExecutor completionExecutor = new ThreadPoolExecutor(
+            0,
+            Integer.MAX_VALUE,
+            60L,
+            TimeUnit.SECONDS,
+            new SynchronousQueue<>(),
+            new FaweBasicThreadFactory("FAWE Completion Executor - %d"),
+            new ThreadPoolExecutor.CallerRunsPolicy()
+    );
     /**
      * Queue for tasks to be completed on the main thread. These take priority of tasks submitted to syncWhenFree queue
      */
@@ -236,6 +258,24 @@ public abstract class QueueHandler implements Trimable, Runnable {
      */
     public ForkJoinTask submit(Runnable run) {
         return forkJoinPoolPrimary.submit(run);
+    }
+
+    /**
+     * Run an edit-completion task, e.g. sending an updated chunk to players, on the dedicated completion executor.
+     * Unlike {@link #async(Runnable)}, tasks submitted here are guaranteed to begin execution even if
+     * the primary and secondary pools are saturated or blocked, as edit flushes block on the futures returned here.
+     * Completion tasks must therefore never block on other FAWE futures themselves.
+     * <p>
+     * Internal API usage only.
+     *
+     * @param run   Runnable to run
+     * @param value Value to return when done
+     * @param <T>   Value type
+     * @return Future for the submitted task
+     */
+    @ApiStatus.Internal
+    public <T> Future<T> completion(Runnable run, T value) {
+        return completionExecutor.submit(run, value);
     }
 
     /**

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
@@ -225,8 +225,11 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
         this.lastChunk.compareAndExchange(chunk, null);
         final long index = MathMan.pairInt(chunk.getX(), chunk.getZ());
         getChunkLock.lock();
-        chunks.remove(index, chunk);
-        getChunkLock.unlock();
+        try {
+            chunks.remove(index, chunk);
+        } finally {
+            getChunkLock.unlock();
+        }
         V future = submitUnchecked(chunk);
         submissions.add(future);
         return future;
@@ -278,7 +281,6 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
     public synchronized boolean trim(boolean aggressive) {
         cacheGet.trim(aggressive);
         cacheSet.trim(aggressive);
-        LOGGER.info("trim");
         if (Thread.currentThread() == currentThread) {
             lastChunk.set(null);
             return chunks.isEmpty();
@@ -481,27 +483,30 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
     public synchronized void flush() {
         if (!chunks.isEmpty()) {
             getChunkLock.lock();
-            if (MemUtil.isMemoryLimited()) {
-                while (!chunks.isEmpty()) {
-                    IQueueChunk chunk = chunks.removeFirst();
-                    this.lastChunk.compareAndExchange(chunk, null);
-                    final Future future = submitUnchecked(chunk);
-                    if (future != null && !future.isDone()) {
-                        pollSubmissions(Settings.settings().QUEUE.PARALLEL_THREADS, true);
-                        submissions.add(future);
+            try {
+                if (MemUtil.isMemoryLimited()) {
+                    while (!chunks.isEmpty()) {
+                        IQueueChunk chunk = chunks.removeFirst();
+                        this.lastChunk.compareAndExchange(chunk, null);
+                        final Future future = submitUnchecked(chunk);
+                        if (future != null && !future.isDone()) {
+                            pollSubmissions(Settings.settings().QUEUE.PARALLEL_THREADS, true);
+                            submissions.add(future);
+                        }
+                    }
+                } else {
+                    while (!chunks.isEmpty()) {
+                        IQueueChunk chunk = chunks.removeFirst();
+                        this.lastChunk.compareAndExchange(chunk, null);
+                        final Future future = submitUnchecked(chunk);
+                        if (future != null && !future.isDone()) {
+                            submissions.add(future);
+                        }
                     }
                 }
-            } else {
-                while (!chunks.isEmpty()) {
-                    IQueueChunk chunk = chunks.removeFirst();
-                    this.lastChunk.compareAndExchange(chunk, null);
-                    final Future future = submitUnchecked(chunk);
-                    if (future != null && !future.isDone()) {
-                        submissions.add(future);
-                    }
-                }
+            } finally {
+                getChunkLock.unlock();
             }
-            getChunkLock.unlock();
         }
         pollSubmissions(0, true);
     }


### PR DESCRIPTION
Fixes #3420.

## Summary

Edit-completion callbacks (sending updated chunks to players, running the caller-supplied finalizer) were submitted to `forkJoinPoolSecondary`. They are also the tail of the future chain that every `SingleThreadQueueExtent` flush blocks on. So a task waiting on that pool can be waiting for a task that needs a worker *from that same pool* — and if no worker is free, neither ever finishes.

This routes completion callbacks to a dedicated executor that can always supply a thread, so the tail of a submission chain never depends on the secondary pool having spare capacity.

## The cycle

Two edges are needed, and both were present:

1. **Occupancy** — something fills the secondary pool with tasks that block.
2. **Dependency** — a flush waiting on that pool needs a *completion callback* that is also scheduled on it.

The reporter's dump shows both: every live secondary worker consumed by FastAsyncVoxelSniper 3.2.3, all but one blocked at the entrance of its `synchronized(session)` block, and the last holding that monitor while blocked in `iterateSubmissions` waiting for a completion callback. Nothing progressed, so no FAWE command ran at all — including `/fawe debugpaste`, which is why the original reports have so little to go on.

### Why the pool didn't just add a worker

Worth being precise about, because "raise `parallel-threads`" is the advice people keep giving and it cannot work.

```java
private final ForkJoinPool forkJoinPoolSecondary = new ForkJoinPool(
        Settings.settings().QUEUE.PARALLEL_THREADS,
        new FaweForkJoinWorkerThreadFactory("FAWE Fork Join Pool Secondary - %s"),
        null, false
);
```

The 4-arg constructor leaves `maximumPoolSize` at 32767. The pool was free to grow and didn't, because `ForkJoinPool` only compensates for blocking it can observe through `managedBlock` — and neither `monitorenter` nor `FutureTask.get` is visible to it. It counted its wedged workers as running. **The pool is blind, not bounded: no `parallel-threads` value avoids this.**

(Also why this went unexplained for so long: a thread blocked on `monitorenter` shows no `park` and no `await` in a dump. It just looks stopped at a source line.)

## The change

**`QueueHandler`** — new executor and a `completion(Runnable, T)` entry point:

```java
private final ThreadPoolExecutor completionExecutor = new ThreadPoolExecutor(
        0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS,
        new SynchronousQueue<>(),
        new FaweBasicThreadFactory("FAWE Completion Executor - %d")
);
```

`SynchronousQueue` + unbounded max means a task never waits in a queue for a worker; core size 0 + 60s keepalive means it holds nothing at rest. `CallerRunsPolicy` (as `FaweCache#newBlockingExecutor` uses) means submission cannot be rejected even on shutdown or thread exhaustion — otherwise the default `AbortPolicy` would contradict the guarantee the javadoc makes. Capping it would reintroduce exactly this bug on the new pool, which is why it isn't capped.

**Correction to an earlier version of this description**, which said the pool holds "about one thread per edit actively finishing" — that was wrong, and the corrected figure matters to the sizing question. Completion tasks are submitted per *chunk* carrying sync tasks, not per edit: `AbstractBukkitGetBlocks` is a per-chunk object.

The concurrent worker count is still not the submission count, though. `completion(...)` is only reachable from inside the `chain` callable in `handleCallFinalizer`, and that callable is dispatched via `QueueHandler#sync(Callable)` — so it is enqueued to `syncTasks` and run **on the main thread, serially**, drained by `QueueHandler#run()` under its per-tick budget (`allocate`, capped at 50ms). Submissions therefore arrive at a metered rate rather than all at once, and live workers track (chunks drained per tick × completion duration), not `target-size`.

That is a real bound, but it is a *rate* bound rather than a ceiling, and it is not enforced anywhere in the executor itself — if completion work is slow (these tasks do network I/O sending chunk packets), workers still accumulate. So the sizing concern is legitimate even though the worst case is smaller than raw submission counts suggest.

**`AbstractBukkitGetBlocks#handleCallFinalizer`** — `async(...)` → `completion(...)`, with the invariant recorded in a comment.

**`adapter-1_21/PaperweightGetBlocks`** — predates the shared helper and carries its own copy of the chain, so it needs the same change directly. Every other adapter shares the helper.

**`SingleThreadQueueExtent`** — unrelated bug found while tracing this path: `flush()` and `submit()` didn't release `getChunkLock` in a `finally`, so an exception escaping `submitUnchecked` leaked it permanently. These queues are pooled and reused, so one failed edit could brick a queue instance for the rest of the server's uptime. Also drops a stray `LOGGER.info("trim")`. **Happy to split this into its own PR** — it is genuinely unrelated and would be easier to review separately.

**Scope note:** only the chunk callback/finalizer moves. `AbstractChangeSet`'s history drain (`AbstractChangeSet:453`) stays on the secondary pool deliberately — its future is discarded at the call site, so nothing blocks on it and it carries no dependency edge.

### The invariant

Completion tasks must never block on other FAWE futures. That holds for everything routed here today (the chunk callback/finalizer pair), and it's the thing to check before adding anything new. It's stated in the javadoc on `completion(...)`.

## On "commands shouldn't have gone there in the first place"

Agreed, and the javadoc already says so — the secondary pool is documented for short "cleanup" tasks that *may* be IO-bound. FAVS submitting whole player-synchronised edits there was misuse, and FAVS 3.2.4 correctly stops doing it.

The narrow argument for this PR is that the *dependency* edge doesn't require any misuse to exist. A completion callback is a cleanup task — it belongs on that pool by the javadoc's own definition. So does the history drain. The pool is therefore in the position of hosting a task that another task is blocked waiting for, which is a starvation cycle among tasks that all legitimately belong there. Misuse makes it easy to hit; it isn't what creates it.

That's the whole claim. This doesn't stop a caller from wedging the secondary pool, and it isn't meant to — it stops a wedged secondary pool from taking the *completion* path down with it.

I'd rather not oversell the "FAWE could do this to itself with no plugin" version of the argument. I went looking for it in the source: only two places in FAWE submit to this pool, `AbstractChangeSet:453` (`drainQueue`, which doesn't block on a future) and `AsyncNotifyQueue:59`. The one genuine same-pool `.get()` is `RollbackDatabase:53` in the constructor, and I haven't established that it runs on a secondary-pool thread. So: a plausible shape, not a demonstrated FAWE-only deadlock, and I'm not resting the PR on it.

## On #3543

#3543 makes lock acquisition order consistent, which closes lock-order (ABBA) inversions. This is a different failure mode: thread-starvation deadlock needs no inversion and, in the FAVS case, involved a single monitor. Consistent ordering wouldn't have prevented it. The two changes are complementary rather than overlapping — I don't think #3543 subsumes this one.

## On virtual threads

Agreed that the secondary pool is a good candidate, being wait-heavy. One caveat for the roadmap: `synchronized` pins the carrier thread until JEP 491 (JDK 24), and FAWE's `sourceCompatibility` is 21 — so on the minimum supported runtime a virtual-thread secondary pool would still have pinned on FAVS's `synchronized(session)` and starved the same way. It's an argument for raising the floor, not against the direction. Out of scope here either way.

## Relationship to FastAsyncVoxelSniper #489

FAVS 3.2.4 moves snipes onto `AsyncNotifyKeyedQueue` and replaces `synchronized(session)` with per-UUID queueing. That is the right fix on their side and it resolves the reported freeze on its own.

| Edge | Cut by | Scope |
|---|---|---|
| Occupancy — a caller fills the pool with blocked work | FAVS #489 | That plugin |
| Dependency — completion needs a worker from that same pool | This PR | Every caller |

Neither depends on the other.

## Behavioral impact

- No public API removed or changed. `completion(...)` is new and `@ApiStatus.Internal`.
- Completion work moves off `forkJoinPoolSecondary`, freeing that pool for what it's documented for.
- One more pool, empty at rest.
- Threads follow the existing naming convention (`FAWE Completion Executor - %d`).

## Testing

Built against the adapters this touches, and run on the server from the original #3420 report with the same plugin set — completion callbacks stayed off the contended pool.

**No deterministic reproduction.** The original deadlock depended on a plugin's thread timing, and I haven't built a synthetic test that reliably wedges the secondary pool. The argument for the change is structural — the dependency edge is visible in the source — rather than test-driven, and that's worth weighing against it.

## Documentation follow-up

@dordsor21 — happy to take the documentation work you described as a separate PR: `QueueHandler#async` javadoc stating that the secondary pool is not for actor or command work, actor tasks going through `Actor#runAction`, and plugin-submitted tasks using their own threads. Say the word and I'll open it whether or not this one lands.

