### PR TITLE
fix: reject timed-out block-mask parses

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/BlockMaskBuilder.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/function/mask/BlockMaskBuilder.java
@@ -318,16 +318,35 @@ public class BlockMaskBuilder {
             }
         });
         try {
-            fut.get(5L, TimeUnit.MILLISECONDS);
-        } catch (ExecutionException e) {
-            if (e.getCause() instanceof InputParseException) {
-                throw (InputParseException) e.getCause();
-            }
-        } catch (InterruptedException | TimeoutException ignored) {
+            awaitRegexParse(fut, input);
         } finally {
-            executor.shutdown();
+            executor.shutdownNow();
         }
         return this;
+    }
+
+    static void awaitRegexParse(Future<?> future, String input) throws InputParseException {
+        try {
+            future.get(5L, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof InputParseException inputParseException) {
+                throw inputParseException;
+            }
+            throw invalidBlockMask(input, cause);
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            throw invalidBlockMask(input, e);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw invalidBlockMask(input, e);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static InputParseException invalidBlockMask(String input, Throwable cause) {
+        return new InputParseException("Unable to parse block mask: " + input, cause);
     }
 
     private void suggest(String input, String property, Collection<BlockType> finalTypes) throws InputParseException {

--- a/worldedit-core/src/test/java/com/fastasyncworldedit/core/function/mask/BlockMaskBuilderTest.java
+++ b/worldedit-core/src/test/java/com/fastasyncworldedit/core/function/mask/BlockMaskBuilderTest.java
@@ -1,0 +1,42 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.fastasyncworldedit.core.function.mask;
+
+import com.sk89q.worldedit.extension.input.InputParseException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.FutureTask;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BlockMaskBuilderTest {
+
+    @Test
+    void rejectsAnUnfinishedRegexParse() {
+        FutureTask<Void> future = new FutureTask<>(() -> null);
+
+        assertThrows(InputParseException.class, () ->
+                BlockMaskBuilder.awaitRegexParse(future, "minecraft:not_a_real_block"));
+
+        assertTrue(future.isCancelled());
+    }
+
+}


### PR DESCRIPTION
## Summary

Reject block-mask parses that do not finish within the existing 5 ms budget.

## Problem

`BlockMaskBuilder.addRegex()` previously ignored both timeout and interruption
from its parsing future. The method then returned a partially constructed mask
as if parsing had succeeded. In practice, an invalid `//gmask` input could be
reported as a successfully set global mask.

The parser now turns timeout, interruption, and unexpected worker failures
into `InputParseException`, cancels timed-out work, and stops the executor
immediately. Existing `InputParseException` failures are preserved.

## Testing

```text
env JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 \
  ./gradlew -Dorg.gradle.configureondemand=false \
  :worldedit-core:test \
  --tests com.fastasyncworldedit.core.function.mask.BlockMaskBuilderTest \
  --no-daemon
```

