### PR TITLE
fix: write correct entity y/z coordinates when saving clipboard to disk

### DIFF
--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/extent/clipboard/DiskOptimizedClipboard.java
@@ -594,8 +594,8 @@ public class DiskOptimizedClipboard extends LinearClipboard {
                                 HashMap<String, Tag<?, ?>> value = new HashMap<>(data.getValue());
                                 List<DoubleTag> pos = new ArrayList<>(3);
                                 pos.add(new DoubleTag(entity.getLocation().x()));
-                                pos.add(new DoubleTag(entity.getLocation().x()));
-                                pos.add(new DoubleTag(entity.getLocation().x()));
+                                pos.add(new DoubleTag(entity.getLocation().y()));
+                                pos.add(new DoubleTag(entity.getLocation().z()));
                                 value.put("Pos", new ListTag(DoubleTag.class, pos));
                                 nbtOS.writeTag(new CompoundTag(value));
                             }


### PR DESCRIPTION
## Overview

Fixes a bug in `DiskOptimizedClipboard` where entity positions saved to a disk clipboard are corrupted. When writing entity NBT data, all three elements of the `Pos` list were set to the entity's x coordinate:

```java
pos.add(new DoubleTag(entity.getLocation().x()));
pos.add(new DoubleTag(entity.getLocation().x())); // should be y
pos.add(new DoubleTag(entity.getLocation().x())); // should be z
```

The read side (`loadNBTFromFileFooter()`) correctly reads `Pos[0..2]` as x, y, z, so every entity loaded from a disk clipboard ends up with its y and z position replaced by x. This fixes the write side to use the y and z coordinates respectively.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
