### PR TITLE
fix: execute Bukkit item use on the main thread

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitWorld.java
@@ -671,7 +671,7 @@ public class BukkitWorld extends AbstractWorld {
         //FAWE end
         BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
         if (adapter != null) {
-            return adapter.simulateItemUse(getWorld(), position, item, face);
+            return TaskManager.taskManager().sync(() -> adapter.simulateItemUse(getWorld(), position, item, face));
         }
 
         return false;


### PR DESCRIPTION
## Summary

Run Bukkit item-use simulation on FAWE's synchronous task manager.

## Problem

`BukkitWorld.useItem()` can be reached from FAWE's asynchronous execution
path. Paper's item-use implementation fires `BlockCanBuildEvent`, which must
run on the server thread, causing `BlockCanBuildEvent may only be triggered
synchronously`.

The adapter call now follows the existing Bukkit integration convention and
uses `TaskManager.taskManager().sync(...)`.

## Testing

```text
env JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 \
  ./gradlew -Dorg.gradle.configureondemand=false \
  :worldedit-bukkit:test --no-daemon
```

Also exercised on Paper 1.21.10 with a Mineflayer item-use brush: the expected
sapling was placed and Paper emitted no asynchronous Bukkit-event error.

