### PR TITLE
Document the secondary pool's task contract

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
@@ -63,6 +63,27 @@ public abstract class QueueHandler implements Trimable, Runnable {
     /**
      * Secondary queue should be used for "cleanup" tasks that are likely to be shorter in life than those submitted to the
      * primary queue. They may be IO-bound tasks.
+     *
+     * <p>
+     * Tasks submitted here must observe two rules:
+     * </p>
+     * <ul>
+     *     <li><b>A task must not wait on anything this pool completes.</b> {@link ForkJoinPool} only compensates for
+     *     blocking it can observe via {@link ForkJoinPool#managedBlock(ForkJoinPool.ManagedBlocker)}. It cannot see
+     *     {@code monitorenter} or {@link Future#get()}, so it counts a blocked worker as running and does not start a
+     *     replacement. Every worker can therefore end up parked waiting for work that only this pool can perform, and
+     *     nothing progresses. If a task does have such a dependency, do not block inside it: submit the dependent half as
+     *     a separate task and chain the futures.</li>
+     *     <li><b>No actor or command work.</b> Player-facing actions belong on
+     *     {@link com.sk89q.worldedit.extension.platform.Actor#runAction(Runnable, boolean, boolean)} (or its
+     *     {@code queueAction} / {@code runAsyncIfFree} wrappers), which serialises per actor without holding a worker
+     *     here.</li>
+     * </ul>
+     * <p>
+     * Downstream plugins should not submit whole edits or other long-lived work to this pool, and should use their own
+     * threads instead. The pool is sized by {@code parallel-threads} for FAWE's own cleanup work; occupying it starves
+     * that work.
+     * </p>
      */
     private final ForkJoinPool forkJoinPoolSecondary = new ForkJoinPool(
             Settings.settings().QUEUE.PARALLEL_THREADS,
@@ -195,6 +216,11 @@ public abstract class QueueHandler implements Trimable, Runnable {
      * Complete a task in the {@code forkJoinPoolSecondary} queue. Secondary queue should be used for "cleanup" tasks that are
      * likely to be shorter in life than those submitted to the primary queue. They may be IO-bound tasks.
      *
+     * <p>
+     * The submitted task must not wait on a {@link Future} completed by this pool, and must not be actor or command work.
+     * See the {@code forkJoinPoolSecondary} field for the full contract and the reasoning behind it.
+     * </p>
+     *
      * @param run   Runnable to run
      * @param value Value to return when done
      * @param <T>   Value type
@@ -208,6 +234,11 @@ public abstract class QueueHandler implements Trimable, Runnable {
      * Complete a task in the {@code forkJoinPoolSecondary} queue. Secondary queue should be used for "cleanup" tasks that are
      * likely to be shorter in life than those submitted to the primary queue. They may be IO-bound tasks.
      *
+     * <p>
+     * The submitted task must not wait on a {@link Future} completed by this pool, and must not be actor or command work.
+     * See the {@code forkJoinPoolSecondary} field for the full contract and the reasoning behind it.
+     * </p>
+     *
      * @param run Runnable to run
      * @return Future for submitted task
      */
@@ -218,6 +249,11 @@ public abstract class QueueHandler implements Trimable, Runnable {
     /**
      * Complete a task in the {@code forkJoinPoolSecondary} queue. Secondary queue should be used for "cleanup" tasks that are
      * likely to be shorter in life than those submitted to the primary queue. They may be IO-bound tasks.
+     *
+     * <p>
+     * The submitted task must not wait on a {@link Future} completed by this pool, and must not be actor or command work.
+     * See the {@code forkJoinPoolSecondary} field for the full contract and the reasoning behind it.
+     * </p>
      *
      * @param call Callable to run
      * @param <T>  Return value type

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/QueueHandler.java
@@ -64,26 +64,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
      * Secondary queue should be used for "cleanup" tasks that are likely to be shorter in life than those submitted to the
      * primary queue. They may be IO-bound tasks.
      *
-     * <p>
-     * Tasks submitted here must observe two rules:
-     * </p>
-     * <ul>
-     *     <li><b>A task must not wait on anything this pool completes.</b> {@link ForkJoinPool} only compensates for
-     *     blocking it can observe via {@link ForkJoinPool#managedBlock(ForkJoinPool.ManagedBlocker)}. It cannot see
-     *     {@code monitorenter} or {@link Future#get()}, so it counts a blocked worker as running and does not start a
-     *     replacement. Every worker can therefore end up parked waiting for work that only this pool can perform, and
-     *     nothing progresses. If a task does have such a dependency, do not block inside it: submit the dependent half as
-     *     a separate task and chain the futures.</li>
-     *     <li><b>No actor or command work.</b> Player-facing actions belong on
-     *     {@link com.sk89q.worldedit.extension.platform.Actor#runAction(Runnable, boolean, boolean)} (or its
-     *     {@code queueAction} / {@code runAsyncIfFree} wrappers), which serialises per actor without holding a worker
-     *     here.</li>
-     * </ul>
-     * <p>
-     * Downstream plugins should not submit whole edits or other long-lived work to this pool, and should use their own
-     * threads instead. The pool is sized by {@code parallel-threads} for FAWE's own cleanup work; occupying it starves
-     * that work.
-     * </p>
+     * @see #getForkJoinPoolSecondary() the full task contract and the reasoning behind it
      */
     private final ForkJoinPool forkJoinPoolSecondary = new ForkJoinPool(
             Settings.settings().QUEUE.PARALLEL_THREADS,
@@ -218,7 +199,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
      *
      * <p>
      * The submitted task must not wait on a {@link Future} completed by this pool, and must not be actor or command work.
-     * See the {@code forkJoinPoolSecondary} field for the full contract and the reasoning behind it.
+     * See {@link #getForkJoinPoolSecondary()} for the full contract and the reasoning behind it.
      * </p>
      *
      * @param run   Runnable to run
@@ -236,7 +217,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
      *
      * <p>
      * The submitted task must not wait on a {@link Future} completed by this pool, and must not be actor or command work.
-     * See the {@code forkJoinPoolSecondary} field for the full contract and the reasoning behind it.
+     * See {@link #getForkJoinPoolSecondary()} for the full contract and the reasoning behind it.
      * </p>
      *
      * @param run Runnable to run
@@ -252,7 +233,7 @@ public abstract class QueueHandler implements Trimable, Runnable {
      *
      * <p>
      * The submitted task must not wait on a {@link Future} completed by this pool, and must not be actor or command work.
-     * See the {@code forkJoinPoolSecondary} field for the full contract and the reasoning behind it.
+     * See {@link #getForkJoinPoolSecondary()} for the full contract and the reasoning behind it.
      * </p>
      *
      * @param call Callable to run
@@ -578,6 +559,27 @@ public abstract class QueueHandler implements Trimable, Runnable {
     /**
      * Secondary queue should be used for "cleanup" tasks that are likely to be shorter in life than those submitted to the
      * primary queue. They may be IO-bound tasks.
+     *
+     * <p>
+     * Tasks submitted here must observe two rules:
+     * </p>
+     * <ul>
+     *     <li><b>A task must not wait on anything this pool completes.</b> {@link ForkJoinPool} only compensates for
+     *     blocking it can observe via {@link ForkJoinPool#managedBlock(ForkJoinPool.ManagedBlocker)}. It cannot see
+     *     {@code monitorenter} or {@link Future#get()}, so it counts a blocked worker as running and does not start a
+     *     replacement. Every worker can therefore end up parked waiting for work that only this pool can perform, and
+     *     nothing progresses. If a task does have such a dependency, do not block inside it: submit the dependent half as
+     *     a separate task and chain the futures.</li>
+     *     <li><b>No actor or command work.</b> Player-facing actions belong on
+     *     {@link com.sk89q.worldedit.extension.platform.Actor#runAction(Runnable, boolean, boolean)} (or its
+     *     {@code queueAction} / {@code runAsyncIfFree} wrappers), which serialises per actor without holding a worker
+     *     here.</li>
+     * </ul>
+     * <p>
+     * Downstream plugins should not submit whole edits or other long-lived work to this pool, and should use their own
+     * threads instead. The pool is sized by {@code parallel-threads} for FAWE's own cleanup work; occupying it starves
+     * that work.
+     * </p>
      * <p>
      * Internal API usage only.
      *


### PR DESCRIPTION
@dordsor21 — this is the documentation work you asked for, split out as promised in #3609. It stands alone and doesn't depend on that PR landing.

## What this adds

`QueueHandler#async`'s javadoc said what the secondary pool is *for* ("cleanup" tasks, possibly IO-bound) but never said what a task submitted to it must **not** do. Two rules were load-bearing and undocumented:

**1. A task must not wait on anything this pool completes.**

`ForkJoinPool` only compensates for blocking it can observe through `managedBlock`. It cannot see `monitorenter` or `Future#get`, so a blocked worker is still counted as running and no replacement is started. Every worker can end up parked waiting for work only this pool can perform.

The javadoc now states the rule and the remedy you described — if a task does have a dependency, don't block inside it; submit the dependent half separately and chain the futures.

**2. Actor and command work doesn't belong here.**

Player-facing actions go through `Actor#runAction` (or the `queueAction` / `runAsyncIfFree` wrappers), which serialises per actor without holding a worker on this pool.

Plus a note that downstream plugins should use their own threads rather than this pool, which is sized by `parallel-threads` for FAWE's own cleanup work.

## Shape of the change

The full contract lives on the `forkJoinPoolSecondary` field. The three `async(...)` overloads get a two-line summary pointing at it, rather than repeating it three times.

Documentation only — no behavioural change, no API change.
