### PR TITLE
Fix Gradle build performance issues and enable configuration cache support

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
 
 dependencies {
     implementation(gradleApi())
-    implementation(libs.grgit)
     implementation(libs.shadow)
     implementation(libs.paperweight)
 

--- a/build-logic/src/main/kotlin/buildlogic.common.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.common.gradle.kts
@@ -5,7 +5,7 @@ import org.gradle.plugins.ide.idea.model.IdeaModel
 group = rootProject.group
 version = rootProject.version
 
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         cacheChangingModulesFor(1, TimeUnit.DAYS)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,5 @@
-import org.ajoberstar.grgit.Grgit
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
-import java.time.format.DateTimeFormatter
 import xyz.jpenilla.runpaper.task.RunServer
 
 plugins {
@@ -18,11 +16,18 @@ var revision: String = (extra.properties["revision"] as? String) ?: ""
 var buildNumber: String = (extra.properties["buildNumber"] as? String) ?: ""
 var date: String = (extra.properties["date"] as? String) ?: ""
 
-val git: Grgit = Grgit.open {
-    dir = File("$rootDir/.git")
-}
-date = git.head().dateTime.format(DateTimeFormatter.ofPattern("yy.MM.dd"))
-revision = "-${git.head().abbreviatedId}"
+// Get Git metadata during build setup using the Git CLI.
+// This replaces Grgit/JGit so the build stays compatible with Gradle's configuration cache.
+// The result is recorded as a build input and can be reused without re-running Git each time.
+// We keep the short hash length the same as before for consistency.
+fun gitOutput(vararg args: String): String =
+    providers.exec {
+        commandLine("git", *args)
+        workingDir = rootDir
+    }.standardOutput.asText.get().trim()
+
+date = gitOutput("show", "-s", "--format=%cd", "--date=format:%y.%m.%d", "HEAD")
+revision = "-" + gitOutput("rev-parse", "--short=7", "HEAD")
     buildNumber = if (project.hasProperty("buildnumber")) {
         snapshot + "-" + (project.findProperty("buildnumber") as? String ?: "")
     } else {
@@ -38,9 +43,8 @@ extra.set("date", date)
 version = String.format("%s-%s", rootVersion, buildNumber)
 
 if (!project.hasProperty("gitCommitHash")) {
-    pluginManager.apply("org.ajoberstar.grgit")
     ext["gitCommitHash"] = try {
-        extensions.getByName<Grgit>("grgit").head()?.abbreviatedId
+        gitOutput("rev-parse", "--short=7", "HEAD")
     } catch (e: Exception) {
         logger.warn("Error getting commit hash", e)
 
@@ -82,19 +86,17 @@ codecov {
 }
 
 allprojects {
-    gradle.projectsEvaluated {
-        tasks.withType<JavaCompile>().configureEach {
-            options.compilerArgs.addAll(arrayOf("-Xmaxerrs", "1000"))
-        }
-        tasks.withType<Test>().configureEach {
-            maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
-            testLogging {
-                events(FAILED)
-                exceptionFormat = FULL
-                showExceptions = true
-                showCauses = true
-                showStackTraces = true
-            }
+    tasks.withType<JavaCompile>().configureEach {
+        options.compilerArgs.addAll(arrayOf("-Xmaxerrs", "1000"))
+    }
+    tasks.withType<Test>().configureEach {
+        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
+        testLogging {
+            events(FAILED)
+            exceptionFormat = FULL
+            showExceptions = true
+            showCauses = true
+            showStackTraces = true
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,6 @@ junit = "6.1.2"
 # Gradle plugins
 pluginyml = "0.6.0"
 mod-publish-plugin = "2.1.1"
-grgit = "5.3.3"
 shadow = "9.5.1"
 paperweight = "2.0.0-SNAPSHOT"
 codecov = "0.3.0"
@@ -65,7 +64,6 @@ minimumJdependency = "2.10"
 
 [libraries]
 # Gradle plugins
-grgit = { group = "org.ajoberstar.grgit", name = "grgit-gradle", version.ref = "grgit" }
 shadow = { group = "com.gradleup.shadow", name = "shadow-gradle-plugin", version.ref = "shadow" }
 paperweight = { group = "io.papermc.paperweight.userdev", name = "io.papermc.paperweight.userdev.gradle.plugin", version.ref = "paperweight" }
 

--- a/worldedit-core/build.gradle.kts
+++ b/worldedit-core/build.gradle.kts
@@ -69,7 +69,6 @@ tasks.test {
 }
 
 tasks.compileJava {
-    dependsOn(":worldedit-libs:build")
     options.compilerArgs.add("-Aarg.name.key.prefix=")
 }
 
@@ -103,13 +102,28 @@ sourceSets.named("main") {
     }
 }
 
+// Resolve these to plain Strings up front. Referencing `version` or `rootProject`
+// inside the filesMatching action would capture a Project instance in the task,
+// which cannot be serialized by the configuration cache.
+val faweVersion = "$version"
+val faweCommit = "${rootProject.ext["revision"]}"
+val faweDate = "${rootProject.ext["date"]}"
+
 tasks.named<Copy>("processResources") {
+    // Collect into a local of THIS block. A top-level `val` in a .gradle.kts is a
+    // property of the script object, so referencing one from the filesMatching
+    // closure would capture the script itself - which the configuration cache
+    // cannot serialize. A local is captured by value instead.
+    val expansions = mapOf(
+            "version" to faweVersion,
+            "commit" to faweCommit,
+            "date" to faweDate
+    )
+    inputs.property("faweVersion", faweVersion)
+    inputs.property("faweCommit", faweCommit)
+    inputs.property("faweDate", faweDate)
     filesMatching("fawe.properties") {
-        expand(
-                "version" to "$version",
-                "commit" to "${rootProject.ext["revision"]}",
-                "date" to "${rootProject.ext["date"]}"
-        )
+        expand(expansions)
     }
 }
 


### PR DESCRIPTION
## Overview
Three small changes were made to the build scripts that remove redundant or legacy Gradle tasks/behavior. One of which unblocks Gradle's configuration cache and removes a dependency on a legacy Gradle plugin.

## Description
- Replaced our dependency on Grgit with a `providers.exec`-based helper for reading the commit hash and date. Previously, Grgit forked `git` twice at configuration time, which the configuration cache does not support. Grgit will never add support for the configuration cache and is in fact considered to be in "maintenance mode". `providers.exec` results are recorded as declared build inputs instead, so they can be cached and replayed.
  - Hash length from Grgit/Jgit is preserved.
- Removed the `allprojects { gradle.projectsEvaluated { ... } }` wrapper around the `configurateEach` blocks. `configureEach` is already lazy and doesn't need an outer lifecycle hook. The wrapper was registering 18 identical callbacks (one per subproject) for no effect.
  - There is a behavioral change with this. The root's compiler-arg/test-logging settings now register earlier relative to subproject configuration. A subproject setting the same property would now win where root previously won. There are currently no subprojects currently setting these (only `worldedit-core:test.maxHeapSize`, untouched by this block).
- Removed `tasks.compileJava { dependsOn(":worldedit-libs:build") }`. `:worldedit-libs:build` is a *lifecycle* task, not a jar — depending on it pulled in the full build/check/sourcesJar/javadocJar of **all four** `worldedit-libs:*` projects, including `bukkit` and `cli`, which `worldedit-core` does not use. The existing`api(project(":worldedit-libs:core"))` / `annotationProcessor(project(":worldedit-libs:core:ap"))` dependencies already carry correct task ordering via Gradle's variant-aware resolution  (`outgoing.artifact(tasks.named("jar"))` in`buildlogic.libs.gradle.kts`), so the explicit `dependsOn` was redundant as well as too broad. It also broke `configureondemand` for any single-project build:
  ```
  > ./gradlew :worldedit-core:compileJava
  Task with name 'build' not found in project ':worldedit-libs:bukkit'
  ```
- processResources: moved the fawe.properties expansion values into a block-local val, since a top-level val would capture the script object, which the configuration cache can't serialize.
- `configurations.all { }` -> `configurations.configureEach { }`. Same `resolutionStrategy`, applied lazily instead of eagerly realizing every configuration in all 18 projects at configuration time.

### Submitter Checklist
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
