### PR TITLE
fix(tmp): try make clipboard patterns safe for Filter

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ConcurrentReadClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ConcurrentReadClipboard.java
@@ -22,12 +22,7 @@ public class ConcurrentReadClipboard implements Clipboard {
     private final Clipboard parent;
 
     public static Clipboard tryWrap(Clipboard clipboard) {
-        if (clipboard instanceof ConcurrentReadClipboard
-                || clipboard instanceof WorldCopyClipboard
-                || clipboard instanceof EmptyClipboard
-                || clipboard instanceof DiskOptimizedClipboard // FastSchematicReaderV2/V3 no min offset
-                || (clipboard instanceof BlockArrayClipboard blockArrayClipboard
-                && blockArrayClipboard.getParent() instanceof DiskOptimizedClipboard)) {
+        if (clipboard.supportsParallelAccess()) {
             return clipboard;
         }
         return new ConcurrentReadClipboard(clipboard);
@@ -141,6 +136,11 @@ public class ConcurrentReadClipboard implements Clipboard {
     @Nonnull
     public Iterator<BlockVector3> iterator() {
         return parent.iterator();
+    }
+
+    @Override
+    public boolean supportsParallelAccess() {
+        return true;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ConcurrentReadClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ConcurrentReadClipboard.java
@@ -1,0 +1,151 @@
+package com.fastasyncworldedit.core.extent.clipboard;
+
+import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
+import com.sk89q.worldedit.entity.Entity;
+import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.world.biome.BiomeType;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import org.jetbrains.annotations.ApiStatus;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+
+@ApiStatus.Experimental // Temporary wrapper
+public class ConcurrentReadClipboard implements Clipboard {
+
+    private final Clipboard parent;
+
+    public static Clipboard tryWrap(Clipboard clipboard) {
+        if (clipboard instanceof ConcurrentReadClipboard
+                || clipboard instanceof WorldCopyClipboard
+                || clipboard instanceof EmptyClipboard
+                || clipboard instanceof DiskOptimizedClipboard // FastSchematicReaderV2/V3 no min offset
+                || (clipboard instanceof BlockArrayClipboard blockArrayClipboard
+                && blockArrayClipboard.getParent() instanceof DiskOptimizedClipboard)) {
+            return clipboard;
+        }
+        return new ConcurrentReadClipboard(clipboard);
+    }
+
+    private ConcurrentReadClipboard(Clipboard parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public synchronized BlockState getBlock(BlockVector3 position) {
+        return parent.getBlock(position);
+    }
+
+    @Override
+    public synchronized BlockState getBlock(int x, int y, int z) {
+        return parent.getBlock(x, y, z);
+    }
+
+    @Override
+    public synchronized BaseBlock getFullBlock(BlockVector3 position) {
+        return parent.getFullBlock(position);
+    }
+
+    @Override
+    public synchronized BaseBlock getFullBlock(int x, int y, int z) {
+        return parent.getFullBlock(x, y, z);
+    }
+
+    @Override
+    public BiomeType getBiomeType(int x, int y, int z) {
+        return parent.getBiomeType(x, y, z);
+    }
+
+    @Override
+    public BiomeType getBiome(BlockVector3 position) {
+        return parent.getBiome(position);
+    }
+
+    @Override
+    public <B extends BlockStateHolder<B>> boolean setBlock(int x, int y, int z, B block) {
+        throw new UnsupportedOperationException("Wrapper not intended for writing");
+    }
+
+    @Override
+    public boolean tile(int x, int y, int z, FaweCompoundTag tile) {
+        throw new UnsupportedOperationException("Wrapper not intended for writing");
+    }
+
+    @Override
+    public boolean setBiome(int x, int y, int z, BiomeType biome) {
+        throw new UnsupportedOperationException("Wrapper not intended for writing");
+    }
+
+    @Override
+    public boolean setBiome(BlockVector3 position, BiomeType biome) {
+        throw new UnsupportedOperationException("Wrapper not intended for writing");
+    }
+
+    @Override
+    public BlockVector3 getMinimumPoint() {
+        return parent.getMinimumPoint();
+    }
+
+    @Override
+    public BlockVector3 getMaximumPoint() {
+        return parent.getMaximumPoint();
+    }
+
+    @Override
+    public List<? extends Entity> getEntities(Region region) {
+        return parent.getEntities(region);
+    }
+
+    @Override
+    public List<? extends Entity> getEntities() {
+        return parent.getEntities();
+    }
+
+    @Override
+    public Region getRegion() {
+        return parent.getRegion();
+    }
+
+    @Override
+    public BlockVector3 getDimensions() {
+        return parent.getDimensions();
+    }
+
+    @Override
+    public BlockVector3 getOrigin() {
+        return parent.getOrigin();
+    }
+
+    @Override
+    public void setOrigin(BlockVector3 origin) {
+        throw new UnsupportedOperationException("Wrapper not intended for writing");
+    }
+
+    @Override
+    public boolean hasBiomes() {
+        return parent.hasBiomes();
+    }
+
+    @Override
+    public void removeEntity(Entity entity) {
+        throw new UnsupportedOperationException("Wrapper not intended for writing");
+    }
+
+    @Override
+    @Nonnull
+    public Iterator<BlockVector3> iterator() {
+        return parent.iterator();
+    }
+
+    @Override
+    public void close() {
+        parent.close();
+    }
+
+}

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ConcurrentReadClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/ConcurrentReadClipboard.java
@@ -2,7 +2,6 @@ package com.fastasyncworldedit.core.extent.clipboard;
 
 import com.fastasyncworldedit.core.nbt.FaweCompoundTag;
 import com.sk89q.worldedit.entity.Entity;
-import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
@@ -16,6 +15,7 @@ import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.List;
 
+// Only wraps block-handling as reading the rest should be safe for the CPU and memory clips (ignoring 3rd party impls)
 @ApiStatus.Experimental // Temporary wrapper
 public class ConcurrentReadClipboard implements Clipboard {
 
@@ -33,23 +33,31 @@ public class ConcurrentReadClipboard implements Clipboard {
     }
 
     @Override
-    public synchronized BlockState getBlock(BlockVector3 position) {
-        return parent.getBlock(position);
+    public BlockState getBlock(BlockVector3 position) {
+        synchronized (parent) {
+            return parent.getBlock(position);
+        }
     }
 
     @Override
-    public synchronized BlockState getBlock(int x, int y, int z) {
-        return parent.getBlock(x, y, z);
+    public BlockState getBlock(int x, int y, int z) {
+        synchronized (parent) {
+            return parent.getBlock(x, y, z);
+        }
     }
 
     @Override
-    public synchronized BaseBlock getFullBlock(BlockVector3 position) {
-        return parent.getFullBlock(position);
+    public BaseBlock getFullBlock(BlockVector3 position) {
+        synchronized (parent) {
+            return parent.getFullBlock(position);
+        }
     }
 
     @Override
-    public synchronized BaseBlock getFullBlock(int x, int y, int z) {
-        return parent.getFullBlock(x, y, z);
+    public BaseBlock getFullBlock(int x, int y, int z) {
+        synchronized (parent) {
+            return parent.getFullBlock(x, y, z);
+        }
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java
@@ -303,6 +303,11 @@ public class DiskOptimizedClipboard extends LinearClipboard {
         return file.toURI();
     }
 
+    @Override
+    public boolean supportsParallelAccess() {
+        return true;
+    }
+
     public File getFile() {
         return file;
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/EmptyClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/EmptyClipboard.java
@@ -46,6 +46,11 @@ public final class EmptyClipboard implements Clipboard {
     public void removeEntity(@Nonnull Entity entity) {
     }
 
+    @Override
+    public boolean supportsParallelAccess() {
+        return true;
+    }
+
     @Nonnull
     public BlockVector3 getMinimumPoint() {
         return BlockVector3.ZERO;

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/WorldCopyClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/WorldCopyClipboard.java
@@ -103,6 +103,11 @@ public class WorldCopyClipboard extends ReadOnlyClipboard {
     }
 
     @Override
+    public boolean supportsParallelAccess() {
+        return true;
+    }
+
+    @Override
     public void paste(Extent toExtent, BlockVector3 to, boolean pasteAir, boolean pasteEntities, boolean pasteBiomes) {
         boolean close = false;
         if (toExtent instanceof World) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/BlockArrayClipboard.java
@@ -386,6 +386,11 @@ public class BlockArrayClipboard implements Clipboard {
     }
 
     @Override
+    public boolean supportsParallelAccess() {
+        return parent.supportsParallelAccess();
+    }
+
+    @Override
     public void close() {
         this.parent.close();
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
@@ -216,6 +216,15 @@ public interface Clipboard extends Extent, Iterable<BlockVector3>, Closeable, Fl
         return null;
     }
 
+    /**
+     * Check if this clipboard supports concurrent reading.
+     *
+     * @since TODO
+     */
+    default boolean supportsParallelAccess() {
+        return false;
+    }
+
     @Override
     default <T extends Filter> T apply(Region region, T filter, boolean full) {
         if (region.equals(getRegion())) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extent/clipboard/Clipboard.java
@@ -49,6 +49,7 @@ import com.sk89q.worldedit.regions.Regions;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BaseBlock;
+import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -221,6 +222,7 @@ public interface Clipboard extends Extent, Iterable<BlockVector3>, Closeable, Fl
      *
      * @since TODO
      */
+    @ApiStatus.Experimental
     default boolean supportsParallelAccess() {
         return false;
     }

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/ClipboardPattern.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/function/pattern/ClipboardPattern.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldedit.function.pattern;
 
+import com.fastasyncworldedit.core.extent.clipboard.ConcurrentReadClipboard;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.math.BlockVector3;
 
@@ -43,7 +44,7 @@ public class ClipboardPattern extends RepeatingExtentPattern {
      * @param offset    the offset
      */
     public ClipboardPattern(Clipboard clipboard, BlockVector3 offset) {
-        super(clipboard, clipboard.getMinimumPoint(), offset);
+        super(ConcurrentReadClipboard.tryWrap(clipboard), clipboard.getMinimumPoint(), offset);
     }
 
 }


### PR DESCRIPTION
## Overview
Fix corruption when using ClipboardPattern and disabling on disk clipboards as some implementations have an unsafe cache.

This does not fix RandomFullClipboardPattern, which also seems affected but I'm not sure how to wrap the clipboard properly as it uses the old single get clipboard (seemingly on purpose) but idk if or how that should be wrapped as we'd need a map or list, no?

## Description
Add a temporary wrapper to sync block access in clipboards for ClipboardPattern.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
~~- [ ] New public fields and methods are annotated with `@since TODO`.~~
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
