### PR TITLE
fix: resolve data cycler properties per block type

### DIFF
--- a/worldedit-core/build.gradle.kts
+++ b/worldedit-core/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     // Tests
     testRuntimeOnly(libs.log4j.core)
     testImplementation(libs.parallelgzip)
+    testImplementation(libs.sparsebitset)
 }
 
 tasks.test {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/tool/BlockDataCyler.java
@@ -20,6 +20,7 @@
 package com.sk89q.worldedit.command.tool;
 
 import com.fastasyncworldedit.core.configuration.Caption;
+import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.google.common.collect.Lists;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.LocalConfiguration;
@@ -52,7 +53,7 @@ public class BlockDataCyler implements DoubleActionBlockTool {
         return player.hasPermission("worldedit.tool.data-cycler");
     }
 
-    private final Map<UUID, Property<?>> selectedProperties = new HashMap<>();
+    private final Map<UUID, PropertyKey> selectedProperties = new HashMap<>();
 
     private boolean handleCycle(
             LocalConfiguration config, Player player, LocalSession session,
@@ -74,15 +75,17 @@ public class BlockDataCyler implements DoubleActionBlockTool {
         if (block.getStates().keySet().isEmpty()) {
             player.print(Caption.of("worldedit.tool.data-cycler.cant-cycle"));
         } else {
-            Property<?> currentProperty = selectedProperties.get(player.getUniqueId());
+            PropertyKey selectedProperty = selectedProperties.get(player.getUniqueId());
+            Property<?> currentProperty = selectedProperty == null
+                    ? null
+                    : block.getBlockType().getProperty(selectedProperty);
 
-            if (currentProperty == null || (forward && block.getState(currentProperty) == null)) {
+            if (currentProperty == null) {
                 currentProperty = block.getStates().keySet().stream().findFirst().get();
-                selectedProperties.put(player.getUniqueId(), currentProperty);
+                selectedProperties.put(player.getUniqueId(), currentProperty.getKey());
             }
 
             if (forward) {
-                block.getState(currentProperty);
                 int index = currentProperty.getValues().indexOf(block.getState(currentProperty));
                 index = (index + 1) % currentProperty.getValues().size();
                 @SuppressWarnings("unchecked")
@@ -108,7 +111,7 @@ public class BlockDataCyler implements DoubleActionBlockTool {
                 int index = properties.indexOf(currentProperty);
                 index = (index + 1) % properties.size();
                 currentProperty = properties.get(index);
-                selectedProperties.put(player.getUniqueId(), currentProperty);
+                selectedProperties.put(player.getUniqueId(), currentProperty.getKey());
                 player.print(Caption.of("worldedit.tool.data-cycler.cycling", TextComponent.of(currentProperty.getName())));
             }
         }

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/command/tool/BlockDataCylerTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/command/tool/BlockDataCylerTest.java
@@ -1,0 +1,102 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.command.tool;
+
+import com.fastasyncworldedit.core.registry.state.PropertyKey;
+import com.sk89q.worldedit.EditSession;
+import com.sk89q.worldedit.LocalConfiguration;
+import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.registry.state.Property;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BlockDataCylerTest {
+
+    @Test
+    void resolvesRememberedPropertyAgainstCurrentlyClickedBlock() throws Exception {
+        PropertyKey propertyKey = PropertyKey.getOrCreate("cycler_test_property");
+        Property<String> previousProperty = property(propertyKey, List.of("one", "two", "three"));
+        Property<String> currentProperty = property(propertyKey, List.of("first", "second"));
+
+        BaseBlock previousBlock = mock(BaseBlock.class);
+        when(previousBlock.getStates()).thenReturn(Map.of(previousProperty, "one"));
+
+        BlockType currentType = mock(BlockType.class);
+        when(currentType.<String>getProperty(propertyKey)).thenReturn(currentProperty);
+
+        BaseBlock currentBlock = mock(BaseBlock.class);
+        BaseBlock cycledBlock = mock(BaseBlock.class);
+        when(currentBlock.getBlockType()).thenReturn(currentType);
+        when(currentBlock.getStates()).thenReturn(Map.of(currentProperty, "first"));
+        when(currentBlock.getState(previousProperty)).thenThrow(new IndexOutOfBoundsException("stale property offset"));
+        when(currentBlock.getState(currentProperty)).thenReturn("first");
+        when(currentBlock.with(currentProperty, "second")).thenReturn(cycledBlock);
+
+        World world = mock(World.class);
+        BlockVector3 position = BlockVector3.at(1, 2, 3);
+        when(world.getFullBlock(position)).thenReturn(previousBlock, currentBlock);
+
+        UUID playerId = UUID.randomUUID();
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(playerId);
+
+        EditSession editSession = mock(EditSession.class);
+        LocalSession localSession = mock(LocalSession.class);
+        when(localSession.createEditSession(player, null)).thenReturn(editSession);
+
+        LocalConfiguration configuration = new LocalConfiguration() {
+            @Override
+            public void load() {
+            }
+        };
+        Location clicked = new Location(world, position.toVector3());
+        BlockDataCyler cycler = new BlockDataCyler();
+
+        cycler.actSecondary(null, configuration, player, localSession, clicked, null);
+        cycler.actPrimary(null, configuration, player, localSession, clicked, null);
+
+        verify(currentBlock, never()).getState(previousProperty);
+        verify(editSession).setBlock(position, cycledBlock);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Property<String> property(PropertyKey key, List<String> values) {
+        Property<String> property = mock(Property.class);
+        when(property.getKey()).thenReturn(key);
+        when(property.getName()).thenReturn(key.getName());
+        when(property.getValues()).thenReturn(values);
+        return property;
+    }
+
+}


### PR DESCRIPTION
## Summary

Resolve a remembered data-cycler property against the currently clicked block
type before using it.

## Problem

The data cycler stored a `Property<?>` instance directly. A property instance
contains state-layout information for the block type from which it came, so
using it after clicking another block type could read an invalid state offset
or construct the wrong state.

Store the stable `PropertyKey` instead, then obtain the matching property from
the current block type. The test-only SparseBitSet dependency is required when
Mockito loads `LocalSession`'s type hierarchy; the main dependency is
compile-only.

## Testing

```text
env JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 \
  ./gradlew -Dorg.gradle.configureondemand=false \
  :worldedit-core:test \
  --tests com.sk89q.worldedit.command.tool.BlockDataCylerTest \
  --no-daemon
```

