### PR TITLE
Bind ItemTypes constants to explicit ids instead of field order

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemTypes.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/item/ItemTypes.java
@@ -23,7 +23,6 @@ import com.fastasyncworldedit.core.world.block.ItemTypesCache;
 import com.sk89q.worldedit.world.registry.LegacyMapper;
 
 import javax.annotation.Nullable;
-import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Locale;
 
@@ -36,3056 +35,3114 @@ import java.util.Locale;
 public final class ItemTypes {
 
     //FAWE start - init
+    static {
+        // Initializing the cache is what populates ItemType.REGISTRY from the running platform. Static initializers run in
+        // declaration order, so this must stay above the constants for them to resolve to anything.
+        ItemTypesCache.init();
+    }
+
     @Nullable
-    public static final ItemType ACACIA_BOAT = init();
+    public static final ItemType ACACIA_BOAT = get("minecraft:acacia_boat");
     @Nullable
-    public static final ItemType ACACIA_BUTTON = init();
+    public static final ItemType ACACIA_BUTTON = get("minecraft:acacia_button");
     @Nullable
-    public static final ItemType ACACIA_CHEST_BOAT = init();
+    public static final ItemType ACACIA_CHEST_BOAT = get("minecraft:acacia_chest_boat");
     @Nullable
-    public static final ItemType ACACIA_DOOR = init();
+    public static final ItemType ACACIA_DOOR = get("minecraft:acacia_door");
     @Nullable
-    public static final ItemType ACACIA_FENCE = init();
+    public static final ItemType ACACIA_FENCE = get("minecraft:acacia_fence");
     @Nullable
-    public static final ItemType ACACIA_FENCE_GATE = init();
+    public static final ItemType ACACIA_FENCE_GATE = get("minecraft:acacia_fence_gate");
     @Nullable
-    public static final ItemType ACACIA_HANGING_SIGN = init();
+    public static final ItemType ACACIA_HANGING_SIGN = get("minecraft:acacia_hanging_sign");
     @Nullable
-    public static final ItemType ACACIA_LEAVES = init();
+    public static final ItemType ACACIA_LEAVES = get("minecraft:acacia_leaves");
     @Nullable
-    public static final ItemType ACACIA_LOG = init();
+    public static final ItemType ACACIA_LOG = get("minecraft:acacia_log");
     @Nullable
-    public static final ItemType ACACIA_PLANKS = init();
+    public static final ItemType ACACIA_PLANKS = get("minecraft:acacia_planks");
     @Nullable
-    public static final ItemType ACACIA_PRESSURE_PLATE = init();
+    public static final ItemType ACACIA_PRESSURE_PLATE = get("minecraft:acacia_pressure_plate");
     @Nullable
-    public static final ItemType ACACIA_SAPLING = init();
+    public static final ItemType ACACIA_SAPLING = get("minecraft:acacia_sapling");
     @Nullable
-    public static final ItemType ACACIA_SHELF = init();
+    public static final ItemType ACACIA_SHELF = get("minecraft:acacia_shelf");
     @Nullable
-    public static final ItemType ACACIA_SIGN = init();
+    public static final ItemType ACACIA_SIGN = get("minecraft:acacia_sign");
     @Nullable
-    public static final ItemType ACACIA_SLAB = init();
+    public static final ItemType ACACIA_SLAB = get("minecraft:acacia_slab");
     @Nullable
-    public static final ItemType ACACIA_STAIRS = init();
+    public static final ItemType ACACIA_STAIRS = get("minecraft:acacia_stairs");
     @Nullable
-    public static final ItemType ACACIA_TRAPDOOR = init();
+    public static final ItemType ACACIA_TRAPDOOR = get("minecraft:acacia_trapdoor");
     @Nullable
-    public static final ItemType ACACIA_WOOD = init();
+    public static final ItemType ACACIA_WOOD = get("minecraft:acacia_wood");
     @Nullable
-    public static final ItemType ACTIVATOR_RAIL = init();
+    public static final ItemType ACTIVATOR_RAIL = get("minecraft:activator_rail");
     @Nullable
-    public static final ItemType AIR = init();
+    public static final ItemType AIR = get("minecraft:air");
     @Nullable
-    public static final ItemType ALLAY_SPAWN_EGG = init();
+    public static final ItemType ALLAY_SPAWN_EGG = get("minecraft:allay_spawn_egg");
     @Nullable
-    public static final ItemType ALLIUM = init();
+    public static final ItemType ALLIUM = get("minecraft:allium");
     @Nullable
-    public static final ItemType AMETHYST_BLOCK = init();
+    public static final ItemType AMETHYST_BLOCK = get("minecraft:amethyst_block");
     @Nullable
-    public static final ItemType AMETHYST_CLUSTER = init();
+    public static final ItemType AMETHYST_CLUSTER = get("minecraft:amethyst_cluster");
     @Nullable
-    public static final ItemType AMETHYST_SHARD = init();
+    public static final ItemType AMETHYST_SHARD = get("minecraft:amethyst_shard");
     @Nullable
-    public static final ItemType ANCIENT_DEBRIS = init();
+    public static final ItemType ANCIENT_DEBRIS = get("minecraft:ancient_debris");
     @Nullable
-    public static final ItemType ANDESITE = init();
+    public static final ItemType ANDESITE = get("minecraft:andesite");
     @Nullable
-    public static final ItemType ANDESITE_SLAB = init();
+    public static final ItemType ANDESITE_SLAB = get("minecraft:andesite_slab");
     @Nullable
-    public static final ItemType ANDESITE_STAIRS = init();
+    public static final ItemType ANDESITE_STAIRS = get("minecraft:andesite_stairs");
     @Nullable
-    public static final ItemType ANDESITE_WALL = init();
+    public static final ItemType ANDESITE_WALL = get("minecraft:andesite_wall");
     @Nullable
-    public static final ItemType ANGLER_POTTERY_SHERD = init();
+    public static final ItemType ANGLER_POTTERY_SHERD = get("minecraft:angler_pottery_sherd");
     @Nullable
-    public static final ItemType ANVIL = init();
+    public static final ItemType ANVIL = get("minecraft:anvil");
     @Nullable
-    public static final ItemType APPLE = init();
+    public static final ItemType APPLE = get("minecraft:apple");
     @Nullable
-    public static final ItemType ARCHER_POTTERY_SHERD = init();
+    public static final ItemType ARCHER_POTTERY_SHERD = get("minecraft:archer_pottery_sherd");
     @Nullable
-    public static final ItemType ARMOR_STAND = init();
+    public static final ItemType ARMADILLO_SCUTE = get("minecraft:armadillo_scute");
     @Nullable
-    public static final ItemType ARMADILLO_SCUTE = init();
+    public static final ItemType ARMADILLO_SPAWN_EGG = get("minecraft:armadillo_spawn_egg");
     @Nullable
-    public static final ItemType ARMADILLO_SPAWN_EGG = init();
+    public static final ItemType ARMOR_STAND = get("minecraft:armor_stand");
     @Nullable
-    public static final ItemType ARMS_UP_POTTERY_SHERD = init();
+    public static final ItemType ARMS_UP_POTTERY_SHERD = get("minecraft:arms_up_pottery_sherd");
     @Nullable
-    public static final ItemType ARROW = init();
+    public static final ItemType ARROW = get("minecraft:arrow");
     @Nullable
-    public static final ItemType AXOLOTL_BUCKET = init();
+    public static final ItemType AXOLOTL_BUCKET = get("minecraft:axolotl_bucket");
     @Nullable
-    public static final ItemType AXOLOTL_SPAWN_EGG = init();
+    public static final ItemType AXOLOTL_SPAWN_EGG = get("minecraft:axolotl_spawn_egg");
     @Nullable
-    public static final ItemType AZALEA = init();
+    public static final ItemType AZALEA = get("minecraft:azalea");
     @Nullable
-    public static final ItemType AZALEA_LEAVES = init();
+    public static final ItemType AZALEA_LEAVES = get("minecraft:azalea_leaves");
     @Nullable
-    public static final ItemType AZURE_BLUET = init();
+    public static final ItemType AZURE_BLUET = get("minecraft:azure_bluet");
     @Nullable
-    public static final ItemType BAKED_POTATO = init();
+    public static final ItemType BAKED_POTATO = get("minecraft:baked_potato");
     @Nullable
-    public static final ItemType BAMBOO = init();
+    public static final ItemType BAMBOO = get("minecraft:bamboo");
     @Nullable
-    public static final ItemType BAMBOO_BLOCK = init();
+    public static final ItemType BAMBOO_BLOCK = get("minecraft:bamboo_block");
     @Nullable
-    public static final ItemType BAMBOO_BUTTON = init();
+    public static final ItemType BAMBOO_BUTTON = get("minecraft:bamboo_button");
     @Nullable
-    public static final ItemType BAMBOO_CHEST_RAFT = init();
+    public static final ItemType BAMBOO_CHEST_RAFT = get("minecraft:bamboo_chest_raft");
     @Nullable
-    public static final ItemType BAMBOO_DOOR = init();
+    public static final ItemType BAMBOO_DOOR = get("minecraft:bamboo_door");
     @Nullable
-    public static final ItemType BAMBOO_FENCE = init();
+    public static final ItemType BAMBOO_FENCE = get("minecraft:bamboo_fence");
     @Nullable
-    public static final ItemType BAMBOO_FENCE_GATE = init();
+    public static final ItemType BAMBOO_FENCE_GATE = get("minecraft:bamboo_fence_gate");
     @Nullable
-    public static final ItemType BAMBOO_HANGING_SIGN = init();
+    public static final ItemType BAMBOO_HANGING_SIGN = get("minecraft:bamboo_hanging_sign");
     @Nullable
-    public static final ItemType BAMBOO_MOSAIC = init();
+    public static final ItemType BAMBOO_MOSAIC = get("minecraft:bamboo_mosaic");
     @Nullable
-    public static final ItemType BAMBOO_MOSAIC_SLAB = init();
+    public static final ItemType BAMBOO_MOSAIC_SLAB = get("minecraft:bamboo_mosaic_slab");
     @Nullable
-    public static final ItemType BAMBOO_MOSAIC_STAIRS = init();
+    public static final ItemType BAMBOO_MOSAIC_STAIRS = get("minecraft:bamboo_mosaic_stairs");
     @Nullable
-    public static final ItemType BAMBOO_PLANKS = init();
+    public static final ItemType BAMBOO_PLANKS = get("minecraft:bamboo_planks");
     @Nullable
-    public static final ItemType BAMBOO_PRESSURE_PLATE = init();
+    public static final ItemType BAMBOO_PRESSURE_PLATE = get("minecraft:bamboo_pressure_plate");
     @Nullable
-    public static final ItemType BAMBOO_SHELF = init();
+    public static final ItemType BAMBOO_RAFT = get("minecraft:bamboo_raft");
     @Nullable
-    public static final ItemType BAMBOO_RAFT = init();
+    public static final ItemType BAMBOO_SHELF = get("minecraft:bamboo_shelf");
     @Nullable
-    public static final ItemType BAMBOO_SIGN = init();
+    public static final ItemType BAMBOO_SIGN = get("minecraft:bamboo_sign");
     @Nullable
-    public static final ItemType BAMBOO_SLAB = init();
+    public static final ItemType BAMBOO_SLAB = get("minecraft:bamboo_slab");
     @Nullable
-    public static final ItemType BAMBOO_STAIRS = init();
+    public static final ItemType BAMBOO_STAIRS = get("minecraft:bamboo_stairs");
     @Nullable
-    public static final ItemType BAMBOO_TRAPDOOR = init();
+    public static final ItemType BAMBOO_TRAPDOOR = get("minecraft:bamboo_trapdoor");
     @Nullable
-    public static final ItemType BARREL = init();
+    public static final ItemType BARREL = get("minecraft:barrel");
     @Nullable
-    public static final ItemType BARRIER = init();
+    public static final ItemType BARRIER = get("minecraft:barrier");
     @Nullable
-    public static final ItemType BASALT = init();
+    public static final ItemType BASALT = get("minecraft:basalt");
     @Nullable
-    public static final ItemType BAT_SPAWN_EGG = init();
+    public static final ItemType BAT_SPAWN_EGG = get("minecraft:bat_spawn_egg");
     @Nullable
-    public static final ItemType BEACON = init();
+    public static final ItemType BEACON = get("minecraft:beacon");
     @Nullable
-    public static final ItemType BEDROCK = init();
+    public static final ItemType BEDROCK = get("minecraft:bedrock");
     @Nullable
-    public static final ItemType BEE_NEST = init();
+    public static final ItemType BEE_NEST = get("minecraft:bee_nest");
     @Nullable
-    public static final ItemType BEE_SPAWN_EGG = init();
+    public static final ItemType BEE_SPAWN_EGG = get("minecraft:bee_spawn_egg");
     @Nullable
-    public static final ItemType BEEF = init();
+    public static final ItemType BEEF = get("minecraft:beef");
     @Nullable
-    public static final ItemType BEEHIVE = init();
+    public static final ItemType BEEHIVE = get("minecraft:beehive");
     @Nullable
-    public static final ItemType BEETROOT = init();
+    public static final ItemType BEETROOT = get("minecraft:beetroot");
     @Nullable
-    public static final ItemType BEETROOT_SEEDS = init();
+    public static final ItemType BEETROOT_SEEDS = get("minecraft:beetroot_seeds");
     @Nullable
-    public static final ItemType BEETROOT_SOUP = init();
+    public static final ItemType BEETROOT_SOUP = get("minecraft:beetroot_soup");
     @Nullable
-    public static final ItemType BELL = init();
+    public static final ItemType BELL = get("minecraft:bell");
     @Nullable
-    public static final ItemType BIG_DRIPLEAF = init();
+    public static final ItemType BIG_DRIPLEAF = get("minecraft:big_dripleaf");
     @Nullable
-    public static final ItemType BIRCH_BOAT = init();
+    public static final ItemType BIRCH_BOAT = get("minecraft:birch_boat");
     @Nullable
-    public static final ItemType BIRCH_BUTTON = init();
+    public static final ItemType BIRCH_BUTTON = get("minecraft:birch_button");
     @Nullable
-    public static final ItemType BIRCH_CHEST_BOAT = init();
+    public static final ItemType BIRCH_CHEST_BOAT = get("minecraft:birch_chest_boat");
     @Nullable
-    public static final ItemType BIRCH_DOOR = init();
+    public static final ItemType BIRCH_DOOR = get("minecraft:birch_door");
     @Nullable
-    public static final ItemType BIRCH_FENCE = init();
+    public static final ItemType BIRCH_FENCE = get("minecraft:birch_fence");
     @Nullable
-    public static final ItemType BIRCH_FENCE_GATE = init();
+    public static final ItemType BIRCH_FENCE_GATE = get("minecraft:birch_fence_gate");
     @Nullable
-    public static final ItemType BIRCH_HANGING_SIGN = init();
+    public static final ItemType BIRCH_HANGING_SIGN = get("minecraft:birch_hanging_sign");
     @Nullable
-    public static final ItemType BIRCH_LEAVES = init();
+    public static final ItemType BIRCH_LEAVES = get("minecraft:birch_leaves");
     @Nullable
-    public static final ItemType BIRCH_LOG = init();
+    public static final ItemType BIRCH_LOG = get("minecraft:birch_log");
     @Nullable
-    public static final ItemType BIRCH_PLANKS = init();
+    public static final ItemType BIRCH_PLANKS = get("minecraft:birch_planks");
     @Nullable
-    public static final ItemType BIRCH_PRESSURE_PLATE = init();
+    public static final ItemType BIRCH_PRESSURE_PLATE = get("minecraft:birch_pressure_plate");
     @Nullable
-    public static final ItemType BIRCH_SAPLING = init();
+    public static final ItemType BIRCH_SAPLING = get("minecraft:birch_sapling");
     @Nullable
-    public static final ItemType BIRCH_SHELF = init();
+    public static final ItemType BIRCH_SHELF = get("minecraft:birch_shelf");
     @Nullable
-    public static final ItemType BIRCH_SIGN = init();
+    public static final ItemType BIRCH_SIGN = get("minecraft:birch_sign");
     @Nullable
-    public static final ItemType BIRCH_SLAB = init();
+    public static final ItemType BIRCH_SLAB = get("minecraft:birch_slab");
     @Nullable
-    public static final ItemType BIRCH_STAIRS = init();
+    public static final ItemType BIRCH_STAIRS = get("minecraft:birch_stairs");
     @Nullable
-    public static final ItemType BIRCH_TRAPDOOR = init();
+    public static final ItemType BIRCH_TRAPDOOR = get("minecraft:birch_trapdoor");
     @Nullable
-    public static final ItemType BIRCH_WOOD = init();
+    public static final ItemType BIRCH_WOOD = get("minecraft:birch_wood");
     @Nullable
-    public static final ItemType BLACK_BANNER = init();
+    public static final ItemType BLACK_BANNER = get("minecraft:black_banner");
     @Nullable
-    public static final ItemType BLACK_BED = init();
+    public static final ItemType BLACK_BED = get("minecraft:black_bed");
     @Nullable
-    public static final ItemType BLACK_BUNDLE = init();
+    public static final ItemType BLACK_BUNDLE = get("minecraft:black_bundle");
     @Nullable
-    public static final ItemType BLACK_CANDLE = init();
+    public static final ItemType BLACK_CANDLE = get("minecraft:black_candle");
     @Nullable
-    public static final ItemType BLACK_CARPET = init();
+    public static final ItemType BLACK_CARPET = get("minecraft:black_carpet");
     @Nullable
-    public static final ItemType BLACK_CONCRETE = init();
+    public static final ItemType BLACK_CONCRETE = get("minecraft:black_concrete");
     @Nullable
-    public static final ItemType BLACK_CONCRETE_POWDER = init();
+    public static final ItemType BLACK_CONCRETE_POWDER = get("minecraft:black_concrete_powder");
     @Nullable
-    public static final ItemType BLACK_DYE = init();
+    public static final ItemType BLACK_DYE = get("minecraft:black_dye");
     @Nullable
-    public static final ItemType BLACK_GLAZED_TERRACOTTA = init();
+    public static final ItemType BLACK_GLAZED_TERRACOTTA = get("minecraft:black_glazed_terracotta");
     @Nullable
-    public static final ItemType BLACK_SHULKER_BOX = init();
+    public static final ItemType BLACK_HARNESS = get("minecraft:black_harness");
     @Nullable
-    public static final ItemType BLACK_STAINED_GLASS = init();
+    public static final ItemType BLACK_SHULKER_BOX = get("minecraft:black_shulker_box");
     @Nullable
-    public static final ItemType BLACK_STAINED_GLASS_PANE = init();
+    public static final ItemType BLACK_STAINED_GLASS = get("minecraft:black_stained_glass");
     @Nullable
-    public static final ItemType BLACK_TERRACOTTA = init();
+    public static final ItemType BLACK_STAINED_GLASS_PANE = get("minecraft:black_stained_glass_pane");
     @Nullable
-    public static final ItemType BLACK_WOOL = init();
+    public static final ItemType BLACK_TERRACOTTA = get("minecraft:black_terracotta");
     @Nullable
-    public static final ItemType BLACKSTONE = init();
+    public static final ItemType BLACK_WOOL = get("minecraft:black_wool");
     @Nullable
-    public static final ItemType BLACKSTONE_SLAB = init();
+    public static final ItemType BLACKSTONE = get("minecraft:blackstone");
     @Nullable
-    public static final ItemType BLACKSTONE_STAIRS = init();
+    public static final ItemType BLACKSTONE_SLAB = get("minecraft:blackstone_slab");
     @Nullable
-    public static final ItemType BLACKSTONE_WALL = init();
+    public static final ItemType BLACKSTONE_STAIRS = get("minecraft:blackstone_stairs");
     @Nullable
-    public static final ItemType BLADE_POTTERY_SHERD = init();
+    public static final ItemType BLACKSTONE_WALL = get("minecraft:blackstone_wall");
     @Nullable
-    public static final ItemType BLAST_FURNACE = init();
+    public static final ItemType BLADE_POTTERY_SHERD = get("minecraft:blade_pottery_sherd");
     @Nullable
-    public static final ItemType BLAZE_POWDER = init();
+    public static final ItemType BLAST_FURNACE = get("minecraft:blast_furnace");
     @Nullable
-    public static final ItemType BLAZE_ROD = init();
+    public static final ItemType BLAZE_POWDER = get("minecraft:blaze_powder");
     @Nullable
-    public static final ItemType BLAZE_SPAWN_EGG = init();
+    public static final ItemType BLAZE_ROD = get("minecraft:blaze_rod");
     @Nullable
-    public static final ItemType BLUE_BANNER = init();
+    public static final ItemType BLAZE_SPAWN_EGG = get("minecraft:blaze_spawn_egg");
     @Nullable
-    public static final ItemType BLUE_BED = init();
+    public static final ItemType BLUE_BANNER = get("minecraft:blue_banner");
     @Nullable
-    public static final ItemType BLUE_BUNDLE = init();
+    public static final ItemType BLUE_BED = get("minecraft:blue_bed");
     @Nullable
-    public static final ItemType BLUE_CANDLE = init();
+    public static final ItemType BLUE_BUNDLE = get("minecraft:blue_bundle");
     @Nullable
-    public static final ItemType BROWN_CANDLE = init();
+    public static final ItemType BLUE_CANDLE = get("minecraft:blue_candle");
     @Nullable
-    public static final ItemType BLUE_CARPET = init();
+    public static final ItemType BLUE_CARPET = get("minecraft:blue_carpet");
     @Nullable
-    public static final ItemType BLUE_CONCRETE = init();
+    public static final ItemType BLUE_CONCRETE = get("minecraft:blue_concrete");
     @Nullable
-    public static final ItemType BLUE_CONCRETE_POWDER = init();
+    public static final ItemType BLUE_CONCRETE_POWDER = get("minecraft:blue_concrete_powder");
     @Nullable
-    public static final ItemType BLUE_DYE = init();
+    public static final ItemType BLUE_DYE = get("minecraft:blue_dye");
     @Nullable
-    public static final ItemType BLUE_EGG = init();
+    public static final ItemType BLUE_EGG = get("minecraft:blue_egg");
     @Nullable
-    public static final ItemType BLUE_GLAZED_TERRACOTTA = init();
+    public static final ItemType BLUE_GLAZED_TERRACOTTA = get("minecraft:blue_glazed_terracotta");
     @Nullable
-    public static final ItemType BLUE_ICE = init();
+    public static final ItemType BLUE_HARNESS = get("minecraft:blue_harness");
     @Nullable
-    public static final ItemType BLUE_ORCHID = init();
+    public static final ItemType BLUE_ICE = get("minecraft:blue_ice");
     @Nullable
-    public static final ItemType BLUE_SHULKER_BOX = init();
+    public static final ItemType BLUE_ORCHID = get("minecraft:blue_orchid");
     @Nullable
-    public static final ItemType BLUE_STAINED_GLASS = init();
+    public static final ItemType BLUE_SHULKER_BOX = get("minecraft:blue_shulker_box");
     @Nullable
-    public static final ItemType BLUE_STAINED_GLASS_PANE = init();
+    public static final ItemType BLUE_STAINED_GLASS = get("minecraft:blue_stained_glass");
     @Nullable
-    public static final ItemType BLUE_TERRACOTTA = init();
+    public static final ItemType BLUE_STAINED_GLASS_PANE = get("minecraft:blue_stained_glass_pane");
     @Nullable
-    public static final ItemType BLUE_WOOL = init();
+    public static final ItemType BLUE_TERRACOTTA = get("minecraft:blue_terracotta");
     @Nullable
-    public static final ItemType BOGGED_SPAWN_EGG = init();
+    public static final ItemType BLUE_WOOL = get("minecraft:blue_wool");
     @Nullable
-    public static final ItemType BOLT_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType BOGGED_SPAWN_EGG = get("minecraft:bogged_spawn_egg");
     @Nullable
-    public static final ItemType BONE = init();
+    public static final ItemType BOLT_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:bolt_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType BONE_BLOCK = init();
+    public static final ItemType BONE = get("minecraft:bone");
     @Nullable
-    public static final ItemType BONE_MEAL = init();
+    public static final ItemType BONE_BLOCK = get("minecraft:bone_block");
     @Nullable
-    public static final ItemType BOOK = init();
+    public static final ItemType BONE_MEAL = get("minecraft:bone_meal");
     @Nullable
-    public static final ItemType BOOKSHELF = init();
+    public static final ItemType BOOK = get("minecraft:book");
     @Nullable
-    public static final ItemType BORDURE_INDENTED_BANNER_PATTERN = init();
+    public static final ItemType BOOKSHELF = get("minecraft:bookshelf");
     @Nullable
-    public static final ItemType BOW = init();
+    public static final ItemType BORDURE_INDENTED_BANNER_PATTERN = get("minecraft:bordure_indented_banner_pattern");
     @Nullable
-    public static final ItemType BOWL = init();
+    public static final ItemType BOW = get("minecraft:bow");
     @Nullable
-    public static final ItemType BRAIN_CORAL = init();
+    public static final ItemType BOWL = get("minecraft:bowl");
     @Nullable
-    public static final ItemType BRAIN_CORAL_BLOCK = init();
+    public static final ItemType BRAIN_CORAL = get("minecraft:brain_coral");
     @Nullable
-    public static final ItemType BRAIN_CORAL_FAN = init();
+    public static final ItemType BRAIN_CORAL_BLOCK = get("minecraft:brain_coral_block");
     @Nullable
-    public static final ItemType BREAD = init();
+    public static final ItemType BRAIN_CORAL_FAN = get("minecraft:brain_coral_fan");
     @Nullable
-    public static final ItemType BREEZE_ROD = init();
+    public static final ItemType BREAD = get("minecraft:bread");
     @Nullable
-    public static final ItemType BREEZE_SPAWN_EGG = init();
+    public static final ItemType BREEZE_ROD = get("minecraft:breeze_rod");
     @Nullable
-    public static final ItemType BREWER_POTTERY_SHERD = init();
+    public static final ItemType BREEZE_SPAWN_EGG = get("minecraft:breeze_spawn_egg");
     @Nullable
-    public static final ItemType BREWING_STAND = init();
+    public static final ItemType BREWER_POTTERY_SHERD = get("minecraft:brewer_pottery_sherd");
     @Nullable
-    public static final ItemType BRICK = init();
+    public static final ItemType BREWING_STAND = get("minecraft:brewing_stand");
     @Nullable
-    public static final ItemType BRICK_SLAB = init();
+    public static final ItemType BRICK = get("minecraft:brick");
     @Nullable
-    public static final ItemType BRICK_STAIRS = init();
+    public static final ItemType BRICK_SLAB = get("minecraft:brick_slab");
     @Nullable
-    public static final ItemType BRICK_WALL = init();
+    public static final ItemType BRICK_STAIRS = get("minecraft:brick_stairs");
     @Nullable
-    public static final ItemType BRICKS = init();
+    public static final ItemType BRICK_WALL = get("minecraft:brick_wall");
     @Nullable
-    public static final ItemType BROWN_BANNER = init();
+    public static final ItemType BRICKS = get("minecraft:bricks");
     @Nullable
-    public static final ItemType BROWN_BED = init();
+    public static final ItemType BROWN_BANNER = get("minecraft:brown_banner");
     @Nullable
-    public static final ItemType BROWN_BUNDLE = init();
+    public static final ItemType BROWN_BED = get("minecraft:brown_bed");
     @Nullable
-    public static final ItemType BROWN_CARPET = init();
+    public static final ItemType BROWN_BUNDLE = get("minecraft:brown_bundle");
     @Nullable
-    public static final ItemType BROWN_CONCRETE = init();
+    public static final ItemType BROWN_CANDLE = get("minecraft:brown_candle");
     @Nullable
-    public static final ItemType BROWN_CONCRETE_POWDER = init();
+    public static final ItemType BROWN_CARPET = get("minecraft:brown_carpet");
     @Nullable
-    public static final ItemType BROWN_DYE = init();
+    public static final ItemType BROWN_CONCRETE = get("minecraft:brown_concrete");
     @Nullable
-    public static final ItemType BROWN_EGG = init();
+    public static final ItemType BROWN_CONCRETE_POWDER = get("minecraft:brown_concrete_powder");
     @Nullable
-    public static final ItemType BROWN_GLAZED_TERRACOTTA = init();
+    public static final ItemType BROWN_DYE = get("minecraft:brown_dye");
     @Nullable
-    public static final ItemType BROWN_MUSHROOM = init();
+    public static final ItemType BROWN_EGG = get("minecraft:brown_egg");
     @Nullable
-    public static final ItemType BROWN_MUSHROOM_BLOCK = init();
+    public static final ItemType BROWN_GLAZED_TERRACOTTA = get("minecraft:brown_glazed_terracotta");
     @Nullable
-    public static final ItemType BROWN_SHULKER_BOX = init();
+    public static final ItemType BROWN_HARNESS = get("minecraft:brown_harness");
     @Nullable
-    public static final ItemType BROWN_STAINED_GLASS = init();
+    public static final ItemType BROWN_MUSHROOM = get("minecraft:brown_mushroom");
     @Nullable
-    public static final ItemType BROWN_STAINED_GLASS_PANE = init();
+    public static final ItemType BROWN_MUSHROOM_BLOCK = get("minecraft:brown_mushroom_block");
     @Nullable
-    public static final ItemType BROWN_TERRACOTTA = init();
+    public static final ItemType BROWN_SHULKER_BOX = get("minecraft:brown_shulker_box");
     @Nullable
-    public static final ItemType BROWN_WOOL = init();
+    public static final ItemType BROWN_STAINED_GLASS = get("minecraft:brown_stained_glass");
     @Nullable
-    public static final ItemType BRUSH = init();
+    public static final ItemType BROWN_STAINED_GLASS_PANE = get("minecraft:brown_stained_glass_pane");
     @Nullable
-    public static final ItemType BUBBLE_CORAL = init();
+    public static final ItemType BROWN_TERRACOTTA = get("minecraft:brown_terracotta");
     @Nullable
-    public static final ItemType BUBBLE_CORAL_BLOCK = init();
+    public static final ItemType BROWN_WOOL = get("minecraft:brown_wool");
     @Nullable
-    public static final ItemType BUBBLE_CORAL_FAN = init();
+    public static final ItemType BRUSH = get("minecraft:brush");
     @Nullable
-    public static final ItemType BUCKET = init();
+    public static final ItemType BUBBLE_CORAL = get("minecraft:bubble_coral");
     @Nullable
-    public static final ItemType BUDDING_AMETHYST = init();
+    public static final ItemType BUBBLE_CORAL_BLOCK = get("minecraft:bubble_coral_block");
     @Nullable
-    public static final ItemType BUNDLE = init();
+    public static final ItemType BUBBLE_CORAL_FAN = get("minecraft:bubble_coral_fan");
     @Nullable
-    public static final ItemType BURN_POTTERY_SHERD = init();
+    public static final ItemType BUCKET = get("minecraft:bucket");
     @Nullable
-    public static final ItemType BUSH = init();
+    public static final ItemType BUDDING_AMETHYST = get("minecraft:budding_amethyst");
     @Nullable
-    public static final ItemType CACTUS = init();
+    public static final ItemType BUNDLE = get("minecraft:bundle");
     @Nullable
-    public static final ItemType CACTUS_FLOWER = init();
+    public static final ItemType BURN_POTTERY_SHERD = get("minecraft:burn_pottery_sherd");
+    @Nullable
+    public static final ItemType BUSH = get("minecraft:bush");
+    @Nullable
+    public static final ItemType CACTUS = get("minecraft:cactus");
+    @Nullable
+    public static final ItemType CACTUS_FLOWER = get("minecraft:cactus_flower");
     @Deprecated
     @Nullable
-    public static final ItemType CACTUS_GREEN = init();
+    public static final ItemType CACTUS_GREEN = get("minecraft:cactus_green");
     @Nullable
-    public static final ItemType CAKE = init();
+    public static final ItemType CAKE = get("minecraft:cake");
     @Nullable
-    public static final ItemType CALCITE = init();
+    public static final ItemType CALCITE = get("minecraft:calcite");
     @Nullable
-    public static final ItemType CALIBRATED_SCULK_SENSOR = init();
+    public static final ItemType CALIBRATED_SCULK_SENSOR = get("minecraft:calibrated_sculk_sensor");
     @Nullable
-    public static final ItemType CAMEL_HUSK_SPAWN_EGG = init();
+    public static final ItemType CAMEL_HUSK_SPAWN_EGG = get("minecraft:camel_husk_spawn_egg");
     @Nullable
-    public static final ItemType CAMEL_SPAWN_EGG = init();
+    public static final ItemType CAMEL_SPAWN_EGG = get("minecraft:camel_spawn_egg");
     @Nullable
-    public static final ItemType CAMPFIRE = init();
+    public static final ItemType CAMPFIRE = get("minecraft:campfire");
     @Nullable
-    public static final ItemType CANDLE = init();
+    public static final ItemType CANDLE = get("minecraft:candle");
     @Nullable
-    public static final ItemType CARROT = init();
+    public static final ItemType CARROT = get("minecraft:carrot");
     @Nullable
-    public static final ItemType CARROT_ON_A_STICK = init();
+    public static final ItemType CARROT_ON_A_STICK = get("minecraft:carrot_on_a_stick");
     @Nullable
-    public static final ItemType CARTOGRAPHY_TABLE = init();
+    public static final ItemType CARTOGRAPHY_TABLE = get("minecraft:cartography_table");
     @Nullable
-    public static final ItemType CARVED_PUMPKIN = init();
+    public static final ItemType CARVED_PUMPKIN = get("minecraft:carved_pumpkin");
     @Nullable
-    public static final ItemType CAT_SPAWN_EGG = init();
+    public static final ItemType CAT_SPAWN_EGG = get("minecraft:cat_spawn_egg");
     @Nullable
-    public static final ItemType CAULDRON = init();
+    public static final ItemType CAULDRON = get("minecraft:cauldron");
     @Nullable
-    public static final ItemType CAVE_SPIDER_SPAWN_EGG = init();
+    public static final ItemType CAVE_SPIDER_SPAWN_EGG = get("minecraft:cave_spider_spawn_egg");
     @Deprecated
     @Nullable
-    public static final ItemType CHAIN = init();
+    public static final ItemType CHAIN = get("minecraft:chain");
     @Nullable
-    public static final ItemType CHAIN_COMMAND_BLOCK = init();
+    public static final ItemType CHAIN_COMMAND_BLOCK = get("minecraft:chain_command_block");
     @Nullable
-    public static final ItemType CHAINMAIL_BOOTS = init();
+    public static final ItemType CHAINMAIL_BOOTS = get("minecraft:chainmail_boots");
     @Nullable
-    public static final ItemType CHAINMAIL_CHESTPLATE = init();
+    public static final ItemType CHAINMAIL_CHESTPLATE = get("minecraft:chainmail_chestplate");
     @Nullable
-    public static final ItemType CHAINMAIL_HELMET = init();
+    public static final ItemType CHAINMAIL_HELMET = get("minecraft:chainmail_helmet");
     @Nullable
-    public static final ItemType CHAINMAIL_LEGGINGS = init();
+    public static final ItemType CHAINMAIL_LEGGINGS = get("minecraft:chainmail_leggings");
     @Nullable
-    public static final ItemType CHARCOAL = init();
+    public static final ItemType CHARCOAL = get("minecraft:charcoal");
     @Nullable
-    public static final ItemType CHERRY_BOAT = init();
+    public static final ItemType CHERRY_BOAT = get("minecraft:cherry_boat");
     @Nullable
-    public static final ItemType CHERRY_BUTTON = init();
+    public static final ItemType CHERRY_BUTTON = get("minecraft:cherry_button");
     @Nullable
-    public static final ItemType CHERRY_CHEST_BOAT = init();
+    public static final ItemType CHERRY_CHEST_BOAT = get("minecraft:cherry_chest_boat");
     @Nullable
-    public static final ItemType CHERRY_DOOR = init();
+    public static final ItemType CHERRY_DOOR = get("minecraft:cherry_door");
     @Nullable
-    public static final ItemType CHERRY_FENCE = init();
+    public static final ItemType CHERRY_FENCE = get("minecraft:cherry_fence");
     @Nullable
-    public static final ItemType CHERRY_FENCE_GATE = init();
+    public static final ItemType CHERRY_FENCE_GATE = get("minecraft:cherry_fence_gate");
     @Nullable
-    public static final ItemType CHERRY_HANGING_SIGN = init();
+    public static final ItemType CHERRY_HANGING_SIGN = get("minecraft:cherry_hanging_sign");
     @Nullable
-    public static final ItemType CHERRY_LEAVES = init();
+    public static final ItemType CHERRY_LEAVES = get("minecraft:cherry_leaves");
     @Nullable
-    public static final ItemType CHERRY_LOG = init();
+    public static final ItemType CHERRY_LOG = get("minecraft:cherry_log");
     @Nullable
-    public static final ItemType CHERRY_PLANKS = init();
+    public static final ItemType CHERRY_PLANKS = get("minecraft:cherry_planks");
     @Nullable
-    public static final ItemType CHERRY_PRESSURE_PLATE = init();
+    public static final ItemType CHERRY_PRESSURE_PLATE = get("minecraft:cherry_pressure_plate");
     @Nullable
-    public static final ItemType CHERRY_SAPLING = init();
+    public static final ItemType CHERRY_SAPLING = get("minecraft:cherry_sapling");
     @Nullable
-    public static final ItemType CHERRY_SHELF = init();
+    public static final ItemType CHERRY_SHELF = get("minecraft:cherry_shelf");
     @Nullable
-    public static final ItemType CHERRY_SIGN = init();
+    public static final ItemType CHERRY_SIGN = get("minecraft:cherry_sign");
     @Nullable
-    public static final ItemType CHERRY_SLAB = init();
+    public static final ItemType CHERRY_SLAB = get("minecraft:cherry_slab");
     @Nullable
-    public static final ItemType CHERRY_STAIRS = init();
+    public static final ItemType CHERRY_STAIRS = get("minecraft:cherry_stairs");
     @Nullable
-    public static final ItemType CHERRY_TRAPDOOR = init();
+    public static final ItemType CHERRY_TRAPDOOR = get("minecraft:cherry_trapdoor");
     @Nullable
-    public static final ItemType CHERRY_WOOD = init();
+    public static final ItemType CHERRY_WOOD = get("minecraft:cherry_wood");
     @Nullable
-    public static final ItemType CHEST = init();
+    public static final ItemType CHEST = get("minecraft:chest");
     @Nullable
-    public static final ItemType CHEST_MINECART = init();
+    public static final ItemType CHEST_MINECART = get("minecraft:chest_minecart");
     @Nullable
-    public static final ItemType CHICKEN = init();
+    public static final ItemType CHICKEN = get("minecraft:chicken");
     @Nullable
-    public static final ItemType CHICKEN_SPAWN_EGG = init();
+    public static final ItemType CHICKEN_SPAWN_EGG = get("minecraft:chicken_spawn_egg");
     @Nullable
-    public static final ItemType CHIPPED_ANVIL = init();
+    public static final ItemType CHIPPED_ANVIL = get("minecraft:chipped_anvil");
     @Nullable
-    public static final ItemType CHISELED_BOOKSHELF = init();
+    public static final ItemType CHISELED_BOOKSHELF = get("minecraft:chiseled_bookshelf");
     @Nullable
-    public static final ItemType CHISELED_CINNABAR = init();
+    public static final ItemType CHISELED_CINNABAR = get("minecraft:chiseled_cinnabar");
     @Nullable
-    public static final ItemType CHISELED_COPPER = init();
+    public static final ItemType CHISELED_COPPER = get("minecraft:chiseled_copper");
     @Nullable
-    public static final ItemType CHISELED_DEEPSLATE = init();
+    public static final ItemType CHISELED_DEEPSLATE = get("minecraft:chiseled_deepslate");
     @Nullable
-    public static final ItemType CHISELED_NETHER_BRICKS = init();
+    public static final ItemType CHISELED_NETHER_BRICKS = get("minecraft:chiseled_nether_bricks");
     @Nullable
-    public static final ItemType CHISELED_POLISHED_BLACKSTONE = init();
+    public static final ItemType CHISELED_POLISHED_BLACKSTONE = get("minecraft:chiseled_polished_blackstone");
     @Nullable
-    public static final ItemType CHISELED_QUARTZ_BLOCK = init();
+    public static final ItemType CHISELED_QUARTZ_BLOCK = get("minecraft:chiseled_quartz_block");
     @Nullable
-    public static final ItemType CHISELED_RED_SANDSTONE = init();
+    public static final ItemType CHISELED_RED_SANDSTONE = get("minecraft:chiseled_red_sandstone");
     @Nullable
-    public static final ItemType CHISELED_RESIN_BRICKS = init();
+    public static final ItemType CHISELED_RESIN_BRICKS = get("minecraft:chiseled_resin_bricks");
     @Nullable
-    public static final ItemType CHISELED_SANDSTONE = init();
+    public static final ItemType CHISELED_SANDSTONE = get("minecraft:chiseled_sandstone");
     @Nullable
-    public static final ItemType CHISELED_STONE_BRICKS = init();
+    public static final ItemType CHISELED_STONE_BRICKS = get("minecraft:chiseled_stone_bricks");
     @Nullable
-    public static final ItemType CHISELED_SULFUR = init();
+    public static final ItemType CHISELED_SULFUR = get("minecraft:chiseled_sulfur");
     @Nullable
-    public static final ItemType CHISELED_TUFF = init();
+    public static final ItemType CHISELED_TUFF = get("minecraft:chiseled_tuff");
     @Nullable
-    public static final ItemType CHISELED_TUFF_BRICKS = init();
+    public static final ItemType CHISELED_TUFF_BRICKS = get("minecraft:chiseled_tuff_bricks");
     @Nullable
-    public static final ItemType CHORUS_FLOWER = init();
+    public static final ItemType CHORUS_FLOWER = get("minecraft:chorus_flower");
     @Nullable
-    public static final ItemType CHORUS_FRUIT = init();
+    public static final ItemType CHORUS_FRUIT = get("minecraft:chorus_fruit");
     @Nullable
-    public static final ItemType CHORUS_PLANT = init();
+    public static final ItemType CHORUS_PLANT = get("minecraft:chorus_plant");
     @Nullable
-    public static final ItemType CINNABAR = init();
+    public static final ItemType CINNABAR = get("minecraft:cinnabar");
     @Nullable
-    public static final ItemType CINNABAR_BRICK_SLAB = init();
+    public static final ItemType CINNABAR_BRICK_SLAB = get("minecraft:cinnabar_brick_slab");
     @Nullable
-    public static final ItemType CINNABAR_BRICK_STAIRS = init();
+    public static final ItemType CINNABAR_BRICK_STAIRS = get("minecraft:cinnabar_brick_stairs");
     @Nullable
-    public static final ItemType CINNABAR_BRICK_WALL = init();
+    public static final ItemType CINNABAR_BRICK_WALL = get("minecraft:cinnabar_brick_wall");
     @Nullable
-    public static final ItemType CINNABAR_BRICKS = init();
+    public static final ItemType CINNABAR_BRICKS = get("minecraft:cinnabar_bricks");
     @Nullable
-    public static final ItemType CINNABAR_SLAB = init();
+    public static final ItemType CINNABAR_SLAB = get("minecraft:cinnabar_slab");
     @Nullable
-    public static final ItemType CINNABAR_STAIRS = init();
+    public static final ItemType CINNABAR_STAIRS = get("minecraft:cinnabar_stairs");
     @Nullable
-    public static final ItemType CINNABAR_WALL = init();
+    public static final ItemType CINNABAR_WALL = get("minecraft:cinnabar_wall");
     @Nullable
-    public static final ItemType CLAY = init();
+    public static final ItemType CLAY = get("minecraft:clay");
     @Nullable
-    public static final ItemType CLAY_BALL = init();
+    public static final ItemType CLAY_BALL = get("minecraft:clay_ball");
     @Nullable
-    public static final ItemType CLOCK = init();
+    public static final ItemType CLOCK = get("minecraft:clock");
     @Nullable
-    public static final ItemType CLOSED_EYEBLOSSOM = init();
+    public static final ItemType CLOSED_EYEBLOSSOM = get("minecraft:closed_eyeblossom");
     @Nullable
-    public static final ItemType COAL = init();
+    public static final ItemType COAL = get("minecraft:coal");
     @Nullable
-    public static final ItemType COAL_BLOCK = init();
+    public static final ItemType COAL_BLOCK = get("minecraft:coal_block");
     @Nullable
-    public static final ItemType COAL_ORE = init();
+    public static final ItemType COAL_ORE = get("minecraft:coal_ore");
     @Nullable
-    public static final ItemType COARSE_DIRT = init();
+    public static final ItemType COARSE_DIRT = get("minecraft:coarse_dirt");
     @Nullable
-    public static final ItemType COAST_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType COAST_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:coast_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType COBBLED_DEEPSLATE = init();
+    public static final ItemType COBBLED_DEEPSLATE = get("minecraft:cobbled_deepslate");
     @Nullable
-    public static final ItemType COBBLED_DEEPSLATE_SLAB = init();
+    public static final ItemType COBBLED_DEEPSLATE_SLAB = get("minecraft:cobbled_deepslate_slab");
     @Nullable
-    public static final ItemType COBBLED_DEEPSLATE_STAIRS = init();
+    public static final ItemType COBBLED_DEEPSLATE_STAIRS = get("minecraft:cobbled_deepslate_stairs");
     @Nullable
-    public static final ItemType COBBLED_DEEPSLATE_WALL = init();
+    public static final ItemType COBBLED_DEEPSLATE_WALL = get("minecraft:cobbled_deepslate_wall");
     @Nullable
-    public static final ItemType COBBLESTONE = init();
+    public static final ItemType COBBLESTONE = get("minecraft:cobblestone");
     @Nullable
-    public static final ItemType COBBLESTONE_SLAB = init();
+    public static final ItemType COBBLESTONE_SLAB = get("minecraft:cobblestone_slab");
     @Nullable
-    public static final ItemType COBBLESTONE_STAIRS = init();
+    public static final ItemType COBBLESTONE_STAIRS = get("minecraft:cobblestone_stairs");
     @Nullable
-    public static final ItemType COBBLESTONE_WALL = init();
+    public static final ItemType COBBLESTONE_WALL = get("minecraft:cobblestone_wall");
     @Nullable
-    public static final ItemType COBWEB = init();
+    public static final ItemType COBWEB = get("minecraft:cobweb");
     @Nullable
-    public static final ItemType COCOA_BEANS = init();
+    public static final ItemType COCOA_BEANS = get("minecraft:cocoa_beans");
     @Nullable
-    public static final ItemType COD = init();
+    public static final ItemType COD = get("minecraft:cod");
     @Nullable
-    public static final ItemType COD_BUCKET = init();
+    public static final ItemType COD_BUCKET = get("minecraft:cod_bucket");
     @Nullable
-    public static final ItemType COD_SPAWN_EGG = init();
+    public static final ItemType COD_SPAWN_EGG = get("minecraft:cod_spawn_egg");
     @Nullable
-    public static final ItemType COMMAND_BLOCK = init();
+    public static final ItemType COMMAND_BLOCK = get("minecraft:command_block");
     @Nullable
-    public static final ItemType COMMAND_BLOCK_MINECART = init();
+    public static final ItemType COMMAND_BLOCK_MINECART = get("minecraft:command_block_minecart");
     @Nullable
-    public static final ItemType COMPARATOR = init();
+    public static final ItemType COMPARATOR = get("minecraft:comparator");
     @Nullable
-    public static final ItemType COMPASS = init();
+    public static final ItemType COMPASS = get("minecraft:compass");
     @Nullable
-    public static final ItemType COMPOSTER = init();
+    public static final ItemType COMPOSTER = get("minecraft:composter");
     @Nullable
-    public static final ItemType CONDUIT = init();
+    public static final ItemType CONDUIT = get("minecraft:conduit");
     @Nullable
-    public static final ItemType COOKED_BEEF = init();
+    public static final ItemType COOKED_BEEF = get("minecraft:cooked_beef");
     @Nullable
-    public static final ItemType COOKED_CHICKEN = init();
+    public static final ItemType COOKED_CHICKEN = get("minecraft:cooked_chicken");
     @Nullable
-    public static final ItemType COOKED_COD = init();
+    public static final ItemType COOKED_COD = get("minecraft:cooked_cod");
     @Nullable
-    public static final ItemType COOKED_MUTTON = init();
+    public static final ItemType COOKED_MUTTON = get("minecraft:cooked_mutton");
     @Nullable
-    public static final ItemType COOKED_PORKCHOP = init();
+    public static final ItemType COOKED_PORKCHOP = get("minecraft:cooked_porkchop");
     @Nullable
-    public static final ItemType COOKED_RABBIT = init();
+    public static final ItemType COOKED_RABBIT = get("minecraft:cooked_rabbit");
     @Nullable
-    public static final ItemType COOKED_SALMON = init();
+    public static final ItemType COOKED_SALMON = get("minecraft:cooked_salmon");
     @Nullable
-    public static final ItemType COOKIE = init();
+    public static final ItemType COOKIE = get("minecraft:cookie");
     @Nullable
-    public static final ItemType COPPER_AXE = init();
+    public static final ItemType COPPER_AXE = get("minecraft:copper_axe");
     @Nullable
-    public static final ItemType COPPER_BARS = init();
+    public static final ItemType COPPER_BARS = get("minecraft:copper_bars");
     @Nullable
-    public static final ItemType COPPER_BLOCK = init();
+    public static final ItemType COPPER_BLOCK = get("minecraft:copper_block");
     @Nullable
-    public static final ItemType COPPER_BOOTS = init();
+    public static final ItemType COPPER_BOOTS = get("minecraft:copper_boots");
     @Nullable
-    public static final ItemType COPPER_BULB = init();
+    public static final ItemType COPPER_BULB = get("minecraft:copper_bulb");
     @Nullable
-    public static final ItemType COPPER_CHAIN = init();
+    public static final ItemType COPPER_CHAIN = get("minecraft:copper_chain");
     @Nullable
-    public static final ItemType COPPER_CHEST = init();
+    public static final ItemType COPPER_CHEST = get("minecraft:copper_chest");
     @Nullable
-    public static final ItemType COPPER_CHESTPLATE = init();
+    public static final ItemType COPPER_CHESTPLATE = get("minecraft:copper_chestplate");
     @Nullable
-    public static final ItemType COPPER_DOOR = init();
+    public static final ItemType COPPER_DOOR = get("minecraft:copper_door");
     @Nullable
-    public static final ItemType COPPER_GOLEM_SPAWN_EGG = init();
+    public static final ItemType COPPER_GOLEM_SPAWN_EGG = get("minecraft:copper_golem_spawn_egg");
     @Nullable
-    public static final ItemType COPPER_GOLEM_STATUE = init();
+    public static final ItemType COPPER_GOLEM_STATUE = get("minecraft:copper_golem_statue");
     @Nullable
-    public static final ItemType COPPER_GRATE = init();
+    public static final ItemType COPPER_GRATE = get("minecraft:copper_grate");
     @Nullable
-    public static final ItemType COPPER_HELMET = init();
+    public static final ItemType COPPER_HELMET = get("minecraft:copper_helmet");
     @Nullable
-    public static final ItemType COPPER_HOE = init();
+    public static final ItemType COPPER_HOE = get("minecraft:copper_hoe");
     @Nullable
-    public static final ItemType COPPER_HORSE_ARMOR = init();
+    public static final ItemType COPPER_HORSE_ARMOR = get("minecraft:copper_horse_armor");
     @Nullable
-    public static final ItemType COPPER_INGOT = init();
+    public static final ItemType COPPER_INGOT = get("minecraft:copper_ingot");
     @Nullable
-    public static final ItemType COPPER_LANTERN = init();
+    public static final ItemType COPPER_LANTERN = get("minecraft:copper_lantern");
     @Nullable
-    public static final ItemType COPPER_LEGGINGS = init();
+    public static final ItemType COPPER_LEGGINGS = get("minecraft:copper_leggings");
     @Nullable
-    public static final ItemType COPPER_NAUTILUS_ARMOR = init();
+    public static final ItemType COPPER_NAUTILUS_ARMOR = get("minecraft:copper_nautilus_armor");
     @Nullable
-    public static final ItemType COPPER_NUGGET = init();
+    public static final ItemType COPPER_NUGGET = get("minecraft:copper_nugget");
     @Nullable
-    public static final ItemType COPPER_ORE = init();
+    public static final ItemType COPPER_ORE = get("minecraft:copper_ore");
     @Nullable
-    public static final ItemType COPPER_PICKAXE = init();
+    public static final ItemType COPPER_PICKAXE = get("minecraft:copper_pickaxe");
     @Nullable
-    public static final ItemType COPPER_SHOVEL = init();
+    public static final ItemType COPPER_SHOVEL = get("minecraft:copper_shovel");
     @Nullable
-    public static final ItemType COPPER_SPEAR = init();
+    public static final ItemType COPPER_SPEAR = get("minecraft:copper_spear");
     @Nullable
-    public static final ItemType COPPER_SWORD = init();
+    public static final ItemType COPPER_SWORD = get("minecraft:copper_sword");
     @Nullable
-    public static final ItemType COPPER_TORCH = init();
+    public static final ItemType COPPER_TORCH = get("minecraft:copper_torch");
     @Nullable
-    public static final ItemType COPPER_TRAPDOOR = init();
+    public static final ItemType COPPER_TRAPDOOR = get("minecraft:copper_trapdoor");
     @Nullable
-    public static final ItemType CORNFLOWER = init();
+    public static final ItemType CORNFLOWER = get("minecraft:cornflower");
     @Nullable
-    public static final ItemType COW_SPAWN_EGG = init();
+    public static final ItemType COW_SPAWN_EGG = get("minecraft:cow_spawn_egg");
     @Nullable
-    public static final ItemType CRACKED_DEEPSLATE_BRICKS = init();
+    public static final ItemType CRACKED_DEEPSLATE_BRICKS = get("minecraft:cracked_deepslate_bricks");
     @Nullable
-    public static final ItemType CRACKED_DEEPSLATE_TILES = init();
+    public static final ItemType CRACKED_DEEPSLATE_TILES = get("minecraft:cracked_deepslate_tiles");
     @Nullable
-    public static final ItemType CRACKED_NETHER_BRICKS = init();
+    public static final ItemType CRACKED_NETHER_BRICKS = get("minecraft:cracked_nether_bricks");
     @Nullable
-    public static final ItemType CRACKED_POLISHED_BLACKSTONE_BRICKS = init();
+    public static final ItemType CRACKED_POLISHED_BLACKSTONE_BRICKS = get("minecraft:cracked_polished_blackstone_bricks");
     @Nullable
-    public static final ItemType CRACKED_STONE_BRICKS = init();
+    public static final ItemType CRACKED_STONE_BRICKS = get("minecraft:cracked_stone_bricks");
     @Nullable
-    public static final ItemType CRAFTER = init();
+    public static final ItemType CRAFTER = get("minecraft:crafter");
     @Nullable
-    public static final ItemType CRAFTING_TABLE = init();
-    @Nullable public static final ItemType CREAKING_HEART = init();
-    @Nullable public static final ItemType CREAKING_SPAWN_EGG = init();
+    public static final ItemType CRAFTING_TABLE = get("minecraft:crafting_table");
     @Nullable
-    public static final ItemType CREEPER_BANNER_PATTERN = init();
+    public static final ItemType CREAKING_HEART = get("minecraft:creaking_heart");
     @Nullable
-    public static final ItemType CREEPER_HEAD = init();
+    public static final ItemType CREAKING_SPAWN_EGG = get("minecraft:creaking_spawn_egg");
     @Nullable
-    public static final ItemType CREEPER_SPAWN_EGG = init();
+    public static final ItemType CREEPER_BANNER_PATTERN = get("minecraft:creeper_banner_pattern");
     @Nullable
-    public static final ItemType CRIMSON_BUTTON = init();
+    public static final ItemType CREEPER_HEAD = get("minecraft:creeper_head");
     @Nullable
-    public static final ItemType CRIMSON_DOOR = init();
+    public static final ItemType CREEPER_SPAWN_EGG = get("minecraft:creeper_spawn_egg");
     @Nullable
-    public static final ItemType CRIMSON_FENCE = init();
+    public static final ItemType CRIMSON_BUTTON = get("minecraft:crimson_button");
     @Nullable
-    public static final ItemType CRIMSON_FENCE_GATE = init();
+    public static final ItemType CRIMSON_DOOR = get("minecraft:crimson_door");
     @Nullable
-    public static final ItemType CRIMSON_FUNGUS = init();
+    public static final ItemType CRIMSON_FENCE = get("minecraft:crimson_fence");
     @Nullable
-    public static final ItemType CRIMSON_HANGING_SIGN = init();
+    public static final ItemType CRIMSON_FENCE_GATE = get("minecraft:crimson_fence_gate");
     @Nullable
-    public static final ItemType CRIMSON_HYPHAE = init();
+    public static final ItemType CRIMSON_FUNGUS = get("minecraft:crimson_fungus");
     @Nullable
-    public static final ItemType CRIMSON_NYLIUM = init();
+    public static final ItemType CRIMSON_HANGING_SIGN = get("minecraft:crimson_hanging_sign");
     @Nullable
-    public static final ItemType CRIMSON_PLANKS = init();
+    public static final ItemType CRIMSON_HYPHAE = get("minecraft:crimson_hyphae");
     @Nullable
-    public static final ItemType CRIMSON_PRESSURE_PLATE = init();
+    public static final ItemType CRIMSON_NYLIUM = get("minecraft:crimson_nylium");
     @Nullable
-    public static final ItemType CRIMSON_ROOTS = init();
+    public static final ItemType CRIMSON_PLANKS = get("minecraft:crimson_planks");
     @Nullable
-    public static final ItemType CRIMSON_SHELF = init();
+    public static final ItemType CRIMSON_PRESSURE_PLATE = get("minecraft:crimson_pressure_plate");
     @Nullable
-    public static final ItemType CRIMSON_SIGN = init();
+    public static final ItemType CRIMSON_ROOTS = get("minecraft:crimson_roots");
     @Nullable
-    public static final ItemType CRIMSON_SLAB = init();
+    public static final ItemType CRIMSON_SHELF = get("minecraft:crimson_shelf");
     @Nullable
-    public static final ItemType CRIMSON_STAIRS = init();
+    public static final ItemType CRIMSON_SIGN = get("minecraft:crimson_sign");
     @Nullable
-    public static final ItemType CRIMSON_STEM = init();
+    public static final ItemType CRIMSON_SLAB = get("minecraft:crimson_slab");
     @Nullable
-    public static final ItemType CRIMSON_TRAPDOOR = init();
+    public static final ItemType CRIMSON_STAIRS = get("minecraft:crimson_stairs");
     @Nullable
-    public static final ItemType CROSSBOW = init();
+    public static final ItemType CRIMSON_STEM = get("minecraft:crimson_stem");
     @Nullable
-    public static final ItemType CRYING_OBSIDIAN = init();
+    public static final ItemType CRIMSON_TRAPDOOR = get("minecraft:crimson_trapdoor");
     @Nullable
-    public static final ItemType CUT_COPPER = init();
+    public static final ItemType CROSSBOW = get("minecraft:crossbow");
     @Nullable
-    public static final ItemType CUT_COPPER_SLAB = init();
+    public static final ItemType CRYING_OBSIDIAN = get("minecraft:crying_obsidian");
     @Nullable
-    public static final ItemType CUT_COPPER_STAIRS = init();
+    public static final ItemType CUT_COPPER = get("minecraft:cut_copper");
     @Nullable
-    public static final ItemType CUT_RED_SANDSTONE = init();
+    public static final ItemType CUT_COPPER_SLAB = get("minecraft:cut_copper_slab");
     @Nullable
-    public static final ItemType CUT_RED_SANDSTONE_SLAB = init();
+    public static final ItemType CUT_COPPER_STAIRS = get("minecraft:cut_copper_stairs");
     @Nullable
-    public static final ItemType CUT_SANDSTONE = init();
+    public static final ItemType CUT_RED_SANDSTONE = get("minecraft:cut_red_sandstone");
     @Nullable
-    public static final ItemType CUT_SANDSTONE_SLAB = init();
+    public static final ItemType CUT_RED_SANDSTONE_SLAB = get("minecraft:cut_red_sandstone_slab");
     @Nullable
-    public static final ItemType CYAN_BANNER = init();
+    public static final ItemType CUT_SANDSTONE = get("minecraft:cut_sandstone");
     @Nullable
-    public static final ItemType CYAN_BED = init();
-    @Nullable public static final ItemType CYAN_BUNDLE = init();
+    public static final ItemType CUT_SANDSTONE_SLAB = get("minecraft:cut_sandstone_slab");
     @Nullable
-    public static final ItemType CYAN_CANDLE = init();
+    public static final ItemType CYAN_BANNER = get("minecraft:cyan_banner");
     @Nullable
-    public static final ItemType CYAN_CARPET = init();
+    public static final ItemType CYAN_BED = get("minecraft:cyan_bed");
     @Nullable
-    public static final ItemType CYAN_CONCRETE = init();
+    public static final ItemType CYAN_BUNDLE = get("minecraft:cyan_bundle");
     @Nullable
-    public static final ItemType CYAN_CONCRETE_POWDER = init();
+    public static final ItemType CYAN_CANDLE = get("minecraft:cyan_candle");
     @Nullable
-    public static final ItemType CYAN_DYE = init();
+    public static final ItemType CYAN_CARPET = get("minecraft:cyan_carpet");
     @Nullable
-    public static final ItemType CYAN_GLAZED_TERRACOTTA = init();
+    public static final ItemType CYAN_CONCRETE = get("minecraft:cyan_concrete");
     @Nullable
-    public static final ItemType CYAN_SHULKER_BOX = init();
+    public static final ItemType CYAN_CONCRETE_POWDER = get("minecraft:cyan_concrete_powder");
     @Nullable
-    public static final ItemType CYAN_STAINED_GLASS = init();
+    public static final ItemType CYAN_DYE = get("minecraft:cyan_dye");
     @Nullable
-    public static final ItemType CYAN_STAINED_GLASS_PANE = init();
+    public static final ItemType CYAN_GLAZED_TERRACOTTA = get("minecraft:cyan_glazed_terracotta");
     @Nullable
-    public static final ItemType CYAN_TERRACOTTA = init();
+    public static final ItemType CYAN_HARNESS = get("minecraft:cyan_harness");
     @Nullable
-    public static final ItemType CYAN_WOOL = init();
+    public static final ItemType CYAN_SHULKER_BOX = get("minecraft:cyan_shulker_box");
     @Nullable
-    public static final ItemType DAMAGED_ANVIL = init();
+    public static final ItemType CYAN_STAINED_GLASS = get("minecraft:cyan_stained_glass");
     @Nullable
-    public static final ItemType DANDELION = init();
+    public static final ItemType CYAN_STAINED_GLASS_PANE = get("minecraft:cyan_stained_glass_pane");
+    @Nullable
+    public static final ItemType CYAN_TERRACOTTA = get("minecraft:cyan_terracotta");
+    @Nullable
+    public static final ItemType CYAN_WOOL = get("minecraft:cyan_wool");
+    @Nullable
+    public static final ItemType DAMAGED_ANVIL = get("minecraft:damaged_anvil");
+    @Nullable
+    public static final ItemType DANDELION = get("minecraft:dandelion");
     @Deprecated
     @Nullable
-    public static final ItemType DANDELION_YELLOW = init();
+    public static final ItemType DANDELION_YELLOW = get("minecraft:dandelion_yellow");
     @Nullable
-    public static final ItemType DANGER_POTTERY_SHERD = init();
+    public static final ItemType DANGER_POTTERY_SHERD = get("minecraft:danger_pottery_sherd");
     @Nullable
-    public static final ItemType DARK_OAK_BOAT = init();
+    public static final ItemType DARK_OAK_BOAT = get("minecraft:dark_oak_boat");
     @Nullable
-    public static final ItemType DARK_OAK_BUTTON = init();
+    public static final ItemType DARK_OAK_BUTTON = get("minecraft:dark_oak_button");
     @Nullable
-    public static final ItemType DARK_OAK_CHEST_BOAT = init();
+    public static final ItemType DARK_OAK_CHEST_BOAT = get("minecraft:dark_oak_chest_boat");
     @Nullable
-    public static final ItemType DARK_OAK_DOOR = init();
+    public static final ItemType DARK_OAK_DOOR = get("minecraft:dark_oak_door");
     @Nullable
-    public static final ItemType DARK_OAK_FENCE = init();
+    public static final ItemType DARK_OAK_FENCE = get("minecraft:dark_oak_fence");
     @Nullable
-    public static final ItemType DARK_OAK_FENCE_GATE = init();
+    public static final ItemType DARK_OAK_FENCE_GATE = get("minecraft:dark_oak_fence_gate");
     @Nullable
-    public static final ItemType DARK_OAK_HANGING_SIGN = init();
+    public static final ItemType DARK_OAK_HANGING_SIGN = get("minecraft:dark_oak_hanging_sign");
     @Nullable
-    public static final ItemType DARK_OAK_LEAVES = init();
+    public static final ItemType DARK_OAK_LEAVES = get("minecraft:dark_oak_leaves");
     @Nullable
-    public static final ItemType DARK_OAK_LOG = init();
+    public static final ItemType DARK_OAK_LOG = get("minecraft:dark_oak_log");
     @Nullable
-    public static final ItemType DARK_OAK_PLANKS = init();
+    public static final ItemType DARK_OAK_PLANKS = get("minecraft:dark_oak_planks");
     @Nullable
-    public static final ItemType DARK_OAK_PRESSURE_PLATE = init();
+    public static final ItemType DARK_OAK_PRESSURE_PLATE = get("minecraft:dark_oak_pressure_plate");
     @Nullable
-    public static final ItemType DARK_OAK_SAPLING = init();
+    public static final ItemType DARK_OAK_SAPLING = get("minecraft:dark_oak_sapling");
     @Nullable
-    public static final ItemType DARK_OAK_SHELF = init();
+    public static final ItemType DARK_OAK_SHELF = get("minecraft:dark_oak_shelf");
     @Nullable
-    public static final ItemType DARK_OAK_SIGN = init();
+    public static final ItemType DARK_OAK_SIGN = get("minecraft:dark_oak_sign");
     @Nullable
-    public static final ItemType DARK_OAK_SLAB = init();
+    public static final ItemType DARK_OAK_SLAB = get("minecraft:dark_oak_slab");
     @Nullable
-    public static final ItemType DARK_OAK_STAIRS = init();
+    public static final ItemType DARK_OAK_STAIRS = get("minecraft:dark_oak_stairs");
     @Nullable
-    public static final ItemType DARK_OAK_TRAPDOOR = init();
+    public static final ItemType DARK_OAK_TRAPDOOR = get("minecraft:dark_oak_trapdoor");
     @Nullable
-    public static final ItemType DARK_OAK_WOOD = init();
+    public static final ItemType DARK_OAK_WOOD = get("minecraft:dark_oak_wood");
     @Nullable
-    public static final ItemType DARK_PRISMARINE = init();
+    public static final ItemType DARK_PRISMARINE = get("minecraft:dark_prismarine");
     @Nullable
-    public static final ItemType DARK_PRISMARINE_SLAB = init();
+    public static final ItemType DARK_PRISMARINE_SLAB = get("minecraft:dark_prismarine_slab");
     @Nullable
-    public static final ItemType DARK_PRISMARINE_STAIRS = init();
+    public static final ItemType DARK_PRISMARINE_STAIRS = get("minecraft:dark_prismarine_stairs");
     @Nullable
-    public static final ItemType DAYLIGHT_DETECTOR = init();
+    public static final ItemType DAYLIGHT_DETECTOR = get("minecraft:daylight_detector");
     @Nullable
-    public static final ItemType DEAD_BRAIN_CORAL = init();
+    public static final ItemType DEAD_BRAIN_CORAL = get("minecraft:dead_brain_coral");
     @Nullable
-    public static final ItemType DEAD_BRAIN_CORAL_BLOCK = init();
+    public static final ItemType DEAD_BRAIN_CORAL_BLOCK = get("minecraft:dead_brain_coral_block");
     @Nullable
-    public static final ItemType DEAD_BRAIN_CORAL_FAN = init();
+    public static final ItemType DEAD_BRAIN_CORAL_FAN = get("minecraft:dead_brain_coral_fan");
     @Nullable
-    public static final ItemType DEAD_BUBBLE_CORAL = init();
+    public static final ItemType DEAD_BUBBLE_CORAL = get("minecraft:dead_bubble_coral");
     @Nullable
-    public static final ItemType DEAD_BUBBLE_CORAL_BLOCK = init();
+    public static final ItemType DEAD_BUBBLE_CORAL_BLOCK = get("minecraft:dead_bubble_coral_block");
     @Nullable
-    public static final ItemType DEAD_BUBBLE_CORAL_FAN = init();
+    public static final ItemType DEAD_BUBBLE_CORAL_FAN = get("minecraft:dead_bubble_coral_fan");
     @Nullable
-    public static final ItemType DEAD_BUSH = init();
+    public static final ItemType DEAD_BUSH = get("minecraft:dead_bush");
     @Nullable
-    public static final ItemType DEAD_FIRE_CORAL = init();
+    public static final ItemType DEAD_FIRE_CORAL = get("minecraft:dead_fire_coral");
     @Nullable
-    public static final ItemType DEAD_FIRE_CORAL_BLOCK = init();
+    public static final ItemType DEAD_FIRE_CORAL_BLOCK = get("minecraft:dead_fire_coral_block");
     @Nullable
-    public static final ItemType DEAD_FIRE_CORAL_FAN = init();
+    public static final ItemType DEAD_FIRE_CORAL_FAN = get("minecraft:dead_fire_coral_fan");
     @Nullable
-    public static final ItemType DEAD_HORN_CORAL = init();
+    public static final ItemType DEAD_HORN_CORAL = get("minecraft:dead_horn_coral");
     @Nullable
-    public static final ItemType DEAD_HORN_CORAL_BLOCK = init();
+    public static final ItemType DEAD_HORN_CORAL_BLOCK = get("minecraft:dead_horn_coral_block");
     @Nullable
-    public static final ItemType DEAD_HORN_CORAL_FAN = init();
+    public static final ItemType DEAD_HORN_CORAL_FAN = get("minecraft:dead_horn_coral_fan");
     @Nullable
-    public static final ItemType DEAD_TUBE_CORAL = init();
+    public static final ItemType DEAD_TUBE_CORAL = get("minecraft:dead_tube_coral");
     @Nullable
-    public static final ItemType DEAD_TUBE_CORAL_BLOCK = init();
+    public static final ItemType DEAD_TUBE_CORAL_BLOCK = get("minecraft:dead_tube_coral_block");
     @Nullable
-    public static final ItemType DEAD_TUBE_CORAL_FAN = init();
+    public static final ItemType DEAD_TUBE_CORAL_FAN = get("minecraft:dead_tube_coral_fan");
     @Nullable
-    public static final ItemType DEBUG_STICK = init();
+    public static final ItemType DEBUG_STICK = get("minecraft:debug_stick");
     @Nullable
-    public static final ItemType DECORATED_POT = init();
+    public static final ItemType DECORATED_POT = get("minecraft:decorated_pot");
     @Nullable
-    public static final ItemType DEEPSLATE = init();
+    public static final ItemType DEEPSLATE = get("minecraft:deepslate");
     @Nullable
-    public static final ItemType DEEPSLATE_BRICK_SLAB = init();
+    public static final ItemType DEEPSLATE_BRICK_SLAB = get("minecraft:deepslate_brick_slab");
     @Nullable
-    public static final ItemType DEEPSLATE_BRICK_STAIRS = init();
+    public static final ItemType DEEPSLATE_BRICK_STAIRS = get("minecraft:deepslate_brick_stairs");
     @Nullable
-    public static final ItemType DEEPSLATE_BRICK_WALL = init();
+    public static final ItemType DEEPSLATE_BRICK_WALL = get("minecraft:deepslate_brick_wall");
     @Nullable
-    public static final ItemType DEEPSLATE_BRICKS = init();
+    public static final ItemType DEEPSLATE_BRICKS = get("minecraft:deepslate_bricks");
     @Nullable
-    public static final ItemType DEEPSLATE_COAL_ORE = init();
+    public static final ItemType DEEPSLATE_COAL_ORE = get("minecraft:deepslate_coal_ore");
     @Nullable
-    public static final ItemType DEEPSLATE_COPPER_ORE = init();
+    public static final ItemType DEEPSLATE_COPPER_ORE = get("minecraft:deepslate_copper_ore");
     @Nullable
-    public static final ItemType DEEPSLATE_DIAMOND_ORE = init();
+    public static final ItemType DEEPSLATE_DIAMOND_ORE = get("minecraft:deepslate_diamond_ore");
     @Nullable
-    public static final ItemType DEEPSLATE_EMERALD_ORE = init();
+    public static final ItemType DEEPSLATE_EMERALD_ORE = get("minecraft:deepslate_emerald_ore");
     @Nullable
-    public static final ItemType DEEPSLATE_GOLD_ORE = init();
+    public static final ItemType DEEPSLATE_GOLD_ORE = get("minecraft:deepslate_gold_ore");
     @Nullable
-    public static final ItemType DEEPSLATE_IRON_ORE = init();
+    public static final ItemType DEEPSLATE_IRON_ORE = get("minecraft:deepslate_iron_ore");
     @Nullable
-    public static final ItemType DEEPSLATE_LAPIS_ORE = init();
+    public static final ItemType DEEPSLATE_LAPIS_ORE = get("minecraft:deepslate_lapis_ore");
     @Nullable
-    public static final ItemType DEEPSLATE_REDSTONE_ORE = init();
+    public static final ItemType DEEPSLATE_REDSTONE_ORE = get("minecraft:deepslate_redstone_ore");
     @Nullable
-    public static final ItemType DEEPSLATE_TILE_SLAB = init();
+    public static final ItemType DEEPSLATE_TILE_SLAB = get("minecraft:deepslate_tile_slab");
     @Nullable
-    public static final ItemType DEEPSLATE_TILE_STAIRS = init();
+    public static final ItemType DEEPSLATE_TILE_STAIRS = get("minecraft:deepslate_tile_stairs");
     @Nullable
-    public static final ItemType DEEPSLATE_TILE_WALL = init();
+    public static final ItemType DEEPSLATE_TILE_WALL = get("minecraft:deepslate_tile_wall");
     @Nullable
-    public static final ItemType DEEPSLATE_TILES = init();
+    public static final ItemType DEEPSLATE_TILES = get("minecraft:deepslate_tiles");
     @Nullable
-    public static final ItemType DETECTOR_RAIL = init();
+    public static final ItemType DETECTOR_RAIL = get("minecraft:detector_rail");
     @Nullable
-    public static final ItemType DIAMOND = init();
+    public static final ItemType DIAMOND = get("minecraft:diamond");
     @Nullable
-    public static final ItemType DIAMOND_AXE = init();
+    public static final ItemType DIAMOND_AXE = get("minecraft:diamond_axe");
     @Nullable
-    public static final ItemType DIAMOND_BLOCK = init();
+    public static final ItemType DIAMOND_BLOCK = get("minecraft:diamond_block");
     @Nullable
-    public static final ItemType DIAMOND_BOOTS = init();
+    public static final ItemType DIAMOND_BOOTS = get("minecraft:diamond_boots");
     @Nullable
-    public static final ItemType DIAMOND_CHESTPLATE = init();
+    public static final ItemType DIAMOND_CHESTPLATE = get("minecraft:diamond_chestplate");
     @Nullable
-    public static final ItemType DIAMOND_HELMET = init();
+    public static final ItemType DIAMOND_HELMET = get("minecraft:diamond_helmet");
     @Nullable
-    public static final ItemType DIAMOND_HOE = init();
+    public static final ItemType DIAMOND_HOE = get("minecraft:diamond_hoe");
     @Nullable
-    public static final ItemType DIAMOND_HORSE_ARMOR = init();
+    public static final ItemType DIAMOND_HORSE_ARMOR = get("minecraft:diamond_horse_armor");
     @Nullable
-    public static final ItemType DIAMOND_LEGGINGS = init();
+    public static final ItemType DIAMOND_LEGGINGS = get("minecraft:diamond_leggings");
     @Nullable
-    public static final ItemType DIAMOND_NAUTILUS_ARMOR = init();
+    public static final ItemType DIAMOND_NAUTILUS_ARMOR = get("minecraft:diamond_nautilus_armor");
     @Nullable
-    public static final ItemType DIAMOND_ORE = init();
+    public static final ItemType DIAMOND_ORE = get("minecraft:diamond_ore");
     @Nullable
-    public static final ItemType DIAMOND_PICKAXE = init();
+    public static final ItemType DIAMOND_PICKAXE = get("minecraft:diamond_pickaxe");
     @Nullable
-    public static final ItemType DIAMOND_SHOVEL = init();
+    public static final ItemType DIAMOND_SHOVEL = get("minecraft:diamond_shovel");
     @Nullable
-    public static final ItemType DIAMOND_SPEAR = init();
+    public static final ItemType DIAMOND_SPEAR = get("minecraft:diamond_spear");
     @Nullable
-    public static final ItemType DIAMOND_SWORD = init();
+    public static final ItemType DIAMOND_SWORD = get("minecraft:diamond_sword");
     @Nullable
-    public static final ItemType DIORITE = init();
+    public static final ItemType DIORITE = get("minecraft:diorite");
     @Nullable
-    public static final ItemType DIORITE_SLAB = init();
+    public static final ItemType DIORITE_SLAB = get("minecraft:diorite_slab");
     @Nullable
-    public static final ItemType DIORITE_STAIRS = init();
+    public static final ItemType DIORITE_STAIRS = get("minecraft:diorite_stairs");
     @Nullable
-    public static final ItemType DIORITE_WALL = init();
+    public static final ItemType DIORITE_WALL = get("minecraft:diorite_wall");
     @Nullable
-    public static final ItemType DIRT = init();
+    public static final ItemType DIRT = get("minecraft:dirt");
     @Nullable
-    public static final ItemType DIRT_PATH = init();
+    public static final ItemType DIRT_PATH = get("minecraft:dirt_path");
     @Nullable
-    public static final ItemType DISC_FRAGMENT_5 = init();
+    public static final ItemType DISC_FRAGMENT_5 = get("minecraft:disc_fragment_5");
     @Nullable
-    public static final ItemType DISPENSER = init();
+    public static final ItemType DISPENSER = get("minecraft:dispenser");
     @Nullable
-    public static final ItemType DOLPHIN_SPAWN_EGG = init();
+    public static final ItemType DOLPHIN_SPAWN_EGG = get("minecraft:dolphin_spawn_egg");
     @Nullable
-    public static final ItemType DONKEY_SPAWN_EGG = init();
+    public static final ItemType DONKEY_SPAWN_EGG = get("minecraft:donkey_spawn_egg");
     @Nullable
-    public static final ItemType DRAGON_BREATH = init();
+    public static final ItemType DRAGON_BREATH = get("minecraft:dragon_breath");
     @Nullable
-    public static final ItemType DRAGON_EGG = init();
+    public static final ItemType DRAGON_EGG = get("minecraft:dragon_egg");
     @Nullable
-    public static final ItemType DRAGON_HEAD = init();
+    public static final ItemType DRAGON_HEAD = get("minecraft:dragon_head");
     @Nullable
-    public static final ItemType DRIED_KELP = init();
+    public static final ItemType DRIED_GHAST = get("minecraft:dried_ghast");
     @Nullable
-    public static final ItemType DRIED_KELP_BLOCK = init();
+    public static final ItemType DRIED_KELP = get("minecraft:dried_kelp");
     @Nullable
-    public static final ItemType DRIPSTONE_BLOCK = init();
+    public static final ItemType DRIED_KELP_BLOCK = get("minecraft:dried_kelp_block");
     @Nullable
-    public static final ItemType DROPPER = init();
+    public static final ItemType DRIPSTONE_BLOCK = get("minecraft:dripstone_block");
     @Nullable
-    public static final ItemType DROWNED_SPAWN_EGG = init();
+    public static final ItemType DROPPER = get("minecraft:dropper");
     @Nullable
-    public static final ItemType DUNE_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType DROWNED_SPAWN_EGG = get("minecraft:drowned_spawn_egg");
     @Nullable
-    public static final ItemType ECHO_SHARD = init();
+    public static final ItemType DUNE_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:dune_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType EGG = init();
+    public static final ItemType ECHO_SHARD = get("minecraft:echo_shard");
     @Nullable
-    public static final ItemType ELDER_GUARDIAN_SPAWN_EGG = init();
+    public static final ItemType EGG = get("minecraft:egg");
     @Nullable
-    public static final ItemType ELYTRA = init();
+    public static final ItemType ELDER_GUARDIAN_SPAWN_EGG = get("minecraft:elder_guardian_spawn_egg");
     @Nullable
-    public static final ItemType EMERALD = init();
+    public static final ItemType ELYTRA = get("minecraft:elytra");
     @Nullable
-    public static final ItemType EMERALD_BLOCK = init();
+    public static final ItemType EMERALD = get("minecraft:emerald");
     @Nullable
-    public static final ItemType EMERALD_ORE = init();
+    public static final ItemType EMERALD_BLOCK = get("minecraft:emerald_block");
     @Nullable
-    public static final ItemType ENCHANTED_BOOK = init();
+    public static final ItemType EMERALD_ORE = get("minecraft:emerald_ore");
     @Nullable
-    public static final ItemType ENCHANTED_GOLDEN_APPLE = init();
+    public static final ItemType ENCHANTED_BOOK = get("minecraft:enchanted_book");
     @Nullable
-    public static final ItemType ENCHANTING_TABLE = init();
+    public static final ItemType ENCHANTED_GOLDEN_APPLE = get("minecraft:enchanted_golden_apple");
     @Nullable
-    public static final ItemType END_CRYSTAL = init();
+    public static final ItemType ENCHANTING_TABLE = get("minecraft:enchanting_table");
     @Nullable
-    public static final ItemType END_PORTAL_FRAME = init();
+    public static final ItemType END_CRYSTAL = get("minecraft:end_crystal");
     @Nullable
-    public static final ItemType END_ROD = init();
+    public static final ItemType END_PORTAL_FRAME = get("minecraft:end_portal_frame");
     @Nullable
-    public static final ItemType END_STONE = init();
+    public static final ItemType END_ROD = get("minecraft:end_rod");
     @Nullable
-    public static final ItemType END_STONE_BRICK_SLAB = init();
+    public static final ItemType END_STONE = get("minecraft:end_stone");
     @Nullable
-    public static final ItemType END_STONE_BRICK_STAIRS = init();
+    public static final ItemType END_STONE_BRICK_SLAB = get("minecraft:end_stone_brick_slab");
     @Nullable
-    public static final ItemType END_STONE_BRICK_WALL = init();
+    public static final ItemType END_STONE_BRICK_STAIRS = get("minecraft:end_stone_brick_stairs");
     @Nullable
-    public static final ItemType END_STONE_BRICKS = init();
+    public static final ItemType END_STONE_BRICK_WALL = get("minecraft:end_stone_brick_wall");
     @Nullable
-    public static final ItemType ENDER_CHEST = init();
+    public static final ItemType END_STONE_BRICKS = get("minecraft:end_stone_bricks");
     @Nullable
-    public static final ItemType ENDER_DRAGON_SPAWN_EGG = init();
+    public static final ItemType ENDER_CHEST = get("minecraft:ender_chest");
     @Nullable
-    public static final ItemType ENDER_EYE = init();
+    public static final ItemType ENDER_DRAGON_SPAWN_EGG = get("minecraft:ender_dragon_spawn_egg");
     @Nullable
-    public static final ItemType ENDER_PEARL = init();
+    public static final ItemType ENDER_EYE = get("minecraft:ender_eye");
     @Nullable
-    public static final ItemType ENDERMAN_SPAWN_EGG = init();
+    public static final ItemType ENDER_PEARL = get("minecraft:ender_pearl");
     @Nullable
-    public static final ItemType ENDERMITE_SPAWN_EGG = init();
+    public static final ItemType ENDERMAN_SPAWN_EGG = get("minecraft:enderman_spawn_egg");
     @Nullable
-    public static final ItemType EVOKER_SPAWN_EGG = init();
+    public static final ItemType ENDERMITE_SPAWN_EGG = get("minecraft:endermite_spawn_egg");
     @Nullable
-    public static final ItemType EXPERIENCE_BOTTLE = init();
+    public static final ItemType EVOKER_SPAWN_EGG = get("minecraft:evoker_spawn_egg");
     @Nullable
-    public static final ItemType EXPLORER_POTTERY_SHERD = init();
+    public static final ItemType EXPERIENCE_BOTTLE = get("minecraft:experience_bottle");
     @Nullable
-    public static final ItemType EXPOSED_CHISELED_COPPER = init();
+    public static final ItemType EXPLORER_POTTERY_SHERD = get("minecraft:explorer_pottery_sherd");
     @Nullable
-    public static final ItemType EXPOSED_COPPER = init();
+    public static final ItemType EXPOSED_CHISELED_COPPER = get("minecraft:exposed_chiseled_copper");
     @Nullable
-    public static final ItemType EXPOSED_COPPER_BARS = init();
+    public static final ItemType EXPOSED_COPPER = get("minecraft:exposed_copper");
     @Nullable
-    public static final ItemType EXPOSED_COPPER_BULB = init();
+    public static final ItemType EXPOSED_COPPER_BARS = get("minecraft:exposed_copper_bars");
     @Nullable
-    public static final ItemType EXPOSED_COPPER_CHAIN = init();
+    public static final ItemType EXPOSED_COPPER_BULB = get("minecraft:exposed_copper_bulb");
     @Nullable
-    public static final ItemType EXPOSED_COPPER_CHEST = init();
+    public static final ItemType EXPOSED_COPPER_CHAIN = get("minecraft:exposed_copper_chain");
     @Nullable
-    public static final ItemType EXPOSED_COPPER_DOOR = init();
+    public static final ItemType EXPOSED_COPPER_CHEST = get("minecraft:exposed_copper_chest");
     @Nullable
-    public static final ItemType EXPOSED_COPPER_GOLEM_STATUE = init();
+    public static final ItemType EXPOSED_COPPER_DOOR = get("minecraft:exposed_copper_door");
     @Nullable
-    public static final ItemType EXPOSED_COPPER_GRATE = init();
+    public static final ItemType EXPOSED_COPPER_GOLEM_STATUE = get("minecraft:exposed_copper_golem_statue");
     @Nullable
-    public static final ItemType EXPOSED_COPPER_LANTERN = init();
+    public static final ItemType EXPOSED_COPPER_GRATE = get("minecraft:exposed_copper_grate");
     @Nullable
-    public static final ItemType EXPOSED_COPPER_TRAPDOOR = init();
+    public static final ItemType EXPOSED_COPPER_LANTERN = get("minecraft:exposed_copper_lantern");
     @Nullable
-    public static final ItemType EXPOSED_CUT_COPPER = init();
+    public static final ItemType EXPOSED_COPPER_TRAPDOOR = get("minecraft:exposed_copper_trapdoor");
     @Nullable
-    public static final ItemType EXPOSED_CUT_COPPER_SLAB = init();
+    public static final ItemType EXPOSED_CUT_COPPER = get("minecraft:exposed_cut_copper");
     @Nullable
-    public static final ItemType EXPOSED_CUT_COPPER_STAIRS = init();
+    public static final ItemType EXPOSED_CUT_COPPER_SLAB = get("minecraft:exposed_cut_copper_slab");
     @Nullable
-    public static final ItemType EXPOSED_LIGHTNING_ROD = init();
+    public static final ItemType EXPOSED_CUT_COPPER_STAIRS = get("minecraft:exposed_cut_copper_stairs");
     @Nullable
-    public static final ItemType EYE_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType EXPOSED_LIGHTNING_ROD = get("minecraft:exposed_lightning_rod");
     @Nullable
-    public static final ItemType FARMLAND = init();
+    public static final ItemType EYE_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:eye_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType FEATHER = init();
+    public static final ItemType FARMLAND = get("minecraft:farmland");
     @Nullable
-    public static final ItemType FERMENTED_SPIDER_EYE = init();
+    public static final ItemType FEATHER = get("minecraft:feather");
     @Nullable
-    public static final ItemType FERN = init();
-    @Nullable public static final ItemType FIELD_MASONED_BANNER_PATTERN = init();
+    public static final ItemType FERMENTED_SPIDER_EYE = get("minecraft:fermented_spider_eye");
     @Nullable
-    public static final ItemType FILLED_MAP = init();
+    public static final ItemType FERN = get("minecraft:fern");
     @Nullable
-    public static final ItemType FIRE_CHARGE = init();
+    public static final ItemType FIELD_MASONED_BANNER_PATTERN = get("minecraft:field_masoned_banner_pattern");
     @Nullable
-    public static final ItemType FIRE_CORAL = init();
+    public static final ItemType FILLED_MAP = get("minecraft:filled_map");
     @Nullable
-    public static final ItemType FIRE_CORAL_BLOCK = init();
+    public static final ItemType FIRE_CHARGE = get("minecraft:fire_charge");
     @Nullable
-    public static final ItemType FIRE_CORAL_FAN = init();
+    public static final ItemType FIRE_CORAL = get("minecraft:fire_coral");
     @Nullable
-    public static final ItemType FIREFLY_BUSH = init();
+    public static final ItemType FIRE_CORAL_BLOCK = get("minecraft:fire_coral_block");
     @Nullable
-    public static final ItemType FIREWORK_ROCKET = init();
+    public static final ItemType FIRE_CORAL_FAN = get("minecraft:fire_coral_fan");
     @Nullable
-    public static final ItemType FIREWORK_STAR = init();
+    public static final ItemType FIREFLY_BUSH = get("minecraft:firefly_bush");
     @Nullable
-    public static final ItemType FISHING_ROD = init();
+    public static final ItemType FIREWORK_ROCKET = get("minecraft:firework_rocket");
     @Nullable
-    public static final ItemType FLETCHING_TABLE = init();
+    public static final ItemType FIREWORK_STAR = get("minecraft:firework_star");
     @Nullable
-    public static final ItemType FLINT = init();
+    public static final ItemType FISHING_ROD = get("minecraft:fishing_rod");
     @Nullable
-    public static final ItemType FLINT_AND_STEEL = init();
+    public static final ItemType FLETCHING_TABLE = get("minecraft:fletching_table");
     @Nullable
-    public static final ItemType FLOW_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType FLINT = get("minecraft:flint");
     @Nullable
-    public static final ItemType FLOW_BANNER_PATTERN = init();
+    public static final ItemType FLINT_AND_STEEL = get("minecraft:flint_and_steel");
     @Nullable
-    public static final ItemType FLOW_POTTERY_SHERD = init();
+    public static final ItemType FLOW_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:flow_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType FLOWER_BANNER_PATTERN = init();
+    public static final ItemType FLOW_BANNER_PATTERN = get("minecraft:flow_banner_pattern");
     @Nullable
-    public static final ItemType FLOWER_POT = init();
+    public static final ItemType FLOW_POTTERY_SHERD = get("minecraft:flow_pottery_sherd");
     @Nullable
-    public static final ItemType FLOWERING_AZALEA = init();
+    public static final ItemType FLOWER_BANNER_PATTERN = get("minecraft:flower_banner_pattern");
     @Nullable
-    public static final ItemType FLOWERING_AZALEA_LEAVES = init();
+    public static final ItemType FLOWER_POT = get("minecraft:flower_pot");
     @Nullable
-    public static final ItemType FOX_SPAWN_EGG = init();
+    public static final ItemType FLOWERING_AZALEA = get("minecraft:flowering_azalea");
     @Nullable
-    public static final ItemType FRIEND_POTTERY_SHERD = init();
+    public static final ItemType FLOWERING_AZALEA_LEAVES = get("minecraft:flowering_azalea_leaves");
     @Nullable
-    public static final ItemType FROG_SPAWN_EGG = init();
+    public static final ItemType FOX_SPAWN_EGG = get("minecraft:fox_spawn_egg");
     @Nullable
-    public static final ItemType FROGSPAWN = init();
+    public static final ItemType FRIEND_POTTERY_SHERD = get("minecraft:friend_pottery_sherd");
     @Nullable
-    public static final ItemType FURNACE = init();
+    public static final ItemType FROG_SPAWN_EGG = get("minecraft:frog_spawn_egg");
     @Nullable
-    public static final ItemType FURNACE_MINECART = init();
+    public static final ItemType FROGSPAWN = get("minecraft:frogspawn");
     @Nullable
-    public static final ItemType GHAST_SPAWN_EGG = init();
+    public static final ItemType FURNACE = get("minecraft:furnace");
     @Nullable
-    public static final ItemType GHAST_TEAR = init();
+    public static final ItemType FURNACE_MINECART = get("minecraft:furnace_minecart");
     @Nullable
-    public static final ItemType GILDED_BLACKSTONE = init();
+    public static final ItemType GHAST_SPAWN_EGG = get("minecraft:ghast_spawn_egg");
     @Nullable
-    public static final ItemType GLASS = init();
+    public static final ItemType GHAST_TEAR = get("minecraft:ghast_tear");
     @Nullable
-    public static final ItemType GLASS_BOTTLE = init();
+    public static final ItemType GILDED_BLACKSTONE = get("minecraft:gilded_blackstone");
     @Nullable
-    public static final ItemType GLASS_PANE = init();
+    public static final ItemType GLASS = get("minecraft:glass");
     @Nullable
-    public static final ItemType GLISTERING_MELON_SLICE = init();
+    public static final ItemType GLASS_BOTTLE = get("minecraft:glass_bottle");
     @Nullable
-    public static final ItemType GLOBE_BANNER_PATTERN = init();
+    public static final ItemType GLASS_PANE = get("minecraft:glass_pane");
     @Nullable
-    public static final ItemType GLOW_BERRIES = init();
+    public static final ItemType GLISTERING_MELON_SLICE = get("minecraft:glistering_melon_slice");
     @Nullable
-    public static final ItemType GLOW_INK_SAC = init();
+    public static final ItemType GLOBE_BANNER_PATTERN = get("minecraft:globe_banner_pattern");
     @Nullable
-    public static final ItemType GLOW_ITEM_FRAME = init();
+    public static final ItemType GLOW_BERRIES = get("minecraft:glow_berries");
     @Nullable
-    public static final ItemType GLOW_LICHEN = init();
+    public static final ItemType GLOW_INK_SAC = get("minecraft:glow_ink_sac");
     @Nullable
-    public static final ItemType GLOW_SQUID_SPAWN_EGG = init();
+    public static final ItemType GLOW_ITEM_FRAME = get("minecraft:glow_item_frame");
     @Nullable
-    public static final ItemType GLOWSTONE = init();
+    public static final ItemType GLOW_LICHEN = get("minecraft:glow_lichen");
     @Nullable
-    public static final ItemType GLOWSTONE_DUST = init();
+    public static final ItemType GLOW_SQUID_SPAWN_EGG = get("minecraft:glow_squid_spawn_egg");
     @Nullable
-    public static final ItemType GOAT_HORN = init();
+    public static final ItemType GLOWSTONE = get("minecraft:glowstone");
     @Nullable
-    public static final ItemType GOAT_SPAWN_EGG = init();
+    public static final ItemType GLOWSTONE_DUST = get("minecraft:glowstone_dust");
     @Nullable
-    public static final ItemType GOLD_BLOCK = init();
+    public static final ItemType GOAT_HORN = get("minecraft:goat_horn");
     @Nullable
-    public static final ItemType GOLD_INGOT = init();
+    public static final ItemType GOAT_SPAWN_EGG = get("minecraft:goat_spawn_egg");
     @Nullable
-    public static final ItemType GOLD_NUGGET = init();
+    public static final ItemType GOLD_BLOCK = get("minecraft:gold_block");
     @Nullable
-    public static final ItemType GOLD_ORE = init();
+    public static final ItemType GOLD_INGOT = get("minecraft:gold_ingot");
     @Nullable
-    public static final ItemType GOLDEN_APPLE = init();
+    public static final ItemType GOLD_NUGGET = get("minecraft:gold_nugget");
     @Nullable
-    public static final ItemType GOLDEN_AXE = init();
+    public static final ItemType GOLD_ORE = get("minecraft:gold_ore");
     @Nullable
-    public static final ItemType GOLDEN_BOOTS = init();
+    public static final ItemType GOLDEN_APPLE = get("minecraft:golden_apple");
     @Nullable
-    public static final ItemType GOLDEN_CARROT = init();
+    public static final ItemType GOLDEN_AXE = get("minecraft:golden_axe");
     @Nullable
-    public static final ItemType GOLDEN_CHESTPLATE = init();
+    public static final ItemType GOLDEN_BOOTS = get("minecraft:golden_boots");
     @Nullable
-    public static final ItemType GOLDEN_DANDELION = init();
+    public static final ItemType GOLDEN_CARROT = get("minecraft:golden_carrot");
     @Nullable
-    public static final ItemType GOLDEN_HELMET = init();
+    public static final ItemType GOLDEN_CHESTPLATE = get("minecraft:golden_chestplate");
     @Nullable
-    public static final ItemType GOLDEN_HOE = init();
+    public static final ItemType GOLDEN_DANDELION = get("minecraft:golden_dandelion");
     @Nullable
-    public static final ItemType GOLDEN_HORSE_ARMOR = init();
+    public static final ItemType GOLDEN_HELMET = get("minecraft:golden_helmet");
     @Nullable
-    public static final ItemType GOLDEN_LEGGINGS = init();
+    public static final ItemType GOLDEN_HOE = get("minecraft:golden_hoe");
     @Nullable
-    public static final ItemType GOLDEN_NAUTILUS_ARMOR = init();
+    public static final ItemType GOLDEN_HORSE_ARMOR = get("minecraft:golden_horse_armor");
     @Nullable
-    public static final ItemType GOLDEN_PICKAXE = init();
+    public static final ItemType GOLDEN_LEGGINGS = get("minecraft:golden_leggings");
     @Nullable
-    public static final ItemType GOLDEN_SHOVEL = init();
+    public static final ItemType GOLDEN_NAUTILUS_ARMOR = get("minecraft:golden_nautilus_armor");
     @Nullable
-    public static final ItemType GOLDEN_SPEAR = init();
+    public static final ItemType GOLDEN_PICKAXE = get("minecraft:golden_pickaxe");
     @Nullable
-    public static final ItemType GOLDEN_SWORD = init();
+    public static final ItemType GOLDEN_SHOVEL = get("minecraft:golden_shovel");
     @Nullable
-    public static final ItemType GRANITE = init();
+    public static final ItemType GOLDEN_SPEAR = get("minecraft:golden_spear");
     @Nullable
-    public static final ItemType GRANITE_SLAB = init();
+    public static final ItemType GOLDEN_SWORD = get("minecraft:golden_sword");
     @Nullable
-    public static final ItemType GRANITE_STAIRS = init();
+    public static final ItemType GRANITE = get("minecraft:granite");
     @Nullable
-    public static final ItemType GRANITE_WALL = init();
+    public static final ItemType GRANITE_SLAB = get("minecraft:granite_slab");
+    @Nullable
+    public static final ItemType GRANITE_STAIRS = get("minecraft:granite_stairs");
+    @Nullable
+    public static final ItemType GRANITE_WALL = get("minecraft:granite_wall");
     @Nullable @Deprecated
-    public static final ItemType GRASS = init();
+    public static final ItemType GRASS = get("minecraft:grass");
     @Nullable
-    public static final ItemType GRASS_BLOCK = init();
+    public static final ItemType GRASS_BLOCK = get("minecraft:grass_block");
     @Deprecated
     @Nullable
-    public static final ItemType GRASS_PATH = init();
+    public static final ItemType GRASS_PATH = get("minecraft:grass_path");
     @Nullable
-    public static final ItemType GRAVEL = init();
+    public static final ItemType GRAVEL = get("minecraft:gravel");
     @Nullable
-    public static final ItemType GRAY_BANNER = init();
+    public static final ItemType GRAY_BANNER = get("minecraft:gray_banner");
     @Nullable
-    public static final ItemType GRAY_BED = init();
-    @Nullable public static final ItemType GRAY_BUNDLE = init();
+    public static final ItemType GRAY_BED = get("minecraft:gray_bed");
     @Nullable
-    public static final ItemType GRAY_CANDLE = init();
+    public static final ItemType GRAY_BUNDLE = get("minecraft:gray_bundle");
     @Nullable
-    public static final ItemType GRAY_CARPET = init();
+    public static final ItemType GRAY_CANDLE = get("minecraft:gray_candle");
     @Nullable
-    public static final ItemType GRAY_CONCRETE = init();
+    public static final ItemType GRAY_CARPET = get("minecraft:gray_carpet");
     @Nullable
-    public static final ItemType GRAY_CONCRETE_POWDER = init();
+    public static final ItemType GRAY_CONCRETE = get("minecraft:gray_concrete");
     @Nullable
-    public static final ItemType GRAY_DYE = init();
+    public static final ItemType GRAY_CONCRETE_POWDER = get("minecraft:gray_concrete_powder");
     @Nullable
-    public static final ItemType GRAY_GLAZED_TERRACOTTA = init();
+    public static final ItemType GRAY_DYE = get("minecraft:gray_dye");
     @Nullable
-    public static final ItemType GRAY_SHULKER_BOX = init();
+    public static final ItemType GRAY_GLAZED_TERRACOTTA = get("minecraft:gray_glazed_terracotta");
     @Nullable
-    public static final ItemType GRAY_STAINED_GLASS = init();
+    public static final ItemType GRAY_HARNESS = get("minecraft:gray_harness");
     @Nullable
-    public static final ItemType GRAY_STAINED_GLASS_PANE = init();
+    public static final ItemType GRAY_SHULKER_BOX = get("minecraft:gray_shulker_box");
     @Nullable
-    public static final ItemType GRAY_TERRACOTTA = init();
+    public static final ItemType GRAY_STAINED_GLASS = get("minecraft:gray_stained_glass");
     @Nullable
-    public static final ItemType GRAY_WOOL = init();
+    public static final ItemType GRAY_STAINED_GLASS_PANE = get("minecraft:gray_stained_glass_pane");
     @Nullable
-    public static final ItemType GREEN_BANNER = init();
+    public static final ItemType GRAY_TERRACOTTA = get("minecraft:gray_terracotta");
     @Nullable
-    public static final ItemType GREEN_BED = init();
-    @Nullable public static final ItemType GREEN_BUNDLE = init();
+    public static final ItemType GRAY_WOOL = get("minecraft:gray_wool");
     @Nullable
-    public static final ItemType GREEN_CANDLE = init();
+    public static final ItemType GREEN_BANNER = get("minecraft:green_banner");
     @Nullable
-    public static final ItemType GREEN_CARPET = init();
+    public static final ItemType GREEN_BED = get("minecraft:green_bed");
     @Nullable
-    public static final ItemType GREEN_CONCRETE = init();
+    public static final ItemType GREEN_BUNDLE = get("minecraft:green_bundle");
     @Nullable
-    public static final ItemType GREEN_CONCRETE_POWDER = init();
+    public static final ItemType GREEN_CANDLE = get("minecraft:green_candle");
     @Nullable
-    public static final ItemType GREEN_DYE = init();
+    public static final ItemType GREEN_CARPET = get("minecraft:green_carpet");
     @Nullable
-    public static final ItemType GREEN_GLAZED_TERRACOTTA = init();
+    public static final ItemType GREEN_CONCRETE = get("minecraft:green_concrete");
     @Nullable
-    public static final ItemType GREEN_SHULKER_BOX = init();
+    public static final ItemType GREEN_CONCRETE_POWDER = get("minecraft:green_concrete_powder");
     @Nullable
-    public static final ItemType GREEN_STAINED_GLASS = init();
+    public static final ItemType GREEN_DYE = get("minecraft:green_dye");
     @Nullable
-    public static final ItemType GREEN_STAINED_GLASS_PANE = init();
+    public static final ItemType GREEN_GLAZED_TERRACOTTA = get("minecraft:green_glazed_terracotta");
     @Nullable
-    public static final ItemType GREEN_TERRACOTTA = init();
+    public static final ItemType GREEN_HARNESS = get("minecraft:green_harness");
     @Nullable
-    public static final ItemType GREEN_WOOL = init();
+    public static final ItemType GREEN_SHULKER_BOX = get("minecraft:green_shulker_box");
     @Nullable
-    public static final ItemType GRINDSTONE = init();
+    public static final ItemType GREEN_STAINED_GLASS = get("minecraft:green_stained_glass");
     @Nullable
-    public static final ItemType GUARDIAN_SPAWN_EGG = init();
+    public static final ItemType GREEN_STAINED_GLASS_PANE = get("minecraft:green_stained_glass_pane");
     @Nullable
-    public static final ItemType GUNPOWDER = init();
+    public static final ItemType GREEN_TERRACOTTA = get("minecraft:green_terracotta");
     @Nullable
-    public static final ItemType GUSTER_BANNER_PATTERN = init();
+    public static final ItemType GREEN_WOOL = get("minecraft:green_wool");
     @Nullable
-    public static final ItemType GUSTER_POTTERY_SHERD = init();
+    public static final ItemType GRINDSTONE = get("minecraft:grindstone");
     @Nullable
-    public static final ItemType HANGING_ROOTS = init();
+    public static final ItemType GUARDIAN_SPAWN_EGG = get("minecraft:guardian_spawn_egg");
     @Nullable
-    public static final ItemType HAY_BLOCK = init();
+    public static final ItemType GUNPOWDER = get("minecraft:gunpowder");
     @Nullable
-    public static final ItemType HEART_OF_THE_SEA = init();
+    public static final ItemType GUSTER_BANNER_PATTERN = get("minecraft:guster_banner_pattern");
     @Nullable
-    public static final ItemType HEART_POTTERY_SHERD = init();
+    public static final ItemType GUSTER_POTTERY_SHERD = get("minecraft:guster_pottery_sherd");
     @Nullable
-    public static final ItemType HEARTBREAK_POTTERY_SHERD = init();
+    public static final ItemType HANGING_ROOTS = get("minecraft:hanging_roots");
     @Nullable
-    public static final ItemType HEAVY_CORE = init();
+    public static final ItemType HAPPY_GHAST_SPAWN_EGG = get("minecraft:happy_ghast_spawn_egg");
     @Nullable
-    public static final ItemType HEAVY_WEIGHTED_PRESSURE_PLATE = init();
+    public static final ItemType HAY_BLOCK = get("minecraft:hay_block");
     @Nullable
-    public static final ItemType HOGLIN_SPAWN_EGG = init();
+    public static final ItemType HEART_OF_THE_SEA = get("minecraft:heart_of_the_sea");
     @Nullable
-    public static final ItemType HONEY_BLOCK = init();
+    public static final ItemType HEART_POTTERY_SHERD = get("minecraft:heart_pottery_sherd");
     @Nullable
-    public static final ItemType HONEY_BOTTLE = init();
+    public static final ItemType HEARTBREAK_POTTERY_SHERD = get("minecraft:heartbreak_pottery_sherd");
     @Nullable
-    public static final ItemType HONEYCOMB = init();
+    public static final ItemType HEAVY_CORE = get("minecraft:heavy_core");
     @Nullable
-    public static final ItemType HONEYCOMB_BLOCK = init();
+    public static final ItemType HEAVY_WEIGHTED_PRESSURE_PLATE = get("minecraft:heavy_weighted_pressure_plate");
     @Nullable
-    public static final ItemType HOPPER = init();
+    public static final ItemType HOGLIN_SPAWN_EGG = get("minecraft:hoglin_spawn_egg");
     @Nullable
-    public static final ItemType HOPPER_MINECART = init();
+    public static final ItemType HONEY_BLOCK = get("minecraft:honey_block");
     @Nullable
-    public static final ItemType HORN_CORAL = init();
+    public static final ItemType HONEY_BOTTLE = get("minecraft:honey_bottle");
     @Nullable
-    public static final ItemType HORN_CORAL_BLOCK = init();
+    public static final ItemType HONEYCOMB = get("minecraft:honeycomb");
     @Nullable
-    public static final ItemType HORN_CORAL_FAN = init();
+    public static final ItemType HONEYCOMB_BLOCK = get("minecraft:honeycomb_block");
     @Nullable
-    public static final ItemType HORSE_SPAWN_EGG = init();
+    public static final ItemType HOPPER = get("minecraft:hopper");
     @Nullable
-    public static final ItemType HOST_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType HOPPER_MINECART = get("minecraft:hopper_minecart");
     @Nullable
-    public static final ItemType HOWL_POTTERY_SHERD = init();
+    public static final ItemType HORN_CORAL = get("minecraft:horn_coral");
     @Nullable
-    public static final ItemType HUSK_SPAWN_EGG = init();
+    public static final ItemType HORN_CORAL_BLOCK = get("minecraft:horn_coral_block");
     @Nullable
-    public static final ItemType ICE = init();
+    public static final ItemType HORN_CORAL_FAN = get("minecraft:horn_coral_fan");
     @Nullable
-    public static final ItemType INFESTED_CHISELED_STONE_BRICKS = init();
+    public static final ItemType HORSE_SPAWN_EGG = get("minecraft:horse_spawn_egg");
     @Nullable
-    public static final ItemType INFESTED_COBBLESTONE = init();
+    public static final ItemType HOST_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:host_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType INFESTED_CRACKED_STONE_BRICKS = init();
+    public static final ItemType HOWL_POTTERY_SHERD = get("minecraft:howl_pottery_sherd");
     @Nullable
-    public static final ItemType INFESTED_DEEPSLATE = init();
+    public static final ItemType HUSK_SPAWN_EGG = get("minecraft:husk_spawn_egg");
     @Nullable
-    public static final ItemType INFESTED_MOSSY_STONE_BRICKS = init();
+    public static final ItemType ICE = get("minecraft:ice");
     @Nullable
-    public static final ItemType INFESTED_STONE = init();
+    public static final ItemType INFESTED_CHISELED_STONE_BRICKS = get("minecraft:infested_chiseled_stone_bricks");
     @Nullable
-    public static final ItemType INFESTED_STONE_BRICKS = init();
+    public static final ItemType INFESTED_COBBLESTONE = get("minecraft:infested_cobblestone");
     @Nullable
-    public static final ItemType INK_SAC = init();
+    public static final ItemType INFESTED_CRACKED_STONE_BRICKS = get("minecraft:infested_cracked_stone_bricks");
     @Nullable
-    public static final ItemType IRON_AXE = init();
+    public static final ItemType INFESTED_DEEPSLATE = get("minecraft:infested_deepslate");
     @Nullable
-    public static final ItemType IRON_BARS = init();
+    public static final ItemType INFESTED_MOSSY_STONE_BRICKS = get("minecraft:infested_mossy_stone_bricks");
     @Nullable
-    public static final ItemType IRON_BLOCK = init();
+    public static final ItemType INFESTED_STONE = get("minecraft:infested_stone");
     @Nullable
-    public static final ItemType IRON_BOOTS = init();
+    public static final ItemType INFESTED_STONE_BRICKS = get("minecraft:infested_stone_bricks");
     @Nullable
-    public static final ItemType IRON_CHAIN = init();
+    public static final ItemType INK_SAC = get("minecraft:ink_sac");
     @Nullable
-    public static final ItemType IRON_CHESTPLATE = init();
+    public static final ItemType IRON_AXE = get("minecraft:iron_axe");
     @Nullable
-    public static final ItemType IRON_DOOR = init();
+    public static final ItemType IRON_BARS = get("minecraft:iron_bars");
     @Nullable
-    public static final ItemType IRON_GOLEM_SPAWN_EGG = init();
+    public static final ItemType IRON_BLOCK = get("minecraft:iron_block");
     @Nullable
-    public static final ItemType IRON_HELMET = init();
+    public static final ItemType IRON_BOOTS = get("minecraft:iron_boots");
     @Nullable
-    public static final ItemType IRON_HOE = init();
+    public static final ItemType IRON_CHAIN = get("minecraft:iron_chain");
     @Nullable
-    public static final ItemType IRON_HORSE_ARMOR = init();
+    public static final ItemType IRON_CHESTPLATE = get("minecraft:iron_chestplate");
     @Nullable
-    public static final ItemType IRON_INGOT = init();
+    public static final ItemType IRON_DOOR = get("minecraft:iron_door");
     @Nullable
-    public static final ItemType IRON_LEGGINGS = init();
+    public static final ItemType IRON_GOLEM_SPAWN_EGG = get("minecraft:iron_golem_spawn_egg");
     @Nullable
-    public static final ItemType IRON_NAUTILUS_ARMOR = init();
+    public static final ItemType IRON_HELMET = get("minecraft:iron_helmet");
     @Nullable
-    public static final ItemType IRON_NUGGET = init();
+    public static final ItemType IRON_HOE = get("minecraft:iron_hoe");
     @Nullable
-    public static final ItemType IRON_ORE = init();
+    public static final ItemType IRON_HORSE_ARMOR = get("minecraft:iron_horse_armor");
     @Nullable
-    public static final ItemType IRON_PICKAXE = init();
+    public static final ItemType IRON_INGOT = get("minecraft:iron_ingot");
     @Nullable
-    public static final ItemType IRON_SHOVEL = init();
+    public static final ItemType IRON_LEGGINGS = get("minecraft:iron_leggings");
     @Nullable
-    public static final ItemType IRON_SPEAR = init();
+    public static final ItemType IRON_NAUTILUS_ARMOR = get("minecraft:iron_nautilus_armor");
     @Nullable
-    public static final ItemType IRON_SWORD = init();
+    public static final ItemType IRON_NUGGET = get("minecraft:iron_nugget");
     @Nullable
-    public static final ItemType IRON_TRAPDOOR = init();
+    public static final ItemType IRON_ORE = get("minecraft:iron_ore");
     @Nullable
-    public static final ItemType ITEM_FRAME = init();
+    public static final ItemType IRON_PICKAXE = get("minecraft:iron_pickaxe");
     @Nullable
-    public static final ItemType JACK_O_LANTERN = init();
+    public static final ItemType IRON_SHOVEL = get("minecraft:iron_shovel");
     @Nullable
-    public static final ItemType JIGSAW = init();
+    public static final ItemType IRON_SPEAR = get("minecraft:iron_spear");
     @Nullable
-    public static final ItemType JUKEBOX = init();
+    public static final ItemType IRON_SWORD = get("minecraft:iron_sword");
     @Nullable
-    public static final ItemType JUNGLE_BOAT = init();
+    public static final ItemType IRON_TRAPDOOR = get("minecraft:iron_trapdoor");
     @Nullable
-    public static final ItemType JUNGLE_BUTTON = init();
+    public static final ItemType ITEM_FRAME = get("minecraft:item_frame");
     @Nullable
-    public static final ItemType JUNGLE_CHEST_BOAT = init();
+    public static final ItemType JACK_O_LANTERN = get("minecraft:jack_o_lantern");
     @Nullable
-    public static final ItemType JUNGLE_DOOR = init();
+    public static final ItemType JIGSAW = get("minecraft:jigsaw");
     @Nullable
-    public static final ItemType JUNGLE_FENCE = init();
+    public static final ItemType JUKEBOX = get("minecraft:jukebox");
     @Nullable
-    public static final ItemType JUNGLE_FENCE_GATE = init();
+    public static final ItemType JUNGLE_BOAT = get("minecraft:jungle_boat");
     @Nullable
-    public static final ItemType JUNGLE_HANGING_SIGN = init();
+    public static final ItemType JUNGLE_BUTTON = get("minecraft:jungle_button");
     @Nullable
-    public static final ItemType JUNGLE_LEAVES = init();
+    public static final ItemType JUNGLE_CHEST_BOAT = get("minecraft:jungle_chest_boat");
     @Nullable
-    public static final ItemType JUNGLE_LOG = init();
+    public static final ItemType JUNGLE_DOOR = get("minecraft:jungle_door");
     @Nullable
-    public static final ItemType JUNGLE_PLANKS = init();
+    public static final ItemType JUNGLE_FENCE = get("minecraft:jungle_fence");
     @Nullable
-    public static final ItemType JUNGLE_PRESSURE_PLATE = init();
+    public static final ItemType JUNGLE_FENCE_GATE = get("minecraft:jungle_fence_gate");
     @Nullable
-    public static final ItemType JUNGLE_SAPLING = init();
+    public static final ItemType JUNGLE_HANGING_SIGN = get("minecraft:jungle_hanging_sign");
     @Nullable
-    public static final ItemType JUNGLE_SHELF = init();
+    public static final ItemType JUNGLE_LEAVES = get("minecraft:jungle_leaves");
     @Nullable
-    public static final ItemType JUNGLE_SIGN = init();
+    public static final ItemType JUNGLE_LOG = get("minecraft:jungle_log");
     @Nullable
-    public static final ItemType JUNGLE_SLAB = init();
+    public static final ItemType JUNGLE_PLANKS = get("minecraft:jungle_planks");
     @Nullable
-    public static final ItemType JUNGLE_STAIRS = init();
+    public static final ItemType JUNGLE_PRESSURE_PLATE = get("minecraft:jungle_pressure_plate");
     @Nullable
-    public static final ItemType JUNGLE_TRAPDOOR = init();
+    public static final ItemType JUNGLE_SAPLING = get("minecraft:jungle_sapling");
     @Nullable
-    public static final ItemType JUNGLE_WOOD = init();
+    public static final ItemType JUNGLE_SHELF = get("minecraft:jungle_shelf");
     @Nullable
-    public static final ItemType KELP = init();
+    public static final ItemType JUNGLE_SIGN = get("minecraft:jungle_sign");
     @Nullable
-    public static final ItemType KNOWLEDGE_BOOK = init();
+    public static final ItemType JUNGLE_SLAB = get("minecraft:jungle_slab");
     @Nullable
-    public static final ItemType LADDER = init();
+    public static final ItemType JUNGLE_STAIRS = get("minecraft:jungle_stairs");
     @Nullable
-    public static final ItemType LANTERN = init();
+    public static final ItemType JUNGLE_TRAPDOOR = get("minecraft:jungle_trapdoor");
     @Nullable
-    public static final ItemType LAPIS_BLOCK = init();
+    public static final ItemType JUNGLE_WOOD = get("minecraft:jungle_wood");
     @Nullable
-    public static final ItemType LAPIS_LAZULI = init();
+    public static final ItemType KELP = get("minecraft:kelp");
     @Nullable
-    public static final ItemType LAPIS_ORE = init();
+    public static final ItemType KNOWLEDGE_BOOK = get("minecraft:knowledge_book");
     @Nullable
-    public static final ItemType LARGE_AMETHYST_BUD = init();
+    public static final ItemType LADDER = get("minecraft:ladder");
     @Nullable
-    public static final ItemType LARGE_FERN = init();
+    public static final ItemType LANTERN = get("minecraft:lantern");
     @Nullable
-    public static final ItemType LAVA_BUCKET = init();
+    public static final ItemType LAPIS_BLOCK = get("minecraft:lapis_block");
     @Nullable
-    public static final ItemType LEAD = init();
+    public static final ItemType LAPIS_LAZULI = get("minecraft:lapis_lazuli");
     @Nullable
-    public static final ItemType LEAF_LITTER = init();
+    public static final ItemType LAPIS_ORE = get("minecraft:lapis_ore");
     @Nullable
-    public static final ItemType LEATHER = init();
+    public static final ItemType LARGE_AMETHYST_BUD = get("minecraft:large_amethyst_bud");
     @Nullable
-    public static final ItemType LEATHER_BOOTS = init();
+    public static final ItemType LARGE_FERN = get("minecraft:large_fern");
     @Nullable
-    public static final ItemType LEATHER_CHESTPLATE = init();
+    public static final ItemType LAVA_BUCKET = get("minecraft:lava_bucket");
     @Nullable
-    public static final ItemType LEATHER_HELMET = init();
+    public static final ItemType LEAD = get("minecraft:lead");
     @Nullable
-    public static final ItemType LEATHER_HORSE_ARMOR = init();
+    public static final ItemType LEAF_LITTER = get("minecraft:leaf_litter");
     @Nullable
-    public static final ItemType LEATHER_LEGGINGS = init();
+    public static final ItemType LEATHER = get("minecraft:leather");
     @Nullable
-    public static final ItemType LECTERN = init();
+    public static final ItemType LEATHER_BOOTS = get("minecraft:leather_boots");
     @Nullable
-    public static final ItemType LEVER = init();
+    public static final ItemType LEATHER_CHESTPLATE = get("minecraft:leather_chestplate");
     @Nullable
-    public static final ItemType LIGHT = init();
+    public static final ItemType LEATHER_HELMET = get("minecraft:leather_helmet");
     @Nullable
-    public static final ItemType LIGHT_BLUE_BANNER = init();
+    public static final ItemType LEATHER_HORSE_ARMOR = get("minecraft:leather_horse_armor");
     @Nullable
-    public static final ItemType LIGHT_BLUE_BED = init();
-    @Nullable public static final ItemType LIGHT_BLUE_BUNDLE = init();
+    public static final ItemType LEATHER_LEGGINGS = get("minecraft:leather_leggings");
     @Nullable
-    public static final ItemType LIGHT_BLUE_CANDLE = init();
+    public static final ItemType LECTERN = get("minecraft:lectern");
     @Nullable
-    public static final ItemType LIGHT_BLUE_CARPET = init();
+    public static final ItemType LEVER = get("minecraft:lever");
     @Nullable
-    public static final ItemType LIGHT_BLUE_CONCRETE = init();
+    public static final ItemType LIGHT = get("minecraft:light");
     @Nullable
-    public static final ItemType LIGHT_BLUE_CONCRETE_POWDER = init();
+    public static final ItemType LIGHT_BLUE_BANNER = get("minecraft:light_blue_banner");
     @Nullable
-    public static final ItemType LIGHT_BLUE_DYE = init();
+    public static final ItemType LIGHT_BLUE_BED = get("minecraft:light_blue_bed");
     @Nullable
-    public static final ItemType LIGHT_BLUE_GLAZED_TERRACOTTA = init();
+    public static final ItemType LIGHT_BLUE_BUNDLE = get("minecraft:light_blue_bundle");
     @Nullable
-    public static final ItemType LIGHT_BLUE_SHULKER_BOX = init();
+    public static final ItemType LIGHT_BLUE_CANDLE = get("minecraft:light_blue_candle");
     @Nullable
-    public static final ItemType LIGHT_BLUE_STAINED_GLASS = init();
+    public static final ItemType LIGHT_BLUE_CARPET = get("minecraft:light_blue_carpet");
     @Nullable
-    public static final ItemType LIGHT_BLUE_STAINED_GLASS_PANE = init();
+    public static final ItemType LIGHT_BLUE_CONCRETE = get("minecraft:light_blue_concrete");
     @Nullable
-    public static final ItemType LIGHT_BLUE_TERRACOTTA = init();
+    public static final ItemType LIGHT_BLUE_CONCRETE_POWDER = get("minecraft:light_blue_concrete_powder");
     @Nullable
-    public static final ItemType LIGHT_BLUE_WOOL = init();
+    public static final ItemType LIGHT_BLUE_DYE = get("minecraft:light_blue_dye");
     @Nullable
-    public static final ItemType LIGHT_GRAY_BANNER = init();
+    public static final ItemType LIGHT_BLUE_GLAZED_TERRACOTTA = get("minecraft:light_blue_glazed_terracotta");
     @Nullable
-    public static final ItemType LIGHT_GRAY_BED = init();
-    @Nullable public static final ItemType LIGHT_GRAY_BUNDLE = init();
+    public static final ItemType LIGHT_BLUE_HARNESS = get("minecraft:light_blue_harness");
     @Nullable
-    public static final ItemType LIGHT_GRAY_CANDLE = init();
+    public static final ItemType LIGHT_BLUE_SHULKER_BOX = get("minecraft:light_blue_shulker_box");
     @Nullable
-    public static final ItemType LIGHT_GRAY_CARPET = init();
+    public static final ItemType LIGHT_BLUE_STAINED_GLASS = get("minecraft:light_blue_stained_glass");
     @Nullable
-    public static final ItemType LIGHT_GRAY_CONCRETE = init();
+    public static final ItemType LIGHT_BLUE_STAINED_GLASS_PANE = get("minecraft:light_blue_stained_glass_pane");
     @Nullable
-    public static final ItemType LIGHT_GRAY_CONCRETE_POWDER = init();
+    public static final ItemType LIGHT_BLUE_TERRACOTTA = get("minecraft:light_blue_terracotta");
     @Nullable
-    public static final ItemType LIGHT_GRAY_DYE = init();
+    public static final ItemType LIGHT_BLUE_WOOL = get("minecraft:light_blue_wool");
     @Nullable
-    public static final ItemType LIGHT_GRAY_GLAZED_TERRACOTTA = init();
+    public static final ItemType LIGHT_GRAY_BANNER = get("minecraft:light_gray_banner");
     @Nullable
-    public static final ItemType LIGHT_GRAY_SHULKER_BOX = init();
+    public static final ItemType LIGHT_GRAY_BED = get("minecraft:light_gray_bed");
     @Nullable
-    public static final ItemType LIGHT_GRAY_STAINED_GLASS = init();
+    public static final ItemType LIGHT_GRAY_BUNDLE = get("minecraft:light_gray_bundle");
     @Nullable
-    public static final ItemType LIGHT_GRAY_STAINED_GLASS_PANE = init();
+    public static final ItemType LIGHT_GRAY_CANDLE = get("minecraft:light_gray_candle");
     @Nullable
-    public static final ItemType LIGHT_GRAY_TERRACOTTA = init();
+    public static final ItemType LIGHT_GRAY_CARPET = get("minecraft:light_gray_carpet");
     @Nullable
-    public static final ItemType LIGHT_GRAY_WOOL = init();
+    public static final ItemType LIGHT_GRAY_CONCRETE = get("minecraft:light_gray_concrete");
     @Nullable
-    public static final ItemType LIGHT_WEIGHTED_PRESSURE_PLATE = init();
+    public static final ItemType LIGHT_GRAY_CONCRETE_POWDER = get("minecraft:light_gray_concrete_powder");
     @Nullable
-    public static final ItemType LIGHTNING_ROD = init();
+    public static final ItemType LIGHT_GRAY_DYE = get("minecraft:light_gray_dye");
     @Nullable
-    public static final ItemType LILAC = init();
+    public static final ItemType LIGHT_GRAY_GLAZED_TERRACOTTA = get("minecraft:light_gray_glazed_terracotta");
     @Nullable
-    public static final ItemType LILY_OF_THE_VALLEY = init();
+    public static final ItemType LIGHT_GRAY_HARNESS = get("minecraft:light_gray_harness");
     @Nullable
-    public static final ItemType LILY_PAD = init();
+    public static final ItemType LIGHT_GRAY_SHULKER_BOX = get("minecraft:light_gray_shulker_box");
     @Nullable
-    public static final ItemType LIME_BANNER = init();
+    public static final ItemType LIGHT_GRAY_STAINED_GLASS = get("minecraft:light_gray_stained_glass");
     @Nullable
-    public static final ItemType LIME_BED = init();
-    @Nullable public static final ItemType LIME_BUNDLE = init();
+    public static final ItemType LIGHT_GRAY_STAINED_GLASS_PANE = get("minecraft:light_gray_stained_glass_pane");
     @Nullable
-    public static final ItemType LIME_CANDLE = init();
+    public static final ItemType LIGHT_GRAY_TERRACOTTA = get("minecraft:light_gray_terracotta");
     @Nullable
-    public static final ItemType LIME_CARPET = init();
+    public static final ItemType LIGHT_GRAY_WOOL = get("minecraft:light_gray_wool");
     @Nullable
-    public static final ItemType LIME_CONCRETE = init();
+    public static final ItemType LIGHT_WEIGHTED_PRESSURE_PLATE = get("minecraft:light_weighted_pressure_plate");
     @Nullable
-    public static final ItemType LIME_CONCRETE_POWDER = init();
+    public static final ItemType LIGHTNING_ROD = get("minecraft:lightning_rod");
     @Nullable
-    public static final ItemType LIME_DYE = init();
+    public static final ItemType LILAC = get("minecraft:lilac");
     @Nullable
-    public static final ItemType LIME_GLAZED_TERRACOTTA = init();
+    public static final ItemType LILY_OF_THE_VALLEY = get("minecraft:lily_of_the_valley");
     @Nullable
-    public static final ItemType LIME_SHULKER_BOX = init();
+    public static final ItemType LILY_PAD = get("minecraft:lily_pad");
     @Nullable
-    public static final ItemType LIME_STAINED_GLASS = init();
+    public static final ItemType LIME_BANNER = get("minecraft:lime_banner");
     @Nullable
-    public static final ItemType LIME_STAINED_GLASS_PANE = init();
+    public static final ItemType LIME_BED = get("minecraft:lime_bed");
     @Nullable
-    public static final ItemType LIME_TERRACOTTA = init();
+    public static final ItemType LIME_BUNDLE = get("minecraft:lime_bundle");
     @Nullable
-    public static final ItemType LIME_WOOL = init();
+    public static final ItemType LIME_CANDLE = get("minecraft:lime_candle");
     @Nullable
-    public static final ItemType LINGERING_POTION = init();
+    public static final ItemType LIME_CARPET = get("minecraft:lime_carpet");
     @Nullable
-    public static final ItemType LLAMA_SPAWN_EGG = init();
+    public static final ItemType LIME_CONCRETE = get("minecraft:lime_concrete");
     @Nullable
-    public static final ItemType LODESTONE = init();
+    public static final ItemType LIME_CONCRETE_POWDER = get("minecraft:lime_concrete_powder");
     @Nullable
-    public static final ItemType LOOM = init();
+    public static final ItemType LIME_DYE = get("minecraft:lime_dye");
     @Nullable
-    public static final ItemType MACE = init();
+    public static final ItemType LIME_GLAZED_TERRACOTTA = get("minecraft:lime_glazed_terracotta");
     @Nullable
-    public static final ItemType MAGENTA_BANNER = init();
+    public static final ItemType LIME_HARNESS = get("minecraft:lime_harness");
     @Nullable
-    public static final ItemType MAGENTA_BED = init();
-    @Nullable public static final ItemType MAGENTA_BUNDLE = init();
+    public static final ItemType LIME_SHULKER_BOX = get("minecraft:lime_shulker_box");
     @Nullable
-    public static final ItemType MAGENTA_CANDLE = init();
+    public static final ItemType LIME_STAINED_GLASS = get("minecraft:lime_stained_glass");
     @Nullable
-    public static final ItemType MAGENTA_CARPET = init();
+    public static final ItemType LIME_STAINED_GLASS_PANE = get("minecraft:lime_stained_glass_pane");
     @Nullable
-    public static final ItemType MAGENTA_CONCRETE = init();
+    public static final ItemType LIME_TERRACOTTA = get("minecraft:lime_terracotta");
     @Nullable
-    public static final ItemType MAGENTA_CONCRETE_POWDER = init();
+    public static final ItemType LIME_WOOL = get("minecraft:lime_wool");
     @Nullable
-    public static final ItemType MAGENTA_DYE = init();
+    public static final ItemType LINGERING_POTION = get("minecraft:lingering_potion");
     @Nullable
-    public static final ItemType MAGENTA_GLAZED_TERRACOTTA = init();
+    public static final ItemType LLAMA_SPAWN_EGG = get("minecraft:llama_spawn_egg");
     @Nullable
-    public static final ItemType MAGENTA_SHULKER_BOX = init();
+    public static final ItemType LODESTONE = get("minecraft:lodestone");
     @Nullable
-    public static final ItemType MAGENTA_STAINED_GLASS = init();
+    public static final ItemType LOOM = get("minecraft:loom");
     @Nullable
-    public static final ItemType MAGENTA_STAINED_GLASS_PANE = init();
+    public static final ItemType MACE = get("minecraft:mace");
     @Nullable
-    public static final ItemType MAGENTA_TERRACOTTA = init();
+    public static final ItemType MAGENTA_BANNER = get("minecraft:magenta_banner");
     @Nullable
-    public static final ItemType MAGENTA_WOOL = init();
+    public static final ItemType MAGENTA_BED = get("minecraft:magenta_bed");
     @Nullable
-    public static final ItemType MAGMA_BLOCK = init();
+    public static final ItemType MAGENTA_BUNDLE = get("minecraft:magenta_bundle");
     @Nullable
-    public static final ItemType MAGMA_CREAM = init();
+    public static final ItemType MAGENTA_CANDLE = get("minecraft:magenta_candle");
     @Nullable
-    public static final ItemType MAGMA_CUBE_SPAWN_EGG = init();
+    public static final ItemType MAGENTA_CARPET = get("minecraft:magenta_carpet");
     @Nullable
-    public static final ItemType MANGROVE_BOAT = init();
+    public static final ItemType MAGENTA_CONCRETE = get("minecraft:magenta_concrete");
     @Nullable
-    public static final ItemType MANGROVE_BUTTON = init();
+    public static final ItemType MAGENTA_CONCRETE_POWDER = get("minecraft:magenta_concrete_powder");
     @Nullable
-    public static final ItemType MANGROVE_CHEST_BOAT = init();
+    public static final ItemType MAGENTA_DYE = get("minecraft:magenta_dye");
     @Nullable
-    public static final ItemType MANGROVE_DOOR = init();
+    public static final ItemType MAGENTA_GLAZED_TERRACOTTA = get("minecraft:magenta_glazed_terracotta");
     @Nullable
-    public static final ItemType MANGROVE_FENCE = init();
+    public static final ItemType MAGENTA_HARNESS = get("minecraft:magenta_harness");
     @Nullable
-    public static final ItemType MANGROVE_FENCE_GATE = init();
+    public static final ItemType MAGENTA_SHULKER_BOX = get("minecraft:magenta_shulker_box");
     @Nullable
-    public static final ItemType MANGROVE_HANGING_SIGN = init();
+    public static final ItemType MAGENTA_STAINED_GLASS = get("minecraft:magenta_stained_glass");
     @Nullable
-    public static final ItemType MANGROVE_LEAVES = init();
+    public static final ItemType MAGENTA_STAINED_GLASS_PANE = get("minecraft:magenta_stained_glass_pane");
     @Nullable
-    public static final ItemType MANGROVE_LOG = init();
+    public static final ItemType MAGENTA_TERRACOTTA = get("minecraft:magenta_terracotta");
     @Nullable
-    public static final ItemType MANGROVE_PLANKS = init();
+    public static final ItemType MAGENTA_WOOL = get("minecraft:magenta_wool");
     @Nullable
-    public static final ItemType MANGROVE_PRESSURE_PLATE = init();
+    public static final ItemType MAGMA_BLOCK = get("minecraft:magma_block");
     @Nullable
-    public static final ItemType MANGROVE_PROPAGULE = init();
+    public static final ItemType MAGMA_CREAM = get("minecraft:magma_cream");
     @Nullable
-    public static final ItemType MANGROVE_ROOTS = init();
+    public static final ItemType MAGMA_CUBE_SPAWN_EGG = get("minecraft:magma_cube_spawn_egg");
     @Nullable
-    public static final ItemType MANGROVE_SHELF = init();
+    public static final ItemType MANGROVE_BOAT = get("minecraft:mangrove_boat");
     @Nullable
-    public static final ItemType MANGROVE_SIGN = init();
+    public static final ItemType MANGROVE_BUTTON = get("minecraft:mangrove_button");
     @Nullable
-    public static final ItemType MANGROVE_SLAB = init();
+    public static final ItemType MANGROVE_CHEST_BOAT = get("minecraft:mangrove_chest_boat");
     @Nullable
-    public static final ItemType MANGROVE_STAIRS = init();
+    public static final ItemType MANGROVE_DOOR = get("minecraft:mangrove_door");
     @Nullable
-    public static final ItemType MANGROVE_TRAPDOOR = init();
+    public static final ItemType MANGROVE_FENCE = get("minecraft:mangrove_fence");
     @Nullable
-    public static final ItemType MANGROVE_WOOD = init();
+    public static final ItemType MANGROVE_FENCE_GATE = get("minecraft:mangrove_fence_gate");
     @Nullable
-    public static final ItemType MAP = init();
+    public static final ItemType MANGROVE_HANGING_SIGN = get("minecraft:mangrove_hanging_sign");
     @Nullable
-    public static final ItemType MEDIUM_AMETHYST_BUD = init();
+    public static final ItemType MANGROVE_LEAVES = get("minecraft:mangrove_leaves");
     @Nullable
-    public static final ItemType MELON = init();
+    public static final ItemType MANGROVE_LOG = get("minecraft:mangrove_log");
     @Nullable
-    public static final ItemType MELON_SEEDS = init();
+    public static final ItemType MANGROVE_PLANKS = get("minecraft:mangrove_planks");
     @Nullable
-    public static final ItemType MELON_SLICE = init();
+    public static final ItemType MANGROVE_PRESSURE_PLATE = get("minecraft:mangrove_pressure_plate");
     @Nullable
-    public static final ItemType MILK_BUCKET = init();
+    public static final ItemType MANGROVE_PROPAGULE = get("minecraft:mangrove_propagule");
     @Nullable
-    public static final ItemType MINECART = init();
+    public static final ItemType MANGROVE_ROOTS = get("minecraft:mangrove_roots");
     @Nullable
-    public static final ItemType MINER_POTTERY_SHERD = init();
+    public static final ItemType MANGROVE_SHELF = get("minecraft:mangrove_shelf");
     @Nullable
-    public static final ItemType MOJANG_BANNER_PATTERN = init();
+    public static final ItemType MANGROVE_SIGN = get("minecraft:mangrove_sign");
     @Nullable
-    public static final ItemType MOOSHROOM_SPAWN_EGG = init();
+    public static final ItemType MANGROVE_SLAB = get("minecraft:mangrove_slab");
     @Nullable
-    public static final ItemType MOSS_BLOCK = init();
+    public static final ItemType MANGROVE_STAIRS = get("minecraft:mangrove_stairs");
     @Nullable
-    public static final ItemType MOSS_CARPET = init();
+    public static final ItemType MANGROVE_TRAPDOOR = get("minecraft:mangrove_trapdoor");
     @Nullable
-    public static final ItemType MOSSY_COBBLESTONE = init();
+    public static final ItemType MANGROVE_WOOD = get("minecraft:mangrove_wood");
     @Nullable
-    public static final ItemType MOSSY_COBBLESTONE_SLAB = init();
+    public static final ItemType MAP = get("minecraft:map");
     @Nullable
-    public static final ItemType MOSSY_COBBLESTONE_STAIRS = init();
+    public static final ItemType MEDIUM_AMETHYST_BUD = get("minecraft:medium_amethyst_bud");
     @Nullable
-    public static final ItemType MOSSY_COBBLESTONE_WALL = init();
+    public static final ItemType MELON = get("minecraft:melon");
     @Nullable
-    public static final ItemType MOSSY_STONE_BRICK_SLAB = init();
+    public static final ItemType MELON_SEEDS = get("minecraft:melon_seeds");
     @Nullable
-    public static final ItemType MOSSY_STONE_BRICK_STAIRS = init();
+    public static final ItemType MELON_SLICE = get("minecraft:melon_slice");
     @Nullable
-    public static final ItemType MOSSY_STONE_BRICK_WALL = init();
+    public static final ItemType MILK_BUCKET = get("minecraft:milk_bucket");
     @Nullable
-    public static final ItemType MOSSY_STONE_BRICKS = init();
+    public static final ItemType MINECART = get("minecraft:minecart");
     @Nullable
-    public static final ItemType MOURNER_POTTERY_SHERD = init();
+    public static final ItemType MINER_POTTERY_SHERD = get("minecraft:miner_pottery_sherd");
     @Nullable
-    public static final ItemType MUD = init();
+    public static final ItemType MOJANG_BANNER_PATTERN = get("minecraft:mojang_banner_pattern");
     @Nullable
-    public static final ItemType MUD_BRICK_SLAB = init();
+    public static final ItemType MOOSHROOM_SPAWN_EGG = get("minecraft:mooshroom_spawn_egg");
     @Nullable
-    public static final ItemType MUD_BRICK_STAIRS = init();
+    public static final ItemType MOSS_BLOCK = get("minecraft:moss_block");
     @Nullable
-    public static final ItemType MUD_BRICK_WALL = init();
+    public static final ItemType MOSS_CARPET = get("minecraft:moss_carpet");
     @Nullable
-    public static final ItemType MUD_BRICKS = init();
+    public static final ItemType MOSSY_COBBLESTONE = get("minecraft:mossy_cobblestone");
     @Nullable
-    public static final ItemType MUDDY_MANGROVE_ROOTS = init();
+    public static final ItemType MOSSY_COBBLESTONE_SLAB = get("minecraft:mossy_cobblestone_slab");
     @Nullable
-    public static final ItemType MULE_SPAWN_EGG = init();
+    public static final ItemType MOSSY_COBBLESTONE_STAIRS = get("minecraft:mossy_cobblestone_stairs");
     @Nullable
-    public static final ItemType MUSHROOM_STEM = init();
+    public static final ItemType MOSSY_COBBLESTONE_WALL = get("minecraft:mossy_cobblestone_wall");
     @Nullable
-    public static final ItemType MUSHROOM_STEW = init();
+    public static final ItemType MOSSY_STONE_BRICK_SLAB = get("minecraft:mossy_stone_brick_slab");
     @Nullable
-    public static final ItemType MUSIC_DISC_11 = init();
+    public static final ItemType MOSSY_STONE_BRICK_STAIRS = get("minecraft:mossy_stone_brick_stairs");
     @Nullable
-    public static final ItemType MUSIC_DISC_13 = init();
+    public static final ItemType MOSSY_STONE_BRICK_WALL = get("minecraft:mossy_stone_brick_wall");
     @Nullable
-    public static final ItemType MUSIC_DISC_5 = init();
+    public static final ItemType MOSSY_STONE_BRICKS = get("minecraft:mossy_stone_bricks");
     @Nullable
-    public static final ItemType MUSIC_DISC_BLOCKS = init();
+    public static final ItemType MOURNER_POTTERY_SHERD = get("minecraft:mourner_pottery_sherd");
     @Nullable
-    public static final ItemType MUSIC_DISC_BOUNCE = init();
+    public static final ItemType MUD = get("minecraft:mud");
     @Nullable
-    public static final ItemType MUSIC_DISC_CAT = init();
+    public static final ItemType MUD_BRICK_SLAB = get("minecraft:mud_brick_slab");
     @Nullable
-    public static final ItemType MUSIC_DISC_CHIRP = init();
+    public static final ItemType MUD_BRICK_STAIRS = get("minecraft:mud_brick_stairs");
     @Nullable
-    public static final ItemType MUSIC_DISC_CREATOR = init();
+    public static final ItemType MUD_BRICK_WALL = get("minecraft:mud_brick_wall");
     @Nullable
-    public static final ItemType MUSIC_DISC_CREATOR_MUSIC_BOX = init();
+    public static final ItemType MUD_BRICKS = get("minecraft:mud_bricks");
     @Nullable
-    public static final ItemType MUSIC_DISC_FAR = init();
+    public static final ItemType MUDDY_MANGROVE_ROOTS = get("minecraft:muddy_mangrove_roots");
     @Nullable
-    public static final ItemType MUSIC_DISC_LAVA_CHICKEN = init();
+    public static final ItemType MULE_SPAWN_EGG = get("minecraft:mule_spawn_egg");
     @Nullable
-    public static final ItemType MUSIC_DISC_MALL = init();
+    public static final ItemType MUSHROOM_STEM = get("minecraft:mushroom_stem");
     @Nullable
-    public static final ItemType MUSIC_DISC_MELLOHI = init();
+    public static final ItemType MUSHROOM_STEW = get("minecraft:mushroom_stew");
     @Nullable
-    public static final ItemType MUSIC_DISC_OTHERSIDE = init();
+    public static final ItemType MUSIC_DISC_11 = get("minecraft:music_disc_11");
     @Nullable
-    public static final ItemType MUSIC_DISC_PIGSTEP = init();
+    public static final ItemType MUSIC_DISC_13 = get("minecraft:music_disc_13");
     @Nullable
-    public static final ItemType MUSIC_DISC_PRECIPICE = init();
+    public static final ItemType MUSIC_DISC_5 = get("minecraft:music_disc_5");
     @Nullable
-    public static final ItemType MUSIC_DISC_RELIC = init();
+    public static final ItemType MUSIC_DISC_BLOCKS = get("minecraft:music_disc_blocks");
     @Nullable
-    public static final ItemType MUSIC_DISC_STAL = init();
+    public static final ItemType MUSIC_DISC_BOUNCE = get("minecraft:music_disc_bounce");
     @Nullable
-    public static final ItemType MUSIC_DISC_STRAD = init();
+    public static final ItemType MUSIC_DISC_CAT = get("minecraft:music_disc_cat");
     @Nullable
-    public static final ItemType MUSIC_DISC_WAIT = init();
+    public static final ItemType MUSIC_DISC_CHIRP = get("minecraft:music_disc_chirp");
     @Nullable
-    public static final ItemType MUSIC_DISC_WARD = init();
+    public static final ItemType MUSIC_DISC_CREATOR = get("minecraft:music_disc_creator");
     @Nullable
-    public static final ItemType MUTTON = init();
+    public static final ItemType MUSIC_DISC_CREATOR_MUSIC_BOX = get("minecraft:music_disc_creator_music_box");
     @Nullable
-    public static final ItemType MYCELIUM = init();
+    public static final ItemType MUSIC_DISC_FAR = get("minecraft:music_disc_far");
     @Nullable
-    public static final ItemType NAME_TAG = init();
+    public static final ItemType MUSIC_DISC_LAVA_CHICKEN = get("minecraft:music_disc_lava_chicken");
     @Nullable
-    public static final ItemType NAUTILUS_SHELL = init();
+    public static final ItemType MUSIC_DISC_MALL = get("minecraft:music_disc_mall");
     @Nullable
-    public static final ItemType NAUTILUS_SPAWN_EGG = init();
+    public static final ItemType MUSIC_DISC_MELLOHI = get("minecraft:music_disc_mellohi");
     @Nullable
-    public static final ItemType NETHER_BRICK = init();
+    public static final ItemType MUSIC_DISC_OTHERSIDE = get("minecraft:music_disc_otherside");
     @Nullable
-    public static final ItemType NETHER_BRICK_FENCE = init();
+    public static final ItemType MUSIC_DISC_PIGSTEP = get("minecraft:music_disc_pigstep");
     @Nullable
-    public static final ItemType NETHER_BRICK_SLAB = init();
+    public static final ItemType MUSIC_DISC_PRECIPICE = get("minecraft:music_disc_precipice");
     @Nullable
-    public static final ItemType NETHER_BRICK_STAIRS = init();
+    public static final ItemType MUSIC_DISC_RELIC = get("minecraft:music_disc_relic");
     @Nullable
-    public static final ItemType NETHER_BRICK_WALL = init();
+    public static final ItemType MUSIC_DISC_STAL = get("minecraft:music_disc_stal");
     @Nullable
-    public static final ItemType NETHER_BRICKS = init();
+    public static final ItemType MUSIC_DISC_STRAD = get("minecraft:music_disc_strad");
     @Nullable
-    public static final ItemType NETHER_GOLD_ORE = init();
+    public static final ItemType MUSIC_DISC_TEARS = get("minecraft:music_disc_tears");
     @Nullable
-    public static final ItemType NETHER_QUARTZ_ORE = init();
+    public static final ItemType MUSIC_DISC_WAIT = get("minecraft:music_disc_wait");
     @Nullable
-    public static final ItemType NETHER_SPROUTS = init();
+    public static final ItemType MUSIC_DISC_WARD = get("minecraft:music_disc_ward");
     @Nullable
-    public static final ItemType NETHER_STAR = init();
+    public static final ItemType MUTTON = get("minecraft:mutton");
     @Nullable
-    public static final ItemType NETHER_WART = init();
+    public static final ItemType MYCELIUM = get("minecraft:mycelium");
     @Nullable
-    public static final ItemType NETHER_WART_BLOCK = init();
+    public static final ItemType NAME_TAG = get("minecraft:name_tag");
     @Nullable
-    public static final ItemType NETHERITE_AXE = init();
+    public static final ItemType NAUTILUS_SHELL = get("minecraft:nautilus_shell");
     @Nullable
-    public static final ItemType NETHERITE_BLOCK = init();
+    public static final ItemType NAUTILUS_SPAWN_EGG = get("minecraft:nautilus_spawn_egg");
     @Nullable
-    public static final ItemType NETHERITE_BOOTS = init();
+    public static final ItemType NETHER_BRICK = get("minecraft:nether_brick");
     @Nullable
-    public static final ItemType NETHERITE_CHESTPLATE = init();
+    public static final ItemType NETHER_BRICK_FENCE = get("minecraft:nether_brick_fence");
     @Nullable
-    public static final ItemType NETHERITE_HELMET = init();
+    public static final ItemType NETHER_BRICK_SLAB = get("minecraft:nether_brick_slab");
     @Nullable
-    public static final ItemType NETHERITE_HOE = init();
+    public static final ItemType NETHER_BRICK_STAIRS = get("minecraft:nether_brick_stairs");
     @Nullable
-    public static final ItemType NETHERITE_HORSE_ARMOR = init();
+    public static final ItemType NETHER_BRICK_WALL = get("minecraft:nether_brick_wall");
     @Nullable
-    public static final ItemType NETHERITE_INGOT = init();
+    public static final ItemType NETHER_BRICKS = get("minecraft:nether_bricks");
     @Nullable
-    public static final ItemType NETHERITE_LEGGINGS = init();
+    public static final ItemType NETHER_GOLD_ORE = get("minecraft:nether_gold_ore");
     @Nullable
-    public static final ItemType NETHERITE_NAUTILUS_ARMOR = init();
+    public static final ItemType NETHER_QUARTZ_ORE = get("minecraft:nether_quartz_ore");
     @Nullable
-    public static final ItemType NETHERITE_PICKAXE = init();
+    public static final ItemType NETHER_SPROUTS = get("minecraft:nether_sprouts");
     @Nullable
-    public static final ItemType NETHERITE_SCRAP = init();
+    public static final ItemType NETHER_STAR = get("minecraft:nether_star");
     @Nullable
-    public static final ItemType NETHERITE_SHOVEL = init();
+    public static final ItemType NETHER_WART = get("minecraft:nether_wart");
     @Nullable
-    public static final ItemType NETHERITE_SPEAR = init();
+    public static final ItemType NETHER_WART_BLOCK = get("minecraft:nether_wart_block");
     @Nullable
-    public static final ItemType NETHERITE_SWORD = init();
+    public static final ItemType NETHERITE_AXE = get("minecraft:netherite_axe");
     @Nullable
-    public static final ItemType NETHERITE_UPGRADE_SMITHING_TEMPLATE = init();
+    public static final ItemType NETHERITE_BLOCK = get("minecraft:netherite_block");
     @Nullable
-    public static final ItemType NETHERRACK = init();
+    public static final ItemType NETHERITE_BOOTS = get("minecraft:netherite_boots");
     @Nullable
-    public static final ItemType NOTE_BLOCK = init();
+    public static final ItemType NETHERITE_CHESTPLATE = get("minecraft:netherite_chestplate");
     @Nullable
-    public static final ItemType OAK_BOAT = init();
+    public static final ItemType NETHERITE_HELMET = get("minecraft:netherite_helmet");
     @Nullable
-    public static final ItemType OAK_BUTTON = init();
+    public static final ItemType NETHERITE_HOE = get("minecraft:netherite_hoe");
     @Nullable
-    public static final ItemType OAK_CHEST_BOAT = init();
+    public static final ItemType NETHERITE_HORSE_ARMOR = get("minecraft:netherite_horse_armor");
     @Nullable
-    public static final ItemType OAK_DOOR = init();
+    public static final ItemType NETHERITE_INGOT = get("minecraft:netherite_ingot");
     @Nullable
-    public static final ItemType OAK_FENCE = init();
+    public static final ItemType NETHERITE_LEGGINGS = get("minecraft:netherite_leggings");
     @Nullable
-    public static final ItemType OAK_FENCE_GATE = init();
+    public static final ItemType NETHERITE_NAUTILUS_ARMOR = get("minecraft:netherite_nautilus_armor");
     @Nullable
-    public static final ItemType OAK_HANGING_SIGN = init();
+    public static final ItemType NETHERITE_PICKAXE = get("minecraft:netherite_pickaxe");
     @Nullable
-    public static final ItemType OAK_LEAVES = init();
+    public static final ItemType NETHERITE_SCRAP = get("minecraft:netherite_scrap");
     @Nullable
-    public static final ItemType OAK_LOG = init();
+    public static final ItemType NETHERITE_SHOVEL = get("minecraft:netherite_shovel");
     @Nullable
-    public static final ItemType OAK_PLANKS = init();
+    public static final ItemType NETHERITE_SPEAR = get("minecraft:netherite_spear");
     @Nullable
-    public static final ItemType OAK_PRESSURE_PLATE = init();
+    public static final ItemType NETHERITE_SWORD = get("minecraft:netherite_sword");
     @Nullable
-    public static final ItemType OAK_SAPLING = init();
+    public static final ItemType NETHERITE_UPGRADE_SMITHING_TEMPLATE = get("minecraft:netherite_upgrade_smithing_template");
     @Nullable
-    public static final ItemType OAK_SHELF = init();
+    public static final ItemType NETHERRACK = get("minecraft:netherrack");
     @Nullable
-    public static final ItemType OAK_SIGN = init();
+    public static final ItemType NOTE_BLOCK = get("minecraft:note_block");
     @Nullable
-    public static final ItemType OAK_SLAB = init();
+    public static final ItemType OAK_BOAT = get("minecraft:oak_boat");
     @Nullable
-    public static final ItemType OAK_STAIRS = init();
+    public static final ItemType OAK_BUTTON = get("minecraft:oak_button");
     @Nullable
-    public static final ItemType OAK_TRAPDOOR = init();
+    public static final ItemType OAK_CHEST_BOAT = get("minecraft:oak_chest_boat");
     @Nullable
-    public static final ItemType OAK_WOOD = init();
+    public static final ItemType OAK_DOOR = get("minecraft:oak_door");
     @Nullable
-    public static final ItemType OBSERVER = init();
+    public static final ItemType OAK_FENCE = get("minecraft:oak_fence");
     @Nullable
-    public static final ItemType OBSIDIAN = init();
+    public static final ItemType OAK_FENCE_GATE = get("minecraft:oak_fence_gate");
     @Nullable
-    public static final ItemType OCELOT_SPAWN_EGG = init();
+    public static final ItemType OAK_HANGING_SIGN = get("minecraft:oak_hanging_sign");
     @Nullable
-    public static final ItemType OCHRE_FROGLIGHT = init();
+    public static final ItemType OAK_LEAVES = get("minecraft:oak_leaves");
     @Nullable
-    public static final ItemType OMINOUS_BOTTLE = init();
+    public static final ItemType OAK_LOG = get("minecraft:oak_log");
     @Nullable
-    public static final ItemType OMINOUS_TRIAL_KEY = init();
+    public static final ItemType OAK_PLANKS = get("minecraft:oak_planks");
     @Nullable
-    public static final ItemType OPEN_EYEBLOSSOM = init();
+    public static final ItemType OAK_PRESSURE_PLATE = get("minecraft:oak_pressure_plate");
     @Nullable
-    public static final ItemType ORANGE_BANNER = init();
+    public static final ItemType OAK_SAPLING = get("minecraft:oak_sapling");
     @Nullable
-    public static final ItemType ORANGE_BED = init();
-    @Nullable public static final ItemType ORANGE_BUNDLE = init();
+    public static final ItemType OAK_SHELF = get("minecraft:oak_shelf");
     @Nullable
-    public static final ItemType ORANGE_CANDLE = init();
+    public static final ItemType OAK_SIGN = get("minecraft:oak_sign");
     @Nullable
-    public static final ItemType ORANGE_CARPET = init();
+    public static final ItemType OAK_SLAB = get("minecraft:oak_slab");
     @Nullable
-    public static final ItemType ORANGE_CONCRETE = init();
+    public static final ItemType OAK_STAIRS = get("minecraft:oak_stairs");
     @Nullable
-    public static final ItemType ORANGE_CONCRETE_POWDER = init();
+    public static final ItemType OAK_TRAPDOOR = get("minecraft:oak_trapdoor");
     @Nullable
-    public static final ItemType ORANGE_DYE = init();
+    public static final ItemType OAK_WOOD = get("minecraft:oak_wood");
     @Nullable
-    public static final ItemType ORANGE_GLAZED_TERRACOTTA = init();
+    public static final ItemType OBSERVER = get("minecraft:observer");
     @Nullable
-    public static final ItemType ORANGE_SHULKER_BOX = init();
+    public static final ItemType OBSIDIAN = get("minecraft:obsidian");
     @Nullable
-    public static final ItemType ORANGE_STAINED_GLASS = init();
+    public static final ItemType OCELOT_SPAWN_EGG = get("minecraft:ocelot_spawn_egg");
     @Nullable
-    public static final ItemType ORANGE_STAINED_GLASS_PANE = init();
+    public static final ItemType OCHRE_FROGLIGHT = get("minecraft:ochre_froglight");
     @Nullable
-    public static final ItemType ORANGE_TERRACOTTA = init();
+    public static final ItemType OMINOUS_BOTTLE = get("minecraft:ominous_bottle");
     @Nullable
-    public static final ItemType ORANGE_TULIP = init();
+    public static final ItemType OMINOUS_TRIAL_KEY = get("minecraft:ominous_trial_key");
     @Nullable
-    public static final ItemType ORANGE_WOOL = init();
+    public static final ItemType OPEN_EYEBLOSSOM = get("minecraft:open_eyeblossom");
     @Nullable
-    public static final ItemType OXEYE_DAISY = init();
+    public static final ItemType ORANGE_BANNER = get("minecraft:orange_banner");
     @Nullable
-    public static final ItemType OXIDIZED_CHISELED_COPPER = init();
+    public static final ItemType ORANGE_BED = get("minecraft:orange_bed");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER = init();
+    public static final ItemType ORANGE_BUNDLE = get("minecraft:orange_bundle");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER_BARS = init();
+    public static final ItemType ORANGE_CANDLE = get("minecraft:orange_candle");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER_BULB = init();
+    public static final ItemType ORANGE_CARPET = get("minecraft:orange_carpet");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER_CHAIN = init();
+    public static final ItemType ORANGE_CONCRETE = get("minecraft:orange_concrete");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER_CHEST = init();
+    public static final ItemType ORANGE_CONCRETE_POWDER = get("minecraft:orange_concrete_powder");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER_DOOR = init();
+    public static final ItemType ORANGE_DYE = get("minecraft:orange_dye");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER_GOLEM_STATUE = init();
+    public static final ItemType ORANGE_GLAZED_TERRACOTTA = get("minecraft:orange_glazed_terracotta");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER_GRATE = init();
+    public static final ItemType ORANGE_HARNESS = get("minecraft:orange_harness");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER_LANTERN = init();
+    public static final ItemType ORANGE_SHULKER_BOX = get("minecraft:orange_shulker_box");
     @Nullable
-    public static final ItemType OXIDIZED_COPPER_TRAPDOOR = init();
+    public static final ItemType ORANGE_STAINED_GLASS = get("minecraft:orange_stained_glass");
     @Nullable
-    public static final ItemType OXIDIZED_CUT_COPPER = init();
+    public static final ItemType ORANGE_STAINED_GLASS_PANE = get("minecraft:orange_stained_glass_pane");
     @Nullable
-    public static final ItemType OXIDIZED_CUT_COPPER_SLAB = init();
+    public static final ItemType ORANGE_TERRACOTTA = get("minecraft:orange_terracotta");
     @Nullable
-    public static final ItemType OXIDIZED_CUT_COPPER_STAIRS = init();
+    public static final ItemType ORANGE_TULIP = get("minecraft:orange_tulip");
     @Nullable
-    public static final ItemType OXIDIZED_LIGHTNING_ROD = init();
+    public static final ItemType ORANGE_WOOL = get("minecraft:orange_wool");
     @Nullable
-    public static final ItemType PACKED_ICE = init();
+    public static final ItemType OXEYE_DAISY = get("minecraft:oxeye_daisy");
     @Nullable
-    public static final ItemType PACKED_MUD = init();
+    public static final ItemType OXIDIZED_CHISELED_COPPER = get("minecraft:oxidized_chiseled_copper");
     @Nullable
-    public static final ItemType PAINTING = init();
-    @Nullable public static final ItemType PALE_HANGING_MOSS = init();
-    @Nullable public static final ItemType PALE_MOSS_BLOCK = init();
-    @Nullable public static final ItemType PALE_MOSS_CARPET = init();
-    @Nullable public static final ItemType PALE_OAK_BOAT = init();
-    @Nullable public static final ItemType PALE_OAK_BUTTON = init();
-    @Nullable public static final ItemType PALE_OAK_CHEST_BOAT = init();
-    @Nullable public static final ItemType PALE_OAK_DOOR = init();
-    @Nullable public static final ItemType PALE_OAK_FENCE = init();
-    @Nullable public static final ItemType PALE_OAK_FENCE_GATE = init();
-    @Nullable public static final ItemType PALE_OAK_HANGING_SIGN = init();
-    @Nullable public static final ItemType PALE_OAK_LEAVES = init();
-    @Nullable public static final ItemType PALE_OAK_LOG = init();
-    @Nullable public static final ItemType PALE_OAK_PLANKS = init();
-    @Nullable public static final ItemType PALE_OAK_PRESSURE_PLATE = init();
-    @Nullable public static final ItemType PALE_OAK_SAPLING = init();
-    @Nullable public static final ItemType PALE_OAK_SHELF = init();
-    @Nullable public static final ItemType PALE_OAK_SIGN = init();
-    @Nullable public static final ItemType PALE_OAK_SLAB = init();
-    @Nullable public static final ItemType PALE_OAK_STAIRS = init();
-    @Nullable public static final ItemType PALE_OAK_TRAPDOOR = init();
-    @Nullable public static final ItemType PALE_OAK_WOOD = init();
+    public static final ItemType OXIDIZED_COPPER = get("minecraft:oxidized_copper");
     @Nullable
-    public static final ItemType PANDA_SPAWN_EGG = init();
+    public static final ItemType OXIDIZED_COPPER_BARS = get("minecraft:oxidized_copper_bars");
     @Nullable
-    public static final ItemType PAPER = init();
+    public static final ItemType OXIDIZED_COPPER_BULB = get("minecraft:oxidized_copper_bulb");
     @Nullable
-    public static final ItemType PARCHED_SPAWN_EGG = init();
+    public static final ItemType OXIDIZED_COPPER_CHAIN = get("minecraft:oxidized_copper_chain");
     @Nullable
-    public static final ItemType PARROT_SPAWN_EGG = init();
+    public static final ItemType OXIDIZED_COPPER_CHEST = get("minecraft:oxidized_copper_chest");
     @Nullable
-    public static final ItemType PEARLESCENT_FROGLIGHT = init();
+    public static final ItemType OXIDIZED_COPPER_DOOR = get("minecraft:oxidized_copper_door");
     @Nullable
-    public static final ItemType PEONY = init();
+    public static final ItemType OXIDIZED_COPPER_GOLEM_STATUE = get("minecraft:oxidized_copper_golem_statue");
     @Nullable
-    public static final ItemType PETRIFIED_OAK_SLAB = init();
+    public static final ItemType OXIDIZED_COPPER_GRATE = get("minecraft:oxidized_copper_grate");
     @Nullable
-    public static final ItemType PHANTOM_MEMBRANE = init();
+    public static final ItemType OXIDIZED_COPPER_LANTERN = get("minecraft:oxidized_copper_lantern");
     @Nullable
-    public static final ItemType PHANTOM_SPAWN_EGG = init();
+    public static final ItemType OXIDIZED_COPPER_TRAPDOOR = get("minecraft:oxidized_copper_trapdoor");
     @Nullable
-    public static final ItemType PIG_SPAWN_EGG = init();
+    public static final ItemType OXIDIZED_CUT_COPPER = get("minecraft:oxidized_cut_copper");
     @Nullable
-    public static final ItemType PIGLIN_BANNER_PATTERN = init();
+    public static final ItemType OXIDIZED_CUT_COPPER_SLAB = get("minecraft:oxidized_cut_copper_slab");
     @Nullable
-    public static final ItemType PIGLIN_BRUTE_SPAWN_EGG = init();
+    public static final ItemType OXIDIZED_CUT_COPPER_STAIRS = get("minecraft:oxidized_cut_copper_stairs");
     @Nullable
-    public static final ItemType PIGLIN_HEAD = init();
+    public static final ItemType OXIDIZED_LIGHTNING_ROD = get("minecraft:oxidized_lightning_rod");
     @Nullable
-    public static final ItemType PIGLIN_SPAWN_EGG = init();
+    public static final ItemType PACKED_ICE = get("minecraft:packed_ice");
     @Nullable
-    public static final ItemType PILLAGER_SPAWN_EGG = init();
+    public static final ItemType PACKED_MUD = get("minecraft:packed_mud");
     @Nullable
-    public static final ItemType PINK_BANNER = init();
+    public static final ItemType PAINTING = get("minecraft:painting");
     @Nullable
-    public static final ItemType PINK_BED = init();
-    @Nullable public static final ItemType PINK_BUNDLE = init();
+    public static final ItemType PALE_HANGING_MOSS = get("minecraft:pale_hanging_moss");
     @Nullable
-    public static final ItemType PINK_CANDLE = init();
+    public static final ItemType PALE_MOSS_BLOCK = get("minecraft:pale_moss_block");
     @Nullable
-    public static final ItemType PINK_CARPET = init();
+    public static final ItemType PALE_MOSS_CARPET = get("minecraft:pale_moss_carpet");
     @Nullable
-    public static final ItemType PINK_CONCRETE = init();
+    public static final ItemType PALE_OAK_BOAT = get("minecraft:pale_oak_boat");
     @Nullable
-    public static final ItemType PINK_CONCRETE_POWDER = init();
+    public static final ItemType PALE_OAK_BUTTON = get("minecraft:pale_oak_button");
     @Nullable
-    public static final ItemType PINK_DYE = init();
+    public static final ItemType PALE_OAK_CHEST_BOAT = get("minecraft:pale_oak_chest_boat");
     @Nullable
-    public static final ItemType PINK_GLAZED_TERRACOTTA = init();
+    public static final ItemType PALE_OAK_DOOR = get("minecraft:pale_oak_door");
     @Nullable
-    public static final ItemType PINK_PETALS = init();
+    public static final ItemType PALE_OAK_FENCE = get("minecraft:pale_oak_fence");
     @Nullable
-    public static final ItemType PINK_SHULKER_BOX = init();
+    public static final ItemType PALE_OAK_FENCE_GATE = get("minecraft:pale_oak_fence_gate");
     @Nullable
-    public static final ItemType PINK_STAINED_GLASS = init();
+    public static final ItemType PALE_OAK_HANGING_SIGN = get("minecraft:pale_oak_hanging_sign");
     @Nullable
-    public static final ItemType PINK_STAINED_GLASS_PANE = init();
+    public static final ItemType PALE_OAK_LEAVES = get("minecraft:pale_oak_leaves");
     @Nullable
-    public static final ItemType PINK_TERRACOTTA = init();
+    public static final ItemType PALE_OAK_LOG = get("minecraft:pale_oak_log");
     @Nullable
-    public static final ItemType PINK_TULIP = init();
+    public static final ItemType PALE_OAK_PLANKS = get("minecraft:pale_oak_planks");
     @Nullable
-    public static final ItemType PINK_WOOL = init();
+    public static final ItemType PALE_OAK_PRESSURE_PLATE = get("minecraft:pale_oak_pressure_plate");
     @Nullable
-    public static final ItemType PISTON = init();
+    public static final ItemType PALE_OAK_SAPLING = get("minecraft:pale_oak_sapling");
     @Nullable
-    public static final ItemType PITCHER_PLANT = init();
+    public static final ItemType PALE_OAK_SHELF = get("minecraft:pale_oak_shelf");
     @Nullable
-    public static final ItemType PITCHER_POD = init();
+    public static final ItemType PALE_OAK_SIGN = get("minecraft:pale_oak_sign");
     @Nullable
-    public static final ItemType PLAYER_HEAD = init();
+    public static final ItemType PALE_OAK_SLAB = get("minecraft:pale_oak_slab");
     @Nullable
-    public static final ItemType PLENTY_POTTERY_SHERD = init();
+    public static final ItemType PALE_OAK_STAIRS = get("minecraft:pale_oak_stairs");
     @Nullable
-    public static final ItemType PODZOL = init();
+    public static final ItemType PALE_OAK_TRAPDOOR = get("minecraft:pale_oak_trapdoor");
     @Nullable
-    public static final ItemType POINTED_DRIPSTONE = init();
+    public static final ItemType PALE_OAK_WOOD = get("minecraft:pale_oak_wood");
     @Nullable
-    public static final ItemType POISONOUS_POTATO = init();
+    public static final ItemType PANDA_SPAWN_EGG = get("minecraft:panda_spawn_egg");
     @Nullable
-    public static final ItemType POLAR_BEAR_SPAWN_EGG = init();
+    public static final ItemType PAPER = get("minecraft:paper");
     @Nullable
-    public static final ItemType POLISHED_ANDESITE = init();
+    public static final ItemType PARCHED_SPAWN_EGG = get("minecraft:parched_spawn_egg");
     @Nullable
-    public static final ItemType POLISHED_ANDESITE_SLAB = init();
+    public static final ItemType PARROT_SPAWN_EGG = get("minecraft:parrot_spawn_egg");
     @Nullable
-    public static final ItemType POLISHED_ANDESITE_STAIRS = init();
+    public static final ItemType PEARLESCENT_FROGLIGHT = get("minecraft:pearlescent_froglight");
     @Nullable
-    public static final ItemType POLISHED_BASALT = init();
+    public static final ItemType PEONY = get("minecraft:peony");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE = init();
+    public static final ItemType PETRIFIED_OAK_SLAB = get("minecraft:petrified_oak_slab");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE_BRICK_SLAB = init();
+    public static final ItemType PHANTOM_MEMBRANE = get("minecraft:phantom_membrane");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE_BRICK_STAIRS = init();
+    public static final ItemType PHANTOM_SPAWN_EGG = get("minecraft:phantom_spawn_egg");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE_BRICK_WALL = init();
+    public static final ItemType PIG_SPAWN_EGG = get("minecraft:pig_spawn_egg");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE_BRICKS = init();
+    public static final ItemType PIGLIN_BANNER_PATTERN = get("minecraft:piglin_banner_pattern");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE_BUTTON = init();
+    public static final ItemType PIGLIN_BRUTE_SPAWN_EGG = get("minecraft:piglin_brute_spawn_egg");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE_PRESSURE_PLATE = init();
+    public static final ItemType PIGLIN_HEAD = get("minecraft:piglin_head");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE_SLAB = init();
+    public static final ItemType PIGLIN_SPAWN_EGG = get("minecraft:piglin_spawn_egg");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE_STAIRS = init();
+    public static final ItemType PILLAGER_SPAWN_EGG = get("minecraft:pillager_spawn_egg");
     @Nullable
-    public static final ItemType POLISHED_BLACKSTONE_WALL = init();
+    public static final ItemType PINK_BANNER = get("minecraft:pink_banner");
     @Nullable
-    public static final ItemType POLISHED_CINNABAR = init();
+    public static final ItemType PINK_BED = get("minecraft:pink_bed");
     @Nullable
-    public static final ItemType POLISHED_CINNABAR_SLAB = init();
+    public static final ItemType PINK_BUNDLE = get("minecraft:pink_bundle");
     @Nullable
-    public static final ItemType POLISHED_CINNABAR_STAIRS = init();
+    public static final ItemType PINK_CANDLE = get("minecraft:pink_candle");
     @Nullable
-    public static final ItemType POLISHED_CINNABAR_WALL = init();
+    public static final ItemType PINK_CARPET = get("minecraft:pink_carpet");
     @Nullable
-    public static final ItemType POLISHED_DEEPSLATE = init();
+    public static final ItemType PINK_CONCRETE = get("minecraft:pink_concrete");
     @Nullable
-    public static final ItemType POLISHED_DEEPSLATE_SLAB = init();
+    public static final ItemType PINK_CONCRETE_POWDER = get("minecraft:pink_concrete_powder");
     @Nullable
-    public static final ItemType POLISHED_DEEPSLATE_STAIRS = init();
+    public static final ItemType PINK_DYE = get("minecraft:pink_dye");
     @Nullable
-    public static final ItemType POLISHED_DEEPSLATE_WALL = init();
+    public static final ItemType PINK_GLAZED_TERRACOTTA = get("minecraft:pink_glazed_terracotta");
     @Nullable
-    public static final ItemType POLISHED_DIORITE = init();
+    public static final ItemType PINK_HARNESS = get("minecraft:pink_harness");
     @Nullable
-    public static final ItemType POLISHED_DIORITE_SLAB = init();
+    public static final ItemType PINK_PETALS = get("minecraft:pink_petals");
     @Nullable
-    public static final ItemType POLISHED_DIORITE_STAIRS = init();
+    public static final ItemType PINK_SHULKER_BOX = get("minecraft:pink_shulker_box");
     @Nullable
-    public static final ItemType POLISHED_GRANITE = init();
+    public static final ItemType PINK_STAINED_GLASS = get("minecraft:pink_stained_glass");
     @Nullable
-    public static final ItemType POLISHED_GRANITE_SLAB = init();
+    public static final ItemType PINK_STAINED_GLASS_PANE = get("minecraft:pink_stained_glass_pane");
     @Nullable
-    public static final ItemType POLISHED_GRANITE_STAIRS = init();
+    public static final ItemType PINK_TERRACOTTA = get("minecraft:pink_terracotta");
     @Nullable
-    public static final ItemType POLISHED_SULFUR = init();
+    public static final ItemType PINK_TULIP = get("minecraft:pink_tulip");
     @Nullable
-    public static final ItemType POLISHED_SULFUR_SLAB = init();
+    public static final ItemType PINK_WOOL = get("minecraft:pink_wool");
     @Nullable
-    public static final ItemType POLISHED_SULFUR_STAIRS = init();
+    public static final ItemType PISTON = get("minecraft:piston");
     @Nullable
-    public static final ItemType POLISHED_SULFUR_WALL = init();
+    public static final ItemType PITCHER_PLANT = get("minecraft:pitcher_plant");
     @Nullable
-    public static final ItemType POLISHED_TUFF = init();
+    public static final ItemType PITCHER_POD = get("minecraft:pitcher_pod");
     @Nullable
-    public static final ItemType POLISHED_TUFF_SLAB = init();
+    public static final ItemType PLAYER_HEAD = get("minecraft:player_head");
     @Nullable
-    public static final ItemType POLISHED_TUFF_STAIRS = init();
+    public static final ItemType PLENTY_POTTERY_SHERD = get("minecraft:plenty_pottery_sherd");
     @Nullable
-    public static final ItemType POLISHED_TUFF_WALL = init();
+    public static final ItemType PODZOL = get("minecraft:podzol");
     @Nullable
-    public static final ItemType POPPED_CHORUS_FRUIT = init();
+    public static final ItemType POINTED_DRIPSTONE = get("minecraft:pointed_dripstone");
     @Nullable
-    public static final ItemType POPPY = init();
+    public static final ItemType POISONOUS_POTATO = get("minecraft:poisonous_potato");
     @Nullable
-    public static final ItemType PORKCHOP = init();
+    public static final ItemType POLAR_BEAR_SPAWN_EGG = get("minecraft:polar_bear_spawn_egg");
     @Nullable
-    public static final ItemType POTATO = init();
+    public static final ItemType POLISHED_ANDESITE = get("minecraft:polished_andesite");
     @Nullable
-    public static final ItemType POTENT_SULFUR = init();
+    public static final ItemType POLISHED_ANDESITE_SLAB = get("minecraft:polished_andesite_slab");
     @Nullable
-    public static final ItemType POTION = init();
+    public static final ItemType POLISHED_ANDESITE_STAIRS = get("minecraft:polished_andesite_stairs");
     @Nullable
-    public static final ItemType POWDER_SNOW_BUCKET = init();
+    public static final ItemType POLISHED_BASALT = get("minecraft:polished_basalt");
     @Nullable
-    public static final ItemType POWERED_RAIL = init();
+    public static final ItemType POLISHED_BLACKSTONE = get("minecraft:polished_blackstone");
     @Nullable
-    public static final ItemType PRISMARINE = init();
+    public static final ItemType POLISHED_BLACKSTONE_BRICK_SLAB = get("minecraft:polished_blackstone_brick_slab");
     @Nullable
-    public static final ItemType PRISMARINE_BRICK_SLAB = init();
+    public static final ItemType POLISHED_BLACKSTONE_BRICK_STAIRS = get("minecraft:polished_blackstone_brick_stairs");
     @Nullable
-    public static final ItemType PRISMARINE_BRICK_STAIRS = init();
+    public static final ItemType POLISHED_BLACKSTONE_BRICK_WALL = get("minecraft:polished_blackstone_brick_wall");
     @Nullable
-    public static final ItemType PRISMARINE_BRICKS = init();
+    public static final ItemType POLISHED_BLACKSTONE_BRICKS = get("minecraft:polished_blackstone_bricks");
     @Nullable
-    public static final ItemType PRISMARINE_CRYSTALS = init();
+    public static final ItemType POLISHED_BLACKSTONE_BUTTON = get("minecraft:polished_blackstone_button");
     @Nullable
-    public static final ItemType PRISMARINE_SHARD = init();
+    public static final ItemType POLISHED_BLACKSTONE_PRESSURE_PLATE = get("minecraft:polished_blackstone_pressure_plate");
     @Nullable
-    public static final ItemType PRISMARINE_SLAB = init();
+    public static final ItemType POLISHED_BLACKSTONE_SLAB = get("minecraft:polished_blackstone_slab");
     @Nullable
-    public static final ItemType PRISMARINE_STAIRS = init();
+    public static final ItemType POLISHED_BLACKSTONE_STAIRS = get("minecraft:polished_blackstone_stairs");
     @Nullable
-    public static final ItemType PRISMARINE_WALL = init();
+    public static final ItemType POLISHED_BLACKSTONE_WALL = get("minecraft:polished_blackstone_wall");
     @Nullable
-    public static final ItemType PRIZE_POTTERY_SHERD = init();
+    public static final ItemType POLISHED_CINNABAR = get("minecraft:polished_cinnabar");
     @Nullable
-    public static final ItemType PUFFERFISH = init();
+    public static final ItemType POLISHED_CINNABAR_SLAB = get("minecraft:polished_cinnabar_slab");
     @Nullable
-    public static final ItemType PUFFERFISH_BUCKET = init();
+    public static final ItemType POLISHED_CINNABAR_STAIRS = get("minecraft:polished_cinnabar_stairs");
     @Nullable
-    public static final ItemType PUFFERFISH_SPAWN_EGG = init();
+    public static final ItemType POLISHED_CINNABAR_WALL = get("minecraft:polished_cinnabar_wall");
     @Nullable
-    public static final ItemType PUMPKIN = init();
+    public static final ItemType POLISHED_DEEPSLATE = get("minecraft:polished_deepslate");
     @Nullable
-    public static final ItemType PUMPKIN_PIE = init();
+    public static final ItemType POLISHED_DEEPSLATE_SLAB = get("minecraft:polished_deepslate_slab");
     @Nullable
-    public static final ItemType PUMPKIN_SEEDS = init();
+    public static final ItemType POLISHED_DEEPSLATE_STAIRS = get("minecraft:polished_deepslate_stairs");
     @Nullable
-    public static final ItemType PURPLE_BANNER = init();
+    public static final ItemType POLISHED_DEEPSLATE_WALL = get("minecraft:polished_deepslate_wall");
     @Nullable
-    public static final ItemType PURPLE_BED = init();
-    @Nullable public static final ItemType PURPLE_BUNDLE = init();
+    public static final ItemType POLISHED_DIORITE = get("minecraft:polished_diorite");
     @Nullable
-    public static final ItemType PURPLE_CANDLE = init();
+    public static final ItemType POLISHED_DIORITE_SLAB = get("minecraft:polished_diorite_slab");
     @Nullable
-    public static final ItemType PURPLE_CARPET = init();
+    public static final ItemType POLISHED_DIORITE_STAIRS = get("minecraft:polished_diorite_stairs");
     @Nullable
-    public static final ItemType PURPLE_CONCRETE = init();
+    public static final ItemType POLISHED_GRANITE = get("minecraft:polished_granite");
     @Nullable
-    public static final ItemType PURPLE_CONCRETE_POWDER = init();
+    public static final ItemType POLISHED_GRANITE_SLAB = get("minecraft:polished_granite_slab");
     @Nullable
-    public static final ItemType PURPLE_DYE = init();
+    public static final ItemType POLISHED_GRANITE_STAIRS = get("minecraft:polished_granite_stairs");
     @Nullable
-    public static final ItemType PURPLE_GLAZED_TERRACOTTA = init();
+    public static final ItemType POLISHED_SULFUR = get("minecraft:polished_sulfur");
     @Nullable
-    public static final ItemType PURPLE_SHULKER_BOX = init();
+    public static final ItemType POLISHED_SULFUR_SLAB = get("minecraft:polished_sulfur_slab");
     @Nullable
-    public static final ItemType PURPLE_STAINED_GLASS = init();
+    public static final ItemType POLISHED_SULFUR_STAIRS = get("minecraft:polished_sulfur_stairs");
     @Nullable
-    public static final ItemType PURPLE_STAINED_GLASS_PANE = init();
+    public static final ItemType POLISHED_SULFUR_WALL = get("minecraft:polished_sulfur_wall");
     @Nullable
-    public static final ItemType PURPLE_TERRACOTTA = init();
+    public static final ItemType POLISHED_TUFF = get("minecraft:polished_tuff");
     @Nullable
-    public static final ItemType PURPLE_WOOL = init();
+    public static final ItemType POLISHED_TUFF_SLAB = get("minecraft:polished_tuff_slab");
     @Nullable
-    public static final ItemType PURPUR_BLOCK = init();
+    public static final ItemType POLISHED_TUFF_STAIRS = get("minecraft:polished_tuff_stairs");
     @Nullable
-    public static final ItemType PURPUR_PILLAR = init();
+    public static final ItemType POLISHED_TUFF_WALL = get("minecraft:polished_tuff_wall");
     @Nullable
-    public static final ItemType PURPUR_SLAB = init();
+    public static final ItemType POPPED_CHORUS_FRUIT = get("minecraft:popped_chorus_fruit");
     @Nullable
-    public static final ItemType PURPUR_STAIRS = init();
+    public static final ItemType POPPY = get("minecraft:poppy");
     @Nullable
-    public static final ItemType QUARTZ = init();
+    public static final ItemType PORKCHOP = get("minecraft:porkchop");
     @Nullable
-    public static final ItemType QUARTZ_BLOCK = init();
+    public static final ItemType POTATO = get("minecraft:potato");
     @Nullable
-    public static final ItemType QUARTZ_BRICKS = init();
+    public static final ItemType POTENT_SULFUR = get("minecraft:potent_sulfur");
     @Nullable
-    public static final ItemType QUARTZ_PILLAR = init();
+    public static final ItemType POTION = get("minecraft:potion");
     @Nullable
-    public static final ItemType QUARTZ_SLAB = init();
+    public static final ItemType POWDER_SNOW_BUCKET = get("minecraft:powder_snow_bucket");
     @Nullable
-    public static final ItemType QUARTZ_STAIRS = init();
+    public static final ItemType POWERED_RAIL = get("minecraft:powered_rail");
     @Nullable
-    public static final ItemType RABBIT = init();
+    public static final ItemType PRISMARINE = get("minecraft:prismarine");
     @Nullable
-    public static final ItemType RABBIT_FOOT = init();
+    public static final ItemType PRISMARINE_BRICK_SLAB = get("minecraft:prismarine_brick_slab");
     @Nullable
-    public static final ItemType RABBIT_HIDE = init();
+    public static final ItemType PRISMARINE_BRICK_STAIRS = get("minecraft:prismarine_brick_stairs");
     @Nullable
-    public static final ItemType RABBIT_SPAWN_EGG = init();
+    public static final ItemType PRISMARINE_BRICKS = get("minecraft:prismarine_bricks");
     @Nullable
-    public static final ItemType RABBIT_STEW = init();
+    public static final ItemType PRISMARINE_CRYSTALS = get("minecraft:prismarine_crystals");
     @Nullable
-    public static final ItemType RAIL = init();
+    public static final ItemType PRISMARINE_SHARD = get("minecraft:prismarine_shard");
     @Nullable
-    public static final ItemType RAISER_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType PRISMARINE_SLAB = get("minecraft:prismarine_slab");
     @Nullable
-    public static final ItemType RAVAGER_SPAWN_EGG = init();
+    public static final ItemType PRISMARINE_STAIRS = get("minecraft:prismarine_stairs");
     @Nullable
-    public static final ItemType RAW_COPPER = init();
+    public static final ItemType PRISMARINE_WALL = get("minecraft:prismarine_wall");
     @Nullable
-    public static final ItemType RAW_COPPER_BLOCK = init();
+    public static final ItemType PRIZE_POTTERY_SHERD = get("minecraft:prize_pottery_sherd");
     @Nullable
-    public static final ItemType RAW_GOLD = init();
+    public static final ItemType PUFFERFISH = get("minecraft:pufferfish");
     @Nullable
-    public static final ItemType RAW_GOLD_BLOCK = init();
+    public static final ItemType PUFFERFISH_BUCKET = get("minecraft:pufferfish_bucket");
     @Nullable
-    public static final ItemType RAW_IRON = init();
+    public static final ItemType PUFFERFISH_SPAWN_EGG = get("minecraft:pufferfish_spawn_egg");
     @Nullable
-    public static final ItemType RAW_IRON_BLOCK = init();
+    public static final ItemType PUMPKIN = get("minecraft:pumpkin");
     @Nullable
-    public static final ItemType RECOVERY_COMPASS = init();
+    public static final ItemType PUMPKIN_PIE = get("minecraft:pumpkin_pie");
     @Nullable
-    public static final ItemType RED_BANNER = init();
+    public static final ItemType PUMPKIN_SEEDS = get("minecraft:pumpkin_seeds");
     @Nullable
-    public static final ItemType RED_BED = init();
-    @Nullable public static final ItemType RED_BUNDLE = init();
+    public static final ItemType PURPLE_BANNER = get("minecraft:purple_banner");
     @Nullable
-    public static final ItemType RED_CANDLE = init();
+    public static final ItemType PURPLE_BED = get("minecraft:purple_bed");
     @Nullable
-    public static final ItemType RED_CARPET = init();
+    public static final ItemType PURPLE_BUNDLE = get("minecraft:purple_bundle");
     @Nullable
-    public static final ItemType RED_CONCRETE = init();
+    public static final ItemType PURPLE_CANDLE = get("minecraft:purple_candle");
     @Nullable
-    public static final ItemType RED_CONCRETE_POWDER = init();
+    public static final ItemType PURPLE_CARPET = get("minecraft:purple_carpet");
     @Nullable
-    public static final ItemType RED_DYE = init();
+    public static final ItemType PURPLE_CONCRETE = get("minecraft:purple_concrete");
     @Nullable
-    public static final ItemType RED_GLAZED_TERRACOTTA = init();
+    public static final ItemType PURPLE_CONCRETE_POWDER = get("minecraft:purple_concrete_powder");
     @Nullable
-    public static final ItemType RED_MUSHROOM = init();
+    public static final ItemType PURPLE_DYE = get("minecraft:purple_dye");
     @Nullable
-    public static final ItemType RED_MUSHROOM_BLOCK = init();
+    public static final ItemType PURPLE_GLAZED_TERRACOTTA = get("minecraft:purple_glazed_terracotta");
     @Nullable
-    public static final ItemType RED_NETHER_BRICK_SLAB = init();
+    public static final ItemType PURPLE_HARNESS = get("minecraft:purple_harness");
     @Nullable
-    public static final ItemType RED_NETHER_BRICK_STAIRS = init();
+    public static final ItemType PURPLE_SHULKER_BOX = get("minecraft:purple_shulker_box");
     @Nullable
-    public static final ItemType RED_NETHER_BRICK_WALL = init();
+    public static final ItemType PURPLE_STAINED_GLASS = get("minecraft:purple_stained_glass");
     @Nullable
-    public static final ItemType RED_NETHER_BRICKS = init();
+    public static final ItemType PURPLE_STAINED_GLASS_PANE = get("minecraft:purple_stained_glass_pane");
     @Nullable
-    public static final ItemType RED_SAND = init();
+    public static final ItemType PURPLE_TERRACOTTA = get("minecraft:purple_terracotta");
     @Nullable
-    public static final ItemType RED_SANDSTONE = init();
+    public static final ItemType PURPLE_WOOL = get("minecraft:purple_wool");
     @Nullable
-    public static final ItemType RED_SANDSTONE_SLAB = init();
+    public static final ItemType PURPUR_BLOCK = get("minecraft:purpur_block");
     @Nullable
-    public static final ItemType RED_SANDSTONE_STAIRS = init();
+    public static final ItemType PURPUR_PILLAR = get("minecraft:purpur_pillar");
     @Nullable
-    public static final ItemType RED_SANDSTONE_WALL = init();
+    public static final ItemType PURPUR_SLAB = get("minecraft:purpur_slab");
     @Nullable
-    public static final ItemType RED_SHULKER_BOX = init();
+    public static final ItemType PURPUR_STAIRS = get("minecraft:purpur_stairs");
     @Nullable
-    public static final ItemType RED_STAINED_GLASS = init();
+    public static final ItemType QUARTZ = get("minecraft:quartz");
     @Nullable
-    public static final ItemType RED_STAINED_GLASS_PANE = init();
+    public static final ItemType QUARTZ_BLOCK = get("minecraft:quartz_block");
     @Nullable
-    public static final ItemType RED_TERRACOTTA = init();
+    public static final ItemType QUARTZ_BRICKS = get("minecraft:quartz_bricks");
     @Nullable
-    public static final ItemType RED_TULIP = init();
+    public static final ItemType QUARTZ_PILLAR = get("minecraft:quartz_pillar");
     @Nullable
-    public static final ItemType RED_WOOL = init();
+    public static final ItemType QUARTZ_SLAB = get("minecraft:quartz_slab");
     @Nullable
-    public static final ItemType REDSTONE = init();
+    public static final ItemType QUARTZ_STAIRS = get("minecraft:quartz_stairs");
     @Nullable
-    public static final ItemType REDSTONE_BLOCK = init();
+    public static final ItemType RABBIT = get("minecraft:rabbit");
     @Nullable
-    public static final ItemType REDSTONE_LAMP = init();
+    public static final ItemType RABBIT_FOOT = get("minecraft:rabbit_foot");
     @Nullable
-    public static final ItemType REDSTONE_ORE = init();
+    public static final ItemType RABBIT_HIDE = get("minecraft:rabbit_hide");
     @Nullable
-    public static final ItemType REDSTONE_TORCH = init();
+    public static final ItemType RABBIT_SPAWN_EGG = get("minecraft:rabbit_spawn_egg");
     @Nullable
-    public static final ItemType REINFORCED_DEEPSLATE = init();
+    public static final ItemType RABBIT_STEW = get("minecraft:rabbit_stew");
     @Nullable
-    public static final ItemType REPEATER = init();
+    public static final ItemType RAIL = get("minecraft:rail");
     @Nullable
-    public static final ItemType REPEATING_COMMAND_BLOCK = init();
+    public static final ItemType RAISER_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:raiser_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType RESIN_BLOCK = init();
+    public static final ItemType RAVAGER_SPAWN_EGG = get("minecraft:ravager_spawn_egg");
     @Nullable
-    public static final ItemType RESIN_BRICK = init();
+    public static final ItemType RAW_COPPER = get("minecraft:raw_copper");
     @Nullable
-    public static final ItemType RESIN_BRICK_SLAB = init();
+    public static final ItemType RAW_COPPER_BLOCK = get("minecraft:raw_copper_block");
     @Nullable
-    public static final ItemType RESIN_BRICK_STAIRS = init();
+    public static final ItemType RAW_GOLD = get("minecraft:raw_gold");
     @Nullable
-    public static final ItemType RESIN_BRICK_WALL = init();
+    public static final ItemType RAW_GOLD_BLOCK = get("minecraft:raw_gold_block");
     @Nullable
-    public static final ItemType RESIN_BRICKS = init();
+    public static final ItemType RAW_IRON = get("minecraft:raw_iron");
     @Nullable
-    public static final ItemType RESIN_CLUMP = init();
+    public static final ItemType RAW_IRON_BLOCK = get("minecraft:raw_iron_block");
     @Nullable
-    public static final ItemType RESPAWN_ANCHOR = init();
+    public static final ItemType RECOVERY_COMPASS = get("minecraft:recovery_compass");
     @Nullable
-    public static final ItemType RIB_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType RED_BANNER = get("minecraft:red_banner");
     @Nullable
-    public static final ItemType ROOTED_DIRT = init();
+    public static final ItemType RED_BED = get("minecraft:red_bed");
     @Nullable
-    public static final ItemType ROSE_BUSH = init();
+    public static final ItemType RED_BUNDLE = get("minecraft:red_bundle");
+    @Nullable
+    public static final ItemType RED_CANDLE = get("minecraft:red_candle");
+    @Nullable
+    public static final ItemType RED_CARPET = get("minecraft:red_carpet");
+    @Nullable
+    public static final ItemType RED_CONCRETE = get("minecraft:red_concrete");
+    @Nullable
+    public static final ItemType RED_CONCRETE_POWDER = get("minecraft:red_concrete_powder");
+    @Nullable
+    public static final ItemType RED_DYE = get("minecraft:red_dye");
+    @Nullable
+    public static final ItemType RED_GLAZED_TERRACOTTA = get("minecraft:red_glazed_terracotta");
+    @Nullable
+    public static final ItemType RED_HARNESS = get("minecraft:red_harness");
+    @Nullable
+    public static final ItemType RED_MUSHROOM = get("minecraft:red_mushroom");
+    @Nullable
+    public static final ItemType RED_MUSHROOM_BLOCK = get("minecraft:red_mushroom_block");
+    @Nullable
+    public static final ItemType RED_NETHER_BRICK_SLAB = get("minecraft:red_nether_brick_slab");
+    @Nullable
+    public static final ItemType RED_NETHER_BRICK_STAIRS = get("minecraft:red_nether_brick_stairs");
+    @Nullable
+    public static final ItemType RED_NETHER_BRICK_WALL = get("minecraft:red_nether_brick_wall");
+    @Nullable
+    public static final ItemType RED_NETHER_BRICKS = get("minecraft:red_nether_bricks");
+    @Nullable
+    public static final ItemType RED_SAND = get("minecraft:red_sand");
+    @Nullable
+    public static final ItemType RED_SANDSTONE = get("minecraft:red_sandstone");
+    @Nullable
+    public static final ItemType RED_SANDSTONE_SLAB = get("minecraft:red_sandstone_slab");
+    @Nullable
+    public static final ItemType RED_SANDSTONE_STAIRS = get("minecraft:red_sandstone_stairs");
+    @Nullable
+    public static final ItemType RED_SANDSTONE_WALL = get("minecraft:red_sandstone_wall");
+    @Nullable
+    public static final ItemType RED_SHULKER_BOX = get("minecraft:red_shulker_box");
+    @Nullable
+    public static final ItemType RED_STAINED_GLASS = get("minecraft:red_stained_glass");
+    @Nullable
+    public static final ItemType RED_STAINED_GLASS_PANE = get("minecraft:red_stained_glass_pane");
+    @Nullable
+    public static final ItemType RED_TERRACOTTA = get("minecraft:red_terracotta");
+    @Nullable
+    public static final ItemType RED_TULIP = get("minecraft:red_tulip");
+    @Nullable
+    public static final ItemType RED_WOOL = get("minecraft:red_wool");
+    @Nullable
+    public static final ItemType REDSTONE = get("minecraft:redstone");
+    @Nullable
+    public static final ItemType REDSTONE_BLOCK = get("minecraft:redstone_block");
+    @Nullable
+    public static final ItemType REDSTONE_LAMP = get("minecraft:redstone_lamp");
+    @Nullable
+    public static final ItemType REDSTONE_ORE = get("minecraft:redstone_ore");
+    @Nullable
+    public static final ItemType REDSTONE_TORCH = get("minecraft:redstone_torch");
+    @Nullable
+    public static final ItemType REINFORCED_DEEPSLATE = get("minecraft:reinforced_deepslate");
+    @Nullable
+    public static final ItemType REPEATER = get("minecraft:repeater");
+    @Nullable
+    public static final ItemType REPEATING_COMMAND_BLOCK = get("minecraft:repeating_command_block");
+    @Nullable
+    public static final ItemType RESIN_BLOCK = get("minecraft:resin_block");
+    @Nullable
+    public static final ItemType RESIN_BRICK = get("minecraft:resin_brick");
+    @Nullable
+    public static final ItemType RESIN_BRICK_SLAB = get("minecraft:resin_brick_slab");
+    @Nullable
+    public static final ItemType RESIN_BRICK_STAIRS = get("minecraft:resin_brick_stairs");
+    @Nullable
+    public static final ItemType RESIN_BRICK_WALL = get("minecraft:resin_brick_wall");
+    @Nullable
+    public static final ItemType RESIN_BRICKS = get("minecraft:resin_bricks");
+    @Nullable
+    public static final ItemType RESIN_CLUMP = get("minecraft:resin_clump");
+    @Nullable
+    public static final ItemType RESPAWN_ANCHOR = get("minecraft:respawn_anchor");
+    @Nullable
+    public static final ItemType RIB_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:rib_armor_trim_smithing_template");
+    @Nullable
+    public static final ItemType ROOTED_DIRT = get("minecraft:rooted_dirt");
+    @Nullable
+    public static final ItemType ROSE_BUSH = get("minecraft:rose_bush");
     @Deprecated
     @Nullable
-    public static final ItemType ROSE_RED = init();
+    public static final ItemType ROSE_RED = get("minecraft:rose_red");
     @Nullable
-    public static final ItemType ROTTEN_FLESH = init();
+    public static final ItemType ROTTEN_FLESH = get("minecraft:rotten_flesh");
     @Nullable
-    public static final ItemType SADDLE = init();
+    public static final ItemType SADDLE = get("minecraft:saddle");
     @Nullable
-    public static final ItemType SALMON = init();
+    public static final ItemType SALMON = get("minecraft:salmon");
     @Nullable
-    public static final ItemType SALMON_BUCKET = init();
+    public static final ItemType SALMON_BUCKET = get("minecraft:salmon_bucket");
     @Nullable
-    public static final ItemType SALMON_SPAWN_EGG = init();
+    public static final ItemType SALMON_SPAWN_EGG = get("minecraft:salmon_spawn_egg");
     @Nullable
-    public static final ItemType SAND = init();
+    public static final ItemType SAND = get("minecraft:sand");
     @Nullable
-    public static final ItemType SANDSTONE = init();
+    public static final ItemType SANDSTONE = get("minecraft:sandstone");
     @Nullable
-    public static final ItemType SANDSTONE_SLAB = init();
+    public static final ItemType SANDSTONE_SLAB = get("minecraft:sandstone_slab");
     @Nullable
-    public static final ItemType SANDSTONE_STAIRS = init();
+    public static final ItemType SANDSTONE_STAIRS = get("minecraft:sandstone_stairs");
     @Nullable
-    public static final ItemType SANDSTONE_WALL = init();
+    public static final ItemType SANDSTONE_WALL = get("minecraft:sandstone_wall");
     @Nullable
-    public static final ItemType SCAFFOLDING = init();
+    public static final ItemType SCAFFOLDING = get("minecraft:scaffolding");
     @Nullable
-    public static final ItemType SCRAPE_POTTERY_SHERD = init();
+    public static final ItemType SCRAPE_POTTERY_SHERD = get("minecraft:scrape_pottery_sherd");
     @Nullable
-    public static final ItemType SCULK = init();
+    public static final ItemType SCULK = get("minecraft:sculk");
     @Nullable
-    public static final ItemType SCULK_CATALYST = init();
+    public static final ItemType SCULK_CATALYST = get("minecraft:sculk_catalyst");
     @Nullable
-    public static final ItemType SCULK_SENSOR = init();
+    public static final ItemType SCULK_SENSOR = get("minecraft:sculk_sensor");
     @Nullable
-    public static final ItemType SCULK_SHRIEKER = init();
+    public static final ItemType SCULK_SHRIEKER = get("minecraft:sculk_shrieker");
     @Nullable
-    public static final ItemType SCULK_VEIN = init();
+    public static final ItemType SCULK_VEIN = get("minecraft:sculk_vein");
     @Nullable
     @Deprecated
-    public static final ItemType SCUTE = init();
+    public static final ItemType SCUTE = get("minecraft:scute");
     @Nullable
-    public static final ItemType SEA_LANTERN = init();
+    public static final ItemType SEA_LANTERN = get("minecraft:sea_lantern");
     @Nullable
-    public static final ItemType SEA_PICKLE = init();
+    public static final ItemType SEA_PICKLE = get("minecraft:sea_pickle");
     @Nullable
-    public static final ItemType SEAGRASS = init();
+    public static final ItemType SEAGRASS = get("minecraft:seagrass");
     @Nullable
-    public static final ItemType SENTRY_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType SENTRY_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:sentry_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType SHAPER_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType SHAPER_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:shaper_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType SHEAF_POTTERY_SHERD = init();
+    public static final ItemType SHEAF_POTTERY_SHERD = get("minecraft:sheaf_pottery_sherd");
     @Nullable
-    public static final ItemType SHEARS = init();
+    public static final ItemType SHEARS = get("minecraft:shears");
     @Nullable
-    public static final ItemType SHEEP_SPAWN_EGG = init();
+    public static final ItemType SHEEP_SPAWN_EGG = get("minecraft:sheep_spawn_egg");
     @Nullable
-    public static final ItemType SHELTER_POTTERY_SHERD = init();
+    public static final ItemType SHELTER_POTTERY_SHERD = get("minecraft:shelter_pottery_sherd");
     @Nullable
-    public static final ItemType SHIELD = init();
+    public static final ItemType SHIELD = get("minecraft:shield");
     @Nullable
-    public static final ItemType SHORT_DRY_GRASS = init();
+    public static final ItemType SHORT_DRY_GRASS = get("minecraft:short_dry_grass");
     @Nullable
-    public static final ItemType SHORT_GRASS = init();
+    public static final ItemType SHORT_GRASS = get("minecraft:short_grass");
     @Nullable
-    public static final ItemType SHROOMLIGHT = init();
+    public static final ItemType SHROOMLIGHT = get("minecraft:shroomlight");
     @Nullable
-    public static final ItemType SHULKER_BOX = init();
+    public static final ItemType SHULKER_BOX = get("minecraft:shulker_box");
     @Nullable
-    public static final ItemType SHULKER_SHELL = init();
+    public static final ItemType SHULKER_SHELL = get("minecraft:shulker_shell");
     @Nullable
-    public static final ItemType SHULKER_SPAWN_EGG = init();
+    public static final ItemType SHULKER_SPAWN_EGG = get("minecraft:shulker_spawn_egg");
     @Deprecated
     @Nullable
-    public static final ItemType SIGN = init();
+    public static final ItemType SIGN = get("minecraft:sign");
     @Nullable
-    public static final ItemType SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:silence_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType SILVERFISH_SPAWN_EGG = init();
+    public static final ItemType SILVERFISH_SPAWN_EGG = get("minecraft:silverfish_spawn_egg");
     @Nullable
-    public static final ItemType SKELETON_HORSE_SPAWN_EGG = init();
+    public static final ItemType SKELETON_HORSE_SPAWN_EGG = get("minecraft:skeleton_horse_spawn_egg");
     @Nullable
-    public static final ItemType SKELETON_SKULL = init();
+    public static final ItemType SKELETON_SKULL = get("minecraft:skeleton_skull");
     @Nullable
-    public static final ItemType SKELETON_SPAWN_EGG = init();
+    public static final ItemType SKELETON_SPAWN_EGG = get("minecraft:skeleton_spawn_egg");
     @Nullable
-    public static final ItemType SKULL_BANNER_PATTERN = init();
+    public static final ItemType SKULL_BANNER_PATTERN = get("minecraft:skull_banner_pattern");
     @Nullable
-    public static final ItemType SKULL_POTTERY_SHERD = init();
+    public static final ItemType SKULL_POTTERY_SHERD = get("minecraft:skull_pottery_sherd");
     @Nullable
-    public static final ItemType SLIME_BALL = init();
+    public static final ItemType SLIME_BALL = get("minecraft:slime_ball");
     @Nullable
-    public static final ItemType SLIME_BLOCK = init();
+    public static final ItemType SLIME_BLOCK = get("minecraft:slime_block");
     @Nullable
-    public static final ItemType SLIME_SPAWN_EGG = init();
+    public static final ItemType SLIME_SPAWN_EGG = get("minecraft:slime_spawn_egg");
     @Nullable
-    public static final ItemType SMALL_AMETHYST_BUD = init();
+    public static final ItemType SMALL_AMETHYST_BUD = get("minecraft:small_amethyst_bud");
     @Nullable
-    public static final ItemType SMALL_DRIPLEAF = init();
+    public static final ItemType SMALL_DRIPLEAF = get("minecraft:small_dripleaf");
     @Nullable
-    public static final ItemType SMITHING_TABLE = init();
+    public static final ItemType SMITHING_TABLE = get("minecraft:smithing_table");
     @Nullable
-    public static final ItemType SMOKER = init();
+    public static final ItemType SMOKER = get("minecraft:smoker");
     @Nullable
-    public static final ItemType SMOOTH_BASALT = init();
+    public static final ItemType SMOOTH_BASALT = get("minecraft:smooth_basalt");
     @Nullable
-    public static final ItemType SMOOTH_QUARTZ = init();
+    public static final ItemType SMOOTH_QUARTZ = get("minecraft:smooth_quartz");
     @Nullable
-    public static final ItemType SMOOTH_QUARTZ_SLAB = init();
+    public static final ItemType SMOOTH_QUARTZ_SLAB = get("minecraft:smooth_quartz_slab");
     @Nullable
-    public static final ItemType SMOOTH_QUARTZ_STAIRS = init();
+    public static final ItemType SMOOTH_QUARTZ_STAIRS = get("minecraft:smooth_quartz_stairs");
     @Nullable
-    public static final ItemType SMOOTH_RED_SANDSTONE = init();
+    public static final ItemType SMOOTH_RED_SANDSTONE = get("minecraft:smooth_red_sandstone");
     @Nullable
-    public static final ItemType SMOOTH_RED_SANDSTONE_SLAB = init();
+    public static final ItemType SMOOTH_RED_SANDSTONE_SLAB = get("minecraft:smooth_red_sandstone_slab");
     @Nullable
-    public static final ItemType SMOOTH_RED_SANDSTONE_STAIRS = init();
+    public static final ItemType SMOOTH_RED_SANDSTONE_STAIRS = get("minecraft:smooth_red_sandstone_stairs");
     @Nullable
-    public static final ItemType SMOOTH_SANDSTONE = init();
+    public static final ItemType SMOOTH_SANDSTONE = get("minecraft:smooth_sandstone");
     @Nullable
-    public static final ItemType SMOOTH_SANDSTONE_SLAB = init();
+    public static final ItemType SMOOTH_SANDSTONE_SLAB = get("minecraft:smooth_sandstone_slab");
     @Nullable
-    public static final ItemType SMOOTH_SANDSTONE_STAIRS = init();
+    public static final ItemType SMOOTH_SANDSTONE_STAIRS = get("minecraft:smooth_sandstone_stairs");
     @Nullable
-    public static final ItemType SMOOTH_STONE = init();
+    public static final ItemType SMOOTH_STONE = get("minecraft:smooth_stone");
     @Nullable
-    public static final ItemType SMOOTH_STONE_SLAB = init();
+    public static final ItemType SMOOTH_STONE_SLAB = get("minecraft:smooth_stone_slab");
     @Nullable
-    public static final ItemType SNIFFER_EGG = init();
+    public static final ItemType SNIFFER_EGG = get("minecraft:sniffer_egg");
     @Nullable
-    public static final ItemType SNIFFER_SPAWN_EGG = init();
+    public static final ItemType SNIFFER_SPAWN_EGG = get("minecraft:sniffer_spawn_egg");
     @Nullable
-    public static final ItemType SNORT_POTTERY_SHERD = init();
+    public static final ItemType SNORT_POTTERY_SHERD = get("minecraft:snort_pottery_sherd");
     @Nullable
-    public static final ItemType SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:snout_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType SNOW = init();
+    public static final ItemType SNOW = get("minecraft:snow");
     @Nullable
-    public static final ItemType SNOW_BLOCK = init();
+    public static final ItemType SNOW_BLOCK = get("minecraft:snow_block");
     @Nullable
-    public static final ItemType SNOW_GOLEM_SPAWN_EGG = init();
+    public static final ItemType SNOW_GOLEM_SPAWN_EGG = get("minecraft:snow_golem_spawn_egg");
     @Nullable
-    public static final ItemType SNOWBALL = init();
+    public static final ItemType SNOWBALL = get("minecraft:snowball");
     @Nullable
-    public static final ItemType SOUL_CAMPFIRE = init();
+    public static final ItemType SOUL_CAMPFIRE = get("minecraft:soul_campfire");
     @Nullable
-    public static final ItemType SOUL_LANTERN = init();
+    public static final ItemType SOUL_LANTERN = get("minecraft:soul_lantern");
     @Nullable
-    public static final ItemType SOUL_SAND = init();
+    public static final ItemType SOUL_SAND = get("minecraft:soul_sand");
     @Nullable
-    public static final ItemType SOUL_SOIL = init();
+    public static final ItemType SOUL_SOIL = get("minecraft:soul_soil");
     @Nullable
-    public static final ItemType SOUL_TORCH = init();
+    public static final ItemType SOUL_TORCH = get("minecraft:soul_torch");
     @Nullable
-    public static final ItemType SPAWNER = init();
+    public static final ItemType SPAWNER = get("minecraft:spawner");
     @Nullable
-    public static final ItemType SPECTRAL_ARROW = init();
+    public static final ItemType SPECTRAL_ARROW = get("minecraft:spectral_arrow");
     @Nullable
-    public static final ItemType SPIDER_EYE = init();
+    public static final ItemType SPIDER_EYE = get("minecraft:spider_eye");
     @Nullable
-    public static final ItemType SPIDER_SPAWN_EGG = init();
+    public static final ItemType SPIDER_SPAWN_EGG = get("minecraft:spider_spawn_egg");
     @Nullable
-    public static final ItemType SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:spire_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType SPLASH_POTION = init();
+    public static final ItemType SPLASH_POTION = get("minecraft:splash_potion");
     @Nullable
-    public static final ItemType SPONGE = init();
+    public static final ItemType SPONGE = get("minecraft:sponge");
     @Nullable
-    public static final ItemType SPORE_BLOSSOM = init();
+    public static final ItemType SPORE_BLOSSOM = get("minecraft:spore_blossom");
     @Nullable
-    public static final ItemType SPRUCE_BOAT = init();
+    public static final ItemType SPRUCE_BOAT = get("minecraft:spruce_boat");
     @Nullable
-    public static final ItemType SPRUCE_CHEST_BOAT = init();
+    public static final ItemType SPRUCE_BUTTON = get("minecraft:spruce_button");
     @Nullable
-    public static final ItemType SPRUCE_BUTTON = init();
+    public static final ItemType SPRUCE_CHEST_BOAT = get("minecraft:spruce_chest_boat");
     @Nullable
-    public static final ItemType SPRUCE_DOOR = init();
+    public static final ItemType SPRUCE_DOOR = get("minecraft:spruce_door");
     @Nullable
-    public static final ItemType SPRUCE_FENCE = init();
+    public static final ItemType SPRUCE_FENCE = get("minecraft:spruce_fence");
     @Nullable
-    public static final ItemType SPRUCE_FENCE_GATE = init();
+    public static final ItemType SPRUCE_FENCE_GATE = get("minecraft:spruce_fence_gate");
     @Nullable
-    public static final ItemType SPRUCE_HANGING_SIGN = init();
+    public static final ItemType SPRUCE_HANGING_SIGN = get("minecraft:spruce_hanging_sign");
     @Nullable
-    public static final ItemType SPRUCE_LEAVES = init();
+    public static final ItemType SPRUCE_LEAVES = get("minecraft:spruce_leaves");
     @Nullable
-    public static final ItemType SPRUCE_LOG = init();
+    public static final ItemType SPRUCE_LOG = get("minecraft:spruce_log");
     @Nullable
-    public static final ItemType SPRUCE_PLANKS = init();
+    public static final ItemType SPRUCE_PLANKS = get("minecraft:spruce_planks");
     @Nullable
-    public static final ItemType SPRUCE_PRESSURE_PLATE = init();
+    public static final ItemType SPRUCE_PRESSURE_PLATE = get("minecraft:spruce_pressure_plate");
     @Nullable
-    public static final ItemType SPRUCE_SAPLING = init();
+    public static final ItemType SPRUCE_SAPLING = get("minecraft:spruce_sapling");
     @Nullable
-    public static final ItemType SPRUCE_SHELF = init();
+    public static final ItemType SPRUCE_SHELF = get("minecraft:spruce_shelf");
     @Nullable
-    public static final ItemType SPRUCE_SIGN = init();
+    public static final ItemType SPRUCE_SIGN = get("minecraft:spruce_sign");
     @Nullable
-    public static final ItemType SPRUCE_SLAB = init();
+    public static final ItemType SPRUCE_SLAB = get("minecraft:spruce_slab");
     @Nullable
-    public static final ItemType SPRUCE_STAIRS = init();
+    public static final ItemType SPRUCE_STAIRS = get("minecraft:spruce_stairs");
     @Nullable
-    public static final ItemType SPRUCE_TRAPDOOR = init();
+    public static final ItemType SPRUCE_TRAPDOOR = get("minecraft:spruce_trapdoor");
     @Nullable
-    public static final ItemType SPRUCE_WOOD = init();
+    public static final ItemType SPRUCE_WOOD = get("minecraft:spruce_wood");
     @Nullable
-    public static final ItemType SPYGLASS = init();
+    public static final ItemType SPYGLASS = get("minecraft:spyglass");
     @Nullable
-    public static final ItemType SQUID_SPAWN_EGG = init();
+    public static final ItemType SQUID_SPAWN_EGG = get("minecraft:squid_spawn_egg");
     @Nullable
-    public static final ItemType STICK = init();
+    public static final ItemType STICK = get("minecraft:stick");
     @Nullable
-    public static final ItemType STICKY_PISTON = init();
+    public static final ItemType STICKY_PISTON = get("minecraft:sticky_piston");
     @Nullable
-    public static final ItemType STONE = init();
+    public static final ItemType STONE = get("minecraft:stone");
     @Nullable
-    public static final ItemType STONE_AXE = init();
+    public static final ItemType STONE_AXE = get("minecraft:stone_axe");
     @Nullable
-    public static final ItemType STONE_BRICK_SLAB = init();
+    public static final ItemType STONE_BRICK_SLAB = get("minecraft:stone_brick_slab");
     @Nullable
-    public static final ItemType STONE_BRICK_STAIRS = init();
+    public static final ItemType STONE_BRICK_STAIRS = get("minecraft:stone_brick_stairs");
     @Nullable
-    public static final ItemType STONE_BRICK_WALL = init();
+    public static final ItemType STONE_BRICK_WALL = get("minecraft:stone_brick_wall");
     @Nullable
-    public static final ItemType STONE_BRICKS = init();
+    public static final ItemType STONE_BRICKS = get("minecraft:stone_bricks");
     @Nullable
-    public static final ItemType STONE_BUTTON = init();
+    public static final ItemType STONE_BUTTON = get("minecraft:stone_button");
     @Nullable
-    public static final ItemType STONE_HOE = init();
+    public static final ItemType STONE_HOE = get("minecraft:stone_hoe");
     @Nullable
-    public static final ItemType STONE_PICKAXE = init();
+    public static final ItemType STONE_PICKAXE = get("minecraft:stone_pickaxe");
     @Nullable
-    public static final ItemType STONE_PRESSURE_PLATE = init();
+    public static final ItemType STONE_PRESSURE_PLATE = get("minecraft:stone_pressure_plate");
     @Nullable
-    public static final ItemType STONE_SHOVEL = init();
+    public static final ItemType STONE_SHOVEL = get("minecraft:stone_shovel");
     @Nullable
-    public static final ItemType STONE_SLAB = init();
+    public static final ItemType STONE_SLAB = get("minecraft:stone_slab");
     @Nullable
-    public static final ItemType STONE_SPEAR = init();
+    public static final ItemType STONE_SPEAR = get("minecraft:stone_spear");
     @Nullable
-    public static final ItemType STONE_STAIRS = init();
+    public static final ItemType STONE_STAIRS = get("minecraft:stone_stairs");
     @Nullable
-    public static final ItemType STONE_SWORD = init();
+    public static final ItemType STONE_SWORD = get("minecraft:stone_sword");
     @Nullable
-    public static final ItemType STONECUTTER = init();
+    public static final ItemType STONECUTTER = get("minecraft:stonecutter");
     @Nullable
-    public static final ItemType STRAY_SPAWN_EGG = init();
+    public static final ItemType STRAY_SPAWN_EGG = get("minecraft:stray_spawn_egg");
     @Nullable
-    public static final ItemType STRIDER_SPAWN_EGG = init();
+    public static final ItemType STRIDER_SPAWN_EGG = get("minecraft:strider_spawn_egg");
     @Nullable
-    public static final ItemType STRING = init();
+    public static final ItemType STRING = get("minecraft:string");
     @Nullable
-    public static final ItemType STRIPPED_ACACIA_LOG = init();
+    public static final ItemType STRIPPED_ACACIA_LOG = get("minecraft:stripped_acacia_log");
     @Nullable
-    public static final ItemType STRIPPED_ACACIA_WOOD = init();
+    public static final ItemType STRIPPED_ACACIA_WOOD = get("minecraft:stripped_acacia_wood");
     @Nullable
-    public static final ItemType STRIPPED_BAMBOO_BLOCK = init();
+    public static final ItemType STRIPPED_BAMBOO_BLOCK = get("minecraft:stripped_bamboo_block");
     @Nullable
-    public static final ItemType STRIPPED_BIRCH_LOG = init();
+    public static final ItemType STRIPPED_BIRCH_LOG = get("minecraft:stripped_birch_log");
     @Nullable
-    public static final ItemType STRIPPED_BIRCH_WOOD = init();
+    public static final ItemType STRIPPED_BIRCH_WOOD = get("minecraft:stripped_birch_wood");
     @Nullable
-    public static final ItemType STRIPPED_CHERRY_LOG = init();
+    public static final ItemType STRIPPED_CHERRY_LOG = get("minecraft:stripped_cherry_log");
     @Nullable
-    public static final ItemType STRIPPED_CHERRY_WOOD = init();
+    public static final ItemType STRIPPED_CHERRY_WOOD = get("minecraft:stripped_cherry_wood");
     @Nullable
-    public static final ItemType STRIPPED_CRIMSON_HYPHAE = init();
+    public static final ItemType STRIPPED_CRIMSON_HYPHAE = get("minecraft:stripped_crimson_hyphae");
     @Nullable
-    public static final ItemType STRIPPED_CRIMSON_STEM = init();
+    public static final ItemType STRIPPED_CRIMSON_STEM = get("minecraft:stripped_crimson_stem");
     @Nullable
-    public static final ItemType STRIPPED_DARK_OAK_LOG = init();
+    public static final ItemType STRIPPED_DARK_OAK_LOG = get("minecraft:stripped_dark_oak_log");
     @Nullable
-    public static final ItemType STRIPPED_DARK_OAK_WOOD = init();
+    public static final ItemType STRIPPED_DARK_OAK_WOOD = get("minecraft:stripped_dark_oak_wood");
     @Nullable
-    public static final ItemType STRIPPED_JUNGLE_LOG = init();
+    public static final ItemType STRIPPED_JUNGLE_LOG = get("minecraft:stripped_jungle_log");
     @Nullable
-    public static final ItemType STRIPPED_JUNGLE_WOOD = init();
+    public static final ItemType STRIPPED_JUNGLE_WOOD = get("minecraft:stripped_jungle_wood");
     @Nullable
-    public static final ItemType STRIPPED_MANGROVE_LOG = init();
+    public static final ItemType STRIPPED_MANGROVE_LOG = get("minecraft:stripped_mangrove_log");
     @Nullable
-    public static final ItemType STRIPPED_MANGROVE_WOOD = init();
+    public static final ItemType STRIPPED_MANGROVE_WOOD = get("minecraft:stripped_mangrove_wood");
     @Nullable
-    public static final ItemType STRIPPED_OAK_LOG = init();
+    public static final ItemType STRIPPED_OAK_LOG = get("minecraft:stripped_oak_log");
     @Nullable
-    public static final ItemType STRIPPED_OAK_WOOD = init();
-    @Nullable public static final ItemType STRIPPED_PALE_OAK_LOG = init();
-    @Nullable public static final ItemType STRIPPED_PALE_OAK_WOOD = init();
+    public static final ItemType STRIPPED_OAK_WOOD = get("minecraft:stripped_oak_wood");
     @Nullable
-    public static final ItemType STRIPPED_SPRUCE_LOG = init();
+    public static final ItemType STRIPPED_PALE_OAK_LOG = get("minecraft:stripped_pale_oak_log");
     @Nullable
-    public static final ItemType STRIPPED_SPRUCE_WOOD = init();
+    public static final ItemType STRIPPED_PALE_OAK_WOOD = get("minecraft:stripped_pale_oak_wood");
     @Nullable
-    public static final ItemType STRIPPED_WARPED_HYPHAE = init();
+    public static final ItemType STRIPPED_SPRUCE_LOG = get("minecraft:stripped_spruce_log");
     @Nullable
-    public static final ItemType STRIPPED_WARPED_STEM = init();
+    public static final ItemType STRIPPED_SPRUCE_WOOD = get("minecraft:stripped_spruce_wood");
     @Nullable
-    public static final ItemType STRUCTURE_BLOCK = init();
+    public static final ItemType STRIPPED_WARPED_HYPHAE = get("minecraft:stripped_warped_hyphae");
     @Nullable
-    public static final ItemType STRUCTURE_VOID = init();
+    public static final ItemType STRIPPED_WARPED_STEM = get("minecraft:stripped_warped_stem");
     @Nullable
-    public static final ItemType SUGAR = init();
+    public static final ItemType STRUCTURE_BLOCK = get("minecraft:structure_block");
     @Nullable
-    public static final ItemType SUGAR_CANE = init();
+    public static final ItemType STRUCTURE_VOID = get("minecraft:structure_void");
     @Nullable
-    public static final ItemType SULFUR = init();
+    public static final ItemType SUGAR = get("minecraft:sugar");
     @Nullable
-    public static final ItemType SULFUR_BRICK_SLAB = init();
+    public static final ItemType SUGAR_CANE = get("minecraft:sugar_cane");
     @Nullable
-    public static final ItemType SULFUR_BRICK_STAIRS = init();
+    public static final ItemType SULFUR = get("minecraft:sulfur");
     @Nullable
-    public static final ItemType SULFUR_BRICK_WALL = init();
+    public static final ItemType SULFUR_BRICK_SLAB = get("minecraft:sulfur_brick_slab");
     @Nullable
-    public static final ItemType SULFUR_BRICKS = init();
+    public static final ItemType SULFUR_BRICK_STAIRS = get("minecraft:sulfur_brick_stairs");
     @Nullable
-    public static final ItemType SULFUR_CUBE_BUCKET = init();
+    public static final ItemType SULFUR_BRICK_WALL = get("minecraft:sulfur_brick_wall");
     @Nullable
-    public static final ItemType SULFUR_CUBE_SPAWN_EGG = init();
+    public static final ItemType SULFUR_BRICKS = get("minecraft:sulfur_bricks");
     @Nullable
-    public static final ItemType SULFUR_SLAB = init();
+    public static final ItemType SULFUR_CUBE_BUCKET = get("minecraft:sulfur_cube_bucket");
     @Nullable
-    public static final ItemType SULFUR_SPIKE = init();
+    public static final ItemType SULFUR_CUBE_SPAWN_EGG = get("minecraft:sulfur_cube_spawn_egg");
     @Nullable
-    public static final ItemType SULFUR_STAIRS = init();
+    public static final ItemType SULFUR_SLAB = get("minecraft:sulfur_slab");
     @Nullable
-    public static final ItemType SULFUR_WALL = init();
+    public static final ItemType SULFUR_SPIKE = get("minecraft:sulfur_spike");
     @Nullable
-    public static final ItemType SUNFLOWER = init();
+    public static final ItemType SULFUR_STAIRS = get("minecraft:sulfur_stairs");
     @Nullable
-    public static final ItemType SUSPICIOUS_GRAVEL = init();
+    public static final ItemType SULFUR_WALL = get("minecraft:sulfur_wall");
     @Nullable
-    public static final ItemType SUSPICIOUS_SAND = init();
+    public static final ItemType SUNFLOWER = get("minecraft:sunflower");
     @Nullable
-    public static final ItemType SUSPICIOUS_STEW = init();
+    public static final ItemType SUSPICIOUS_GRAVEL = get("minecraft:suspicious_gravel");
     @Nullable
-    public static final ItemType SWEET_BERRIES = init();
+    public static final ItemType SUSPICIOUS_SAND = get("minecraft:suspicious_sand");
     @Nullable
-    public static final ItemType TADPOLE_BUCKET = init();
+    public static final ItemType SUSPICIOUS_STEW = get("minecraft:suspicious_stew");
     @Nullable
-    public static final ItemType TADPOLE_SPAWN_EGG = init();
+    public static final ItemType SWEET_BERRIES = get("minecraft:sweet_berries");
     @Nullable
-    public static final ItemType TALL_DRY_GRASS = init();
+    public static final ItemType TADPOLE_BUCKET = get("minecraft:tadpole_bucket");
     @Nullable
-    public static final ItemType TALL_GRASS = init();
+    public static final ItemType TADPOLE_SPAWN_EGG = get("minecraft:tadpole_spawn_egg");
     @Nullable
-    public static final ItemType TARGET = init();
+    public static final ItemType TALL_DRY_GRASS = get("minecraft:tall_dry_grass");
     @Nullable
-    public static final ItemType TERRACOTTA = init();
+    public static final ItemType TALL_GRASS = get("minecraft:tall_grass");
     @Nullable
-    public static final ItemType TEST_BLOCK = init();
+    public static final ItemType TARGET = get("minecraft:target");
     @Nullable
-    public static final ItemType TEST_INSTANCE_BLOCK = init();
+    public static final ItemType TERRACOTTA = get("minecraft:terracotta");
     @Nullable
-    public static final ItemType TIDE_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType TEST_BLOCK = get("minecraft:test_block");
     @Nullable
-    public static final ItemType TINTED_GLASS = init();
+    public static final ItemType TEST_INSTANCE_BLOCK = get("minecraft:test_instance_block");
     @Nullable
-    public static final ItemType TIPPED_ARROW = init();
+    public static final ItemType TIDE_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:tide_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType TNT = init();
+    public static final ItemType TINTED_GLASS = get("minecraft:tinted_glass");
     @Nullable
-    public static final ItemType TNT_MINECART = init();
+    public static final ItemType TIPPED_ARROW = get("minecraft:tipped_arrow");
     @Nullable
-    public static final ItemType TORCH = init();
+    public static final ItemType TNT = get("minecraft:tnt");
     @Nullable
-    public static final ItemType TORCHFLOWER = init();
+    public static final ItemType TNT_MINECART = get("minecraft:tnt_minecart");
     @Nullable
-    public static final ItemType TORCHFLOWER_SEEDS = init();
+    public static final ItemType TORCH = get("minecraft:torch");
     @Nullable
-    public static final ItemType TOTEM_OF_UNDYING = init();
+    public static final ItemType TORCHFLOWER = get("minecraft:torchflower");
     @Nullable
-    public static final ItemType TRADER_LLAMA_SPAWN_EGG = init();
+    public static final ItemType TORCHFLOWER_SEEDS = get("minecraft:torchflower_seeds");
     @Nullable
-    public static final ItemType TRAPPED_CHEST = init();
+    public static final ItemType TOTEM_OF_UNDYING = get("minecraft:totem_of_undying");
     @Nullable
-    public static final ItemType TRIAL_KEY = init();
+    public static final ItemType TRADER_LLAMA_SPAWN_EGG = get("minecraft:trader_llama_spawn_egg");
     @Nullable
-    public static final ItemType TRIAL_SPAWNER = init();
+    public static final ItemType TRAPPED_CHEST = get("minecraft:trapped_chest");
     @Nullable
-    public static final ItemType TRIDENT = init();
+    public static final ItemType TRIAL_KEY = get("minecraft:trial_key");
     @Nullable
-    public static final ItemType TRIPWIRE_HOOK = init();
+    public static final ItemType TRIAL_SPAWNER = get("minecraft:trial_spawner");
     @Nullable
-    public static final ItemType TROPICAL_FISH = init();
+    public static final ItemType TRIDENT = get("minecraft:trident");
     @Nullable
-    public static final ItemType TROPICAL_FISH_BUCKET = init();
+    public static final ItemType TRIPWIRE_HOOK = get("minecraft:tripwire_hook");
     @Nullable
-    public static final ItemType TROPICAL_FISH_SPAWN_EGG = init();
+    public static final ItemType TROPICAL_FISH = get("minecraft:tropical_fish");
     @Nullable
-    public static final ItemType TUBE_CORAL = init();
+    public static final ItemType TROPICAL_FISH_BUCKET = get("minecraft:tropical_fish_bucket");
     @Nullable
-    public static final ItemType TUBE_CORAL_BLOCK = init();
+    public static final ItemType TROPICAL_FISH_SPAWN_EGG = get("minecraft:tropical_fish_spawn_egg");
     @Nullable
-    public static final ItemType TUBE_CORAL_FAN = init();
+    public static final ItemType TUBE_CORAL = get("minecraft:tube_coral");
     @Nullable
-    public static final ItemType TUFF = init();
+    public static final ItemType TUBE_CORAL_BLOCK = get("minecraft:tube_coral_block");
     @Nullable
-    public static final ItemType TUFF_BRICK_SLAB = init();
+    public static final ItemType TUBE_CORAL_FAN = get("minecraft:tube_coral_fan");
     @Nullable
-    public static final ItemType TUFF_BRICK_STAIRS = init();
+    public static final ItemType TUFF = get("minecraft:tuff");
     @Nullable
-    public static final ItemType TUFF_BRICK_WALL = init();
+    public static final ItemType TUFF_BRICK_SLAB = get("minecraft:tuff_brick_slab");
     @Nullable
-    public static final ItemType TUFF_BRICKS = init();
+    public static final ItemType TUFF_BRICK_STAIRS = get("minecraft:tuff_brick_stairs");
     @Nullable
-    public static final ItemType TUFF_SLAB = init();
+    public static final ItemType TUFF_BRICK_WALL = get("minecraft:tuff_brick_wall");
     @Nullable
-    public static final ItemType TUFF_STAIRS = init();
+    public static final ItemType TUFF_BRICKS = get("minecraft:tuff_bricks");
     @Nullable
-    public static final ItemType TUFF_WALL = init();
+    public static final ItemType TUFF_SLAB = get("minecraft:tuff_slab");
     @Nullable
-    public static final ItemType TURTLE_EGG = init();
+    public static final ItemType TUFF_STAIRS = get("minecraft:tuff_stairs");
     @Nullable
-    public static final ItemType TURTLE_HELMET = init();
+    public static final ItemType TUFF_WALL = get("minecraft:tuff_wall");
     @Nullable
-    public static final ItemType TURTLE_SCUTE = init();
+    public static final ItemType TURTLE_EGG = get("minecraft:turtle_egg");
     @Nullable
-    public static final ItemType TURTLE_SPAWN_EGG = init();
+    public static final ItemType TURTLE_HELMET = get("minecraft:turtle_helmet");
     @Nullable
-    public static final ItemType TWISTING_VINES = init();
+    public static final ItemType TURTLE_SCUTE = get("minecraft:turtle_scute");
     @Nullable
-    public static final ItemType VAULT = init();
+    public static final ItemType TURTLE_SPAWN_EGG = get("minecraft:turtle_spawn_egg");
     @Nullable
-    public static final ItemType VERDANT_FROGLIGHT = init();
+    public static final ItemType TWISTING_VINES = get("minecraft:twisting_vines");
     @Nullable
-    public static final ItemType VEX_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType VAULT = get("minecraft:vault");
     @Nullable
-    public static final ItemType VEX_SPAWN_EGG = init();
+    public static final ItemType VERDANT_FROGLIGHT = get("minecraft:verdant_froglight");
     @Nullable
-    public static final ItemType VILLAGER_SPAWN_EGG = init();
+    public static final ItemType VEX_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:vex_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType VINDICATOR_SPAWN_EGG = init();
+    public static final ItemType VEX_SPAWN_EGG = get("minecraft:vex_spawn_egg");
     @Nullable
-    public static final ItemType VINE = init();
+    public static final ItemType VILLAGER_SPAWN_EGG = get("minecraft:villager_spawn_egg");
     @Nullable
-    public static final ItemType WANDERING_TRADER_SPAWN_EGG = init();
+    public static final ItemType VINDICATOR_SPAWN_EGG = get("minecraft:vindicator_spawn_egg");
     @Nullable
-    public static final ItemType WARD_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType VINE = get("minecraft:vine");
     @Nullable
-    public static final ItemType WARDEN_SPAWN_EGG = init();
+    public static final ItemType WANDERING_TRADER_SPAWN_EGG = get("minecraft:wandering_trader_spawn_egg");
     @Nullable
-    public static final ItemType WARPED_BUTTON = init();
+    public static final ItemType WARD_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:ward_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType WARPED_DOOR = init();
+    public static final ItemType WARDEN_SPAWN_EGG = get("minecraft:warden_spawn_egg");
     @Nullable
-    public static final ItemType WARPED_FENCE = init();
+    public static final ItemType WARPED_BUTTON = get("minecraft:warped_button");
     @Nullable
-    public static final ItemType WARPED_FENCE_GATE = init();
+    public static final ItemType WARPED_DOOR = get("minecraft:warped_door");
     @Nullable
-    public static final ItemType WARPED_FUNGUS = init();
+    public static final ItemType WARPED_FENCE = get("minecraft:warped_fence");
     @Nullable
-    public static final ItemType WARPED_FUNGUS_ON_A_STICK = init();
+    public static final ItemType WARPED_FENCE_GATE = get("minecraft:warped_fence_gate");
     @Nullable
-    public static final ItemType WARPED_HANGING_SIGN = init();
+    public static final ItemType WARPED_FUNGUS = get("minecraft:warped_fungus");
     @Nullable
-    public static final ItemType WARPED_HYPHAE = init();
+    public static final ItemType WARPED_FUNGUS_ON_A_STICK = get("minecraft:warped_fungus_on_a_stick");
     @Nullable
-    public static final ItemType WARPED_NYLIUM = init();
+    public static final ItemType WARPED_HANGING_SIGN = get("minecraft:warped_hanging_sign");
     @Nullable
-    public static final ItemType WARPED_PLANKS = init();
+    public static final ItemType WARPED_HYPHAE = get("minecraft:warped_hyphae");
     @Nullable
-    public static final ItemType WARPED_PRESSURE_PLATE = init();
+    public static final ItemType WARPED_NYLIUM = get("minecraft:warped_nylium");
     @Nullable
-    public static final ItemType WARPED_ROOTS = init();
+    public static final ItemType WARPED_PLANKS = get("minecraft:warped_planks");
     @Nullable
-    public static final ItemType WARPED_SHELF = init();
+    public static final ItemType WARPED_PRESSURE_PLATE = get("minecraft:warped_pressure_plate");
     @Nullable
-    public static final ItemType WARPED_SIGN = init();
+    public static final ItemType WARPED_ROOTS = get("minecraft:warped_roots");
     @Nullable
-    public static final ItemType WARPED_SLAB = init();
+    public static final ItemType WARPED_SHELF = get("minecraft:warped_shelf");
     @Nullable
-    public static final ItemType WARPED_STAIRS = init();
+    public static final ItemType WARPED_SIGN = get("minecraft:warped_sign");
     @Nullable
-    public static final ItemType WARPED_STEM = init();
+    public static final ItemType WARPED_SLAB = get("minecraft:warped_slab");
     @Nullable
-    public static final ItemType WARPED_TRAPDOOR = init();
+    public static final ItemType WARPED_STAIRS = get("minecraft:warped_stairs");
     @Nullable
-    public static final ItemType WARPED_WART_BLOCK = init();
+    public static final ItemType WARPED_STEM = get("minecraft:warped_stem");
     @Nullable
-    public static final ItemType WATER_BUCKET = init();
+    public static final ItemType WARPED_TRAPDOOR = get("minecraft:warped_trapdoor");
     @Nullable
-    public static final ItemType WAXED_CHISELED_COPPER = init();
+    public static final ItemType WARPED_WART_BLOCK = get("minecraft:warped_wart_block");
     @Nullable
-    public static final ItemType WAXED_COPPER_BARS = init();
+    public static final ItemType WATER_BUCKET = get("minecraft:water_bucket");
     @Nullable
-    public static final ItemType WAXED_COPPER_BLOCK = init();
+    public static final ItemType WAXED_CHISELED_COPPER = get("minecraft:waxed_chiseled_copper");
     @Nullable
-    public static final ItemType WAXED_COPPER_BULB = init();
+    public static final ItemType WAXED_COPPER_BARS = get("minecraft:waxed_copper_bars");
     @Nullable
-    public static final ItemType WAXED_COPPER_CHAIN = init();
+    public static final ItemType WAXED_COPPER_BLOCK = get("minecraft:waxed_copper_block");
     @Nullable
-    public static final ItemType WAXED_COPPER_CHEST = init();
+    public static final ItemType WAXED_COPPER_BULB = get("minecraft:waxed_copper_bulb");
     @Nullable
-    public static final ItemType WAXED_COPPER_DOOR = init();
+    public static final ItemType WAXED_COPPER_CHAIN = get("minecraft:waxed_copper_chain");
     @Nullable
-    public static final ItemType WAXED_COPPER_GOLEM_STATUE = init();
+    public static final ItemType WAXED_COPPER_CHEST = get("minecraft:waxed_copper_chest");
     @Nullable
-    public static final ItemType WAXED_COPPER_GRATE = init();
+    public static final ItemType WAXED_COPPER_DOOR = get("minecraft:waxed_copper_door");
     @Nullable
-    public static final ItemType WAXED_COPPER_LANTERN = init();
+    public static final ItemType WAXED_COPPER_GOLEM_STATUE = get("minecraft:waxed_copper_golem_statue");
     @Nullable
-    public static final ItemType WAXED_COPPER_TRAPDOOR = init();
+    public static final ItemType WAXED_COPPER_GRATE = get("minecraft:waxed_copper_grate");
     @Nullable
-    public static final ItemType WAXED_CUT_COPPER = init();
+    public static final ItemType WAXED_COPPER_LANTERN = get("minecraft:waxed_copper_lantern");
     @Nullable
-    public static final ItemType WAXED_CUT_COPPER_SLAB = init();
+    public static final ItemType WAXED_COPPER_TRAPDOOR = get("minecraft:waxed_copper_trapdoor");
     @Nullable
-    public static final ItemType WAXED_CUT_COPPER_STAIRS = init();
+    public static final ItemType WAXED_CUT_COPPER = get("minecraft:waxed_cut_copper");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_CHISELED_COPPER = init();
+    public static final ItemType WAXED_CUT_COPPER_SLAB = get("minecraft:waxed_cut_copper_slab");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER = init();
+    public static final ItemType WAXED_CUT_COPPER_STAIRS = get("minecraft:waxed_cut_copper_stairs");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER_BARS = init();
+    public static final ItemType WAXED_EXPOSED_CHISELED_COPPER = get("minecraft:waxed_exposed_chiseled_copper");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER_BULB = init();
+    public static final ItemType WAXED_EXPOSED_COPPER = get("minecraft:waxed_exposed_copper");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER_CHAIN = init();
+    public static final ItemType WAXED_EXPOSED_COPPER_BARS = get("minecraft:waxed_exposed_copper_bars");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER_CHEST = init();
+    public static final ItemType WAXED_EXPOSED_COPPER_BULB = get("minecraft:waxed_exposed_copper_bulb");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER_DOOR = init();
+    public static final ItemType WAXED_EXPOSED_COPPER_CHAIN = get("minecraft:waxed_exposed_copper_chain");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER_GOLEM_STATUE = init();
+    public static final ItemType WAXED_EXPOSED_COPPER_CHEST = get("minecraft:waxed_exposed_copper_chest");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER_GRATE = init();
+    public static final ItemType WAXED_EXPOSED_COPPER_DOOR = get("minecraft:waxed_exposed_copper_door");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER_LANTERN = init();
+    public static final ItemType WAXED_EXPOSED_COPPER_GOLEM_STATUE = get("minecraft:waxed_exposed_copper_golem_statue");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_COPPER_TRAPDOOR = init();
+    public static final ItemType WAXED_EXPOSED_COPPER_GRATE = get("minecraft:waxed_exposed_copper_grate");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_CUT_COPPER = init();
+    public static final ItemType WAXED_EXPOSED_COPPER_LANTERN = get("minecraft:waxed_exposed_copper_lantern");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_CUT_COPPER_SLAB = init();
+    public static final ItemType WAXED_EXPOSED_COPPER_TRAPDOOR = get("minecraft:waxed_exposed_copper_trapdoor");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_CUT_COPPER_STAIRS = init();
+    public static final ItemType WAXED_EXPOSED_CUT_COPPER = get("minecraft:waxed_exposed_cut_copper");
     @Nullable
-    public static final ItemType WAXED_EXPOSED_LIGHTNING_ROD = init();
+    public static final ItemType WAXED_EXPOSED_CUT_COPPER_SLAB = get("minecraft:waxed_exposed_cut_copper_slab");
     @Nullable
-    public static final ItemType WAXED_LIGHTNING_ROD  = init();
+    public static final ItemType WAXED_EXPOSED_CUT_COPPER_STAIRS = get("minecraft:waxed_exposed_cut_copper_stairs");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_CHISELED_COPPER = init();
+    public static final ItemType WAXED_EXPOSED_LIGHTNING_ROD = get("minecraft:waxed_exposed_lightning_rod");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER = init();
+    public static final ItemType WAXED_LIGHTNING_ROD = get("minecraft:waxed_lightning_rod");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER_BARS = init();
+    public static final ItemType WAXED_OXIDIZED_CHISELED_COPPER = get("minecraft:waxed_oxidized_chiseled_copper");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER_BULB = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER = get("minecraft:waxed_oxidized_copper");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER_CHAIN = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER_BARS = get("minecraft:waxed_oxidized_copper_bars");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER_CHEST = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER_BULB = get("minecraft:waxed_oxidized_copper_bulb");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER_DOOR = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER_CHAIN = get("minecraft:waxed_oxidized_copper_chain");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER_GOLEM_STATUE = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER_CHEST = get("minecraft:waxed_oxidized_copper_chest");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER_GRATE = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER_DOOR = get("minecraft:waxed_oxidized_copper_door");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER_LANTERN = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER_GOLEM_STATUE = get("minecraft:waxed_oxidized_copper_golem_statue");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_COPPER_TRAPDOOR = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER_GRATE = get("minecraft:waxed_oxidized_copper_grate");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_CUT_COPPER = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER_LANTERN = get("minecraft:waxed_oxidized_copper_lantern");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_CUT_COPPER_SLAB = init();
+    public static final ItemType WAXED_OXIDIZED_COPPER_TRAPDOOR = get("minecraft:waxed_oxidized_copper_trapdoor");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_CUT_COPPER_STAIRS = init();
+    public static final ItemType WAXED_OXIDIZED_CUT_COPPER = get("minecraft:waxed_oxidized_cut_copper");
     @Nullable
-    public static final ItemType WAXED_OXIDIZED_LIGHTNING_ROD = init();
+    public static final ItemType WAXED_OXIDIZED_CUT_COPPER_SLAB = get("minecraft:waxed_oxidized_cut_copper_slab");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_CHISELED_COPPER = init();
+    public static final ItemType WAXED_OXIDIZED_CUT_COPPER_STAIRS = get("minecraft:waxed_oxidized_cut_copper_stairs");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER = init();
+    public static final ItemType WAXED_OXIDIZED_LIGHTNING_ROD = get("minecraft:waxed_oxidized_lightning_rod");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER_BARS = init();
+    public static final ItemType WAXED_WEATHERED_CHISELED_COPPER = get("minecraft:waxed_weathered_chiseled_copper");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER_BULB = init();
+    public static final ItemType WAXED_WEATHERED_COPPER = get("minecraft:waxed_weathered_copper");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER_CHAIN = init();
+    public static final ItemType WAXED_WEATHERED_COPPER_BARS = get("minecraft:waxed_weathered_copper_bars");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER_CHEST = init();
+    public static final ItemType WAXED_WEATHERED_COPPER_BULB = get("minecraft:waxed_weathered_copper_bulb");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER_DOOR = init();
+    public static final ItemType WAXED_WEATHERED_COPPER_CHAIN = get("minecraft:waxed_weathered_copper_chain");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER_GOLEM_STATUE = init();
+    public static final ItemType WAXED_WEATHERED_COPPER_CHEST = get("minecraft:waxed_weathered_copper_chest");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER_GRATE = init();
+    public static final ItemType WAXED_WEATHERED_COPPER_DOOR = get("minecraft:waxed_weathered_copper_door");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER_LANTERN = init();
+    public static final ItemType WAXED_WEATHERED_COPPER_GOLEM_STATUE = get("minecraft:waxed_weathered_copper_golem_statue");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_COPPER_TRAPDOOR = init();
+    public static final ItemType WAXED_WEATHERED_COPPER_GRATE = get("minecraft:waxed_weathered_copper_grate");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_CUT_COPPER = init();
+    public static final ItemType WAXED_WEATHERED_COPPER_LANTERN = get("minecraft:waxed_weathered_copper_lantern");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_CUT_COPPER_SLAB = init();
+    public static final ItemType WAXED_WEATHERED_COPPER_TRAPDOOR = get("minecraft:waxed_weathered_copper_trapdoor");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_CUT_COPPER_STAIRS = init();
+    public static final ItemType WAXED_WEATHERED_CUT_COPPER = get("minecraft:waxed_weathered_cut_copper");
     @Nullable
-    public static final ItemType WAXED_WEATHERED_LIGHTNING_ROD = init();
+    public static final ItemType WAXED_WEATHERED_CUT_COPPER_SLAB = get("minecraft:waxed_weathered_cut_copper_slab");
     @Nullable
-    public static final ItemType WAYFINDER_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType WAXED_WEATHERED_CUT_COPPER_STAIRS = get("minecraft:waxed_weathered_cut_copper_stairs");
     @Nullable
-    public static final ItemType WEATHERED_CHISELED_COPPER = init();
+    public static final ItemType WAXED_WEATHERED_LIGHTNING_ROD = get("minecraft:waxed_weathered_lightning_rod");
     @Nullable
-    public static final ItemType WEATHERED_COPPER = init();
+    public static final ItemType WAYFINDER_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:wayfinder_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType WEATHERED_COPPER_BARS = init();
+    public static final ItemType WEATHERED_CHISELED_COPPER = get("minecraft:weathered_chiseled_copper");
     @Nullable
-    public static final ItemType WEATHERED_COPPER_BULB = init();
+    public static final ItemType WEATHERED_COPPER = get("minecraft:weathered_copper");
     @Nullable
-    public static final ItemType WEATHERED_COPPER_CHAIN = init();
+    public static final ItemType WEATHERED_COPPER_BARS = get("minecraft:weathered_copper_bars");
     @Nullable
-    public static final ItemType WEATHERED_COPPER_CHEST = init();
+    public static final ItemType WEATHERED_COPPER_BULB = get("minecraft:weathered_copper_bulb");
     @Nullable
-    public static final ItemType WEATHERED_COPPER_DOOR = init();
+    public static final ItemType WEATHERED_COPPER_CHAIN = get("minecraft:weathered_copper_chain");
     @Nullable
-    public static final ItemType WEATHERED_COPPER_GOLEM_STATUE = init();
+    public static final ItemType WEATHERED_COPPER_CHEST = get("minecraft:weathered_copper_chest");
     @Nullable
-    public static final ItemType WEATHERED_COPPER_GRATE = init();
+    public static final ItemType WEATHERED_COPPER_DOOR = get("minecraft:weathered_copper_door");
     @Nullable
-    public static final ItemType WEATHERED_COPPER_LANTERN = init();
+    public static final ItemType WEATHERED_COPPER_GOLEM_STATUE = get("minecraft:weathered_copper_golem_statue");
     @Nullable
-    public static final ItemType WEATHERED_COPPER_TRAPDOOR = init();
+    public static final ItemType WEATHERED_COPPER_GRATE = get("minecraft:weathered_copper_grate");
     @Nullable
-    public static final ItemType WEATHERED_CUT_COPPER = init();
+    public static final ItemType WEATHERED_COPPER_LANTERN = get("minecraft:weathered_copper_lantern");
     @Nullable
-    public static final ItemType WEATHERED_CUT_COPPER_SLAB = init();
+    public static final ItemType WEATHERED_COPPER_TRAPDOOR = get("minecraft:weathered_copper_trapdoor");
     @Nullable
-    public static final ItemType WEATHERED_CUT_COPPER_STAIRS = init();
+    public static final ItemType WEATHERED_CUT_COPPER = get("minecraft:weathered_cut_copper");
     @Nullable
-    public static final ItemType WEATHERED_LIGHTNING_ROD = init();
+    public static final ItemType WEATHERED_CUT_COPPER_SLAB = get("minecraft:weathered_cut_copper_slab");
     @Nullable
-    public static final ItemType WEEPING_VINES = init();
+    public static final ItemType WEATHERED_CUT_COPPER_STAIRS = get("minecraft:weathered_cut_copper_stairs");
     @Nullable
-    public static final ItemType WET_SPONGE = init();
+    public static final ItemType WEATHERED_LIGHTNING_ROD = get("minecraft:weathered_lightning_rod");
     @Nullable
-    public static final ItemType WHEAT = init();
+    public static final ItemType WEEPING_VINES = get("minecraft:weeping_vines");
     @Nullable
-    public static final ItemType WHEAT_SEEDS = init();
+    public static final ItemType WET_SPONGE = get("minecraft:wet_sponge");
     @Nullable
-    public static final ItemType WHITE_BANNER = init();
+    public static final ItemType WHEAT = get("minecraft:wheat");
     @Nullable
-    public static final ItemType WHITE_BED = init();
-    @Nullable public static final ItemType WHITE_BUNDLE = init();
+    public static final ItemType WHEAT_SEEDS = get("minecraft:wheat_seeds");
     @Nullable
-    public static final ItemType WHITE_CANDLE = init();
+    public static final ItemType WHITE_BANNER = get("minecraft:white_banner");
     @Nullable
-    public static final ItemType WHITE_CARPET = init();
+    public static final ItemType WHITE_BED = get("minecraft:white_bed");
     @Nullable
-    public static final ItemType WHITE_CONCRETE = init();
+    public static final ItemType WHITE_BUNDLE = get("minecraft:white_bundle");
     @Nullable
-    public static final ItemType WHITE_CONCRETE_POWDER = init();
+    public static final ItemType WHITE_CANDLE = get("minecraft:white_candle");
     @Nullable
-    public static final ItemType WHITE_DYE = init();
+    public static final ItemType WHITE_CARPET = get("minecraft:white_carpet");
     @Nullable
-    public static final ItemType WHITE_GLAZED_TERRACOTTA = init();
+    public static final ItemType WHITE_CONCRETE = get("minecraft:white_concrete");
     @Nullable
-    public static final ItemType WHITE_SHULKER_BOX = init();
+    public static final ItemType WHITE_CONCRETE_POWDER = get("minecraft:white_concrete_powder");
     @Nullable
-    public static final ItemType WHITE_STAINED_GLASS = init();
+    public static final ItemType WHITE_DYE = get("minecraft:white_dye");
     @Nullable
-    public static final ItemType WHITE_STAINED_GLASS_PANE = init();
+    public static final ItemType WHITE_GLAZED_TERRACOTTA = get("minecraft:white_glazed_terracotta");
     @Nullable
-    public static final ItemType WHITE_TERRACOTTA = init();
+    public static final ItemType WHITE_HARNESS = get("minecraft:white_harness");
     @Nullable
-    public static final ItemType WHITE_TULIP = init();
+    public static final ItemType WHITE_SHULKER_BOX = get("minecraft:white_shulker_box");
     @Nullable
-    public static final ItemType WHITE_WOOL = init();
+    public static final ItemType WHITE_STAINED_GLASS = get("minecraft:white_stained_glass");
     @Nullable
-    public static final ItemType WILD_ARMOR_TRIM_SMITHING_TEMPLATE = init();
+    public static final ItemType WHITE_STAINED_GLASS_PANE = get("minecraft:white_stained_glass_pane");
     @Nullable
-    public static final ItemType WILDFLOWERS = init();
+    public static final ItemType WHITE_TERRACOTTA = get("minecraft:white_terracotta");
     @Nullable
-    public static final ItemType WIND_CHARGE = init();
+    public static final ItemType WHITE_TULIP = get("minecraft:white_tulip");
     @Nullable
-    public static final ItemType WITCH_SPAWN_EGG = init();
+    public static final ItemType WHITE_WOOL = get("minecraft:white_wool");
     @Nullable
-    public static final ItemType WITHER_ROSE = init();
+    public static final ItemType WILD_ARMOR_TRIM_SMITHING_TEMPLATE = get("minecraft:wild_armor_trim_smithing_template");
     @Nullable
-    public static final ItemType WITHER_SKELETON_SKULL = init();
+    public static final ItemType WILDFLOWERS = get("minecraft:wildflowers");
     @Nullable
-    public static final ItemType WITHER_SKELETON_SPAWN_EGG = init();
+    public static final ItemType WIND_CHARGE = get("minecraft:wind_charge");
     @Nullable
-    public static final ItemType WITHER_SPAWN_EGG = init();
+    public static final ItemType WITCH_SPAWN_EGG = get("minecraft:witch_spawn_egg");
     @Nullable
-    public static final ItemType WOLF_ARMOR = init();
+    public static final ItemType WITHER_ROSE = get("minecraft:wither_rose");
     @Nullable
-    public static final ItemType WOLF_SPAWN_EGG = init();
+    public static final ItemType WITHER_SKELETON_SKULL = get("minecraft:wither_skeleton_skull");
     @Nullable
-    public static final ItemType WOODEN_AXE = init();
+    public static final ItemType WITHER_SKELETON_SPAWN_EGG = get("minecraft:wither_skeleton_spawn_egg");
     @Nullable
-    public static final ItemType WOODEN_HOE = init();
+    public static final ItemType WITHER_SPAWN_EGG = get("minecraft:wither_spawn_egg");
     @Nullable
-    public static final ItemType WOODEN_PICKAXE = init();
+    public static final ItemType WOLF_ARMOR = get("minecraft:wolf_armor");
     @Nullable
-    public static final ItemType WOODEN_SHOVEL = init();
+    public static final ItemType WOLF_SPAWN_EGG = get("minecraft:wolf_spawn_egg");
     @Nullable
-    public static final ItemType WOODEN_SPEAR = init();
+    public static final ItemType WOODEN_AXE = get("minecraft:wooden_axe");
     @Nullable
-    public static final ItemType WOODEN_SWORD = init();
+    public static final ItemType WOODEN_HOE = get("minecraft:wooden_hoe");
     @Nullable
-    public static final ItemType WRITABLE_BOOK = init();
+    public static final ItemType WOODEN_PICKAXE = get("minecraft:wooden_pickaxe");
     @Nullable
-    public static final ItemType WRITTEN_BOOK = init();
+    public static final ItemType WOODEN_SHOVEL = get("minecraft:wooden_shovel");
     @Nullable
-    public static final ItemType YELLOW_BANNER = init();
+    public static final ItemType WOODEN_SPEAR = get("minecraft:wooden_spear");
     @Nullable
-    public static final ItemType YELLOW_BED = init();
-    @Nullable public static final ItemType YELLOW_BUNDLE = init();
+    public static final ItemType WOODEN_SWORD = get("minecraft:wooden_sword");
     @Nullable
-    public static final ItemType YELLOW_CANDLE = init();
+    public static final ItemType WRITABLE_BOOK = get("minecraft:writable_book");
     @Nullable
-    public static final ItemType YELLOW_CARPET = init();
+    public static final ItemType WRITTEN_BOOK = get("minecraft:written_book");
     @Nullable
-    public static final ItemType YELLOW_CONCRETE = init();
+    public static final ItemType YELLOW_BANNER = get("minecraft:yellow_banner");
     @Nullable
-    public static final ItemType YELLOW_CONCRETE_POWDER = init();
+    public static final ItemType YELLOW_BED = get("minecraft:yellow_bed");
     @Nullable
-    public static final ItemType YELLOW_DYE = init();
+    public static final ItemType YELLOW_BUNDLE = get("minecraft:yellow_bundle");
     @Nullable
-    public static final ItemType YELLOW_GLAZED_TERRACOTTA = init();
+    public static final ItemType YELLOW_CANDLE = get("minecraft:yellow_candle");
     @Nullable
-    public static final ItemType YELLOW_SHULKER_BOX = init();
+    public static final ItemType YELLOW_CARPET = get("minecraft:yellow_carpet");
     @Nullable
-    public static final ItemType YELLOW_STAINED_GLASS = init();
+    public static final ItemType YELLOW_CONCRETE = get("minecraft:yellow_concrete");
     @Nullable
-    public static final ItemType YELLOW_STAINED_GLASS_PANE = init();
+    public static final ItemType YELLOW_CONCRETE_POWDER = get("minecraft:yellow_concrete_powder");
     @Nullable
-    public static final ItemType YELLOW_TERRACOTTA = init();
+    public static final ItemType YELLOW_DYE = get("minecraft:yellow_dye");
     @Nullable
-    public static final ItemType YELLOW_WOOL = init();
+    public static final ItemType YELLOW_GLAZED_TERRACOTTA = get("minecraft:yellow_glazed_terracotta");
     @Nullable
-    public static final ItemType ZOGLIN_SPAWN_EGG = init();
+    public static final ItemType YELLOW_HARNESS = get("minecraft:yellow_harness");
     @Nullable
-    public static final ItemType ZOMBIE_HEAD = init();
+    public static final ItemType YELLOW_SHULKER_BOX = get("minecraft:yellow_shulker_box");
     @Nullable
-    public static final ItemType ZOMBIE_HORSE_SPAWN_EGG = init();
+    public static final ItemType YELLOW_STAINED_GLASS = get("minecraft:yellow_stained_glass");
     @Nullable
-    public static final ItemType ZOMBIE_NAUTILUS_SPAWN_EGG = init();
+    public static final ItemType YELLOW_STAINED_GLASS_PANE = get("minecraft:yellow_stained_glass_pane");
+    @Nullable
+    public static final ItemType YELLOW_TERRACOTTA = get("minecraft:yellow_terracotta");
+    @Nullable
+    public static final ItemType YELLOW_WOOL = get("minecraft:yellow_wool");
+    @Nullable
+    public static final ItemType ZOGLIN_SPAWN_EGG = get("minecraft:zoglin_spawn_egg");
+    @Nullable
+    public static final ItemType ZOMBIE_HEAD = get("minecraft:zombie_head");
+    @Nullable
+    public static final ItemType ZOMBIE_HORSE_SPAWN_EGG = get("minecraft:zombie_horse_spawn_egg");
+    @Nullable
+    public static final ItemType ZOMBIE_NAUTILUS_SPAWN_EGG = get("minecraft:zombie_nautilus_spawn_egg");
     @Deprecated
     @Nullable
-    public static final ItemType ZOMBIE_PIGMAN_SPAWN_EGG = init();
+    public static final ItemType ZOMBIE_PIGMAN_SPAWN_EGG = get("minecraft:zombie_pigman_spawn_egg");
     @Nullable
-    public static final ItemType ZOMBIE_SPAWN_EGG = init();
+    public static final ItemType ZOMBIE_SPAWN_EGG = get("minecraft:zombie_spawn_egg");
     @Nullable
-    public static final ItemType ZOMBIE_VILLAGER_SPAWN_EGG = init();
+    public static final ItemType ZOMBIE_VILLAGER_SPAWN_EGG = get("minecraft:zombie_villager_spawn_egg");
     @Nullable
-    public static final ItemType ZOMBIFIED_PIGLIN_SPAWN_EGG = init();
+    public static final ItemType ZOMBIFIED_PIGLIN_SPAWN_EGG = get("minecraft:zombified_piglin_spawn_egg");
 
     private ItemTypes() {
-    }
-
-    private static Field[] fieldsTmp;
-    private static int initIndex;
-
-    private static ItemType init() {
-        try {
-            if (fieldsTmp == null) {
-                fieldsTmp = ItemTypes.class.getDeclaredFields();
-                ItemTypesCache.init(); // force class to load
-            }
-            String name = fieldsTmp[initIndex++].getName().toLowerCase(Locale.ROOT);
-            return ItemType.REGISTRY.get(name);
-        } catch (Throwable e) {
-            e.printStackTrace();
-            throw e;
-        }
-    }
-
-    static {
-        // we should be at the first non-ItemType field now
-        if (!fieldsTmp[initIndex].getName().equals("fieldsTmp")) {
-            throw new IllegalStateException("improper initialization of item type fields");
-        }
-        fieldsTmp = null;
     }
 
     @Nullable


### PR DESCRIPTION
### What this changes

Our changes to `ItemTypes` have the same problem `BlockTypes` had (#3641): falling behind updating constants for new Minecraft versions, and a reflective scheme for binding constants to their ids that's fragile. This change removes the reflective scheme and matches the upstream `ItemTypes` class, which binds each constant to its id explicitly.
Before, each item constant called a no-argument `init()` that walked the class's own field array and derived
the id from whichever field happened to sit at the next index:

```java
private static Field[] fieldsTmp;
private static int initIndex;

private static ItemType init() {
    try {
        if (fieldsTmp == null) {
            fieldsTmp = ItemTypes.class.getDeclaredFields();
            ItemTypesCache.init(); // force class to load
        }
        String name = fieldsTmp[initIndex++].getName().toLowerCase(Locale.ROOT);
        return ItemType.REGISTRY.get(name);
    } catch (Throwable e) {
        e.printStackTrace();
        throw e;
    }
}

static {
    // we should be at the first non-ItemType field now
    if (!fieldsTmp[initIndex].getName().equals("fieldsTmp")) {
        throw new IllegalStateException("improper initialization of item type fields");
    }
    fieldsTmp = null;
}
```

Each constant now states its id and uses the existing `get(String)` method to resolve it:

```java
@Nullable
public static final ItemType ACACIA_BOAT = get("minecraft:acacia_boat");
```

```java
@Nullable
public static ItemType get(String id) {
    return ItemType.REGISTRY.get(id);
}
```

No new method was introduced.

### Why

The biggest problem is that constant resolution relies on `Class.getDeclaredFields()`. This method **does
not specify an order**. We just happened to luck into the fact that the JVM returned fields in source order, but that is not
guaranteed and we shouldn't be left relying on that.

The consequence of this is that every constant from the first disturbance
onward is bound to the *wrong item*. This can lead to silent corruption of world data, which is a severe issue.

The old code did have a check for this, but it only covers one kind of mix-up (missing/extra fields). It wouldn't catch two items just being swapped, since the count would still look right.

Writing the id straight into each constant just makes the whole problem impossible instead of trying to catch it after the fact.

**Upstream already does it this way.** WorldEdit's own `ItemTypes` writes every constant as `get("minecraft:acacia_boat")`. We were doing our own thing here for no real reason; now we're not, so pulling in upstream changes to this file gets a lot easier.
If we fall behind updating Minecraft items in the future, we should be able to just cherry-pick the upstream change.

### Also in this change

**Cache priming moved to a static block.** Reading `ItemType.REGISTRY` triggers `ItemType`'s class initializer, not `ItemTypesCache`'s, and `REGISTRY` starts empty. `ItemTypesCache`'s static block is what queries the platform and registers every item into it, so something has to force that class to initialize before the first constant resolves.
That was the `ItemTypesCache.init()` call, guarded by a lazy `fieldsTmp == null` check so it ran once.

Since there's no lazy state left to guard, the priming moves to a static block placed above the constants:

```java
static {
    // Initializing the cache is what populates ItemType.REGISTRY from the running platform. Static initializers run in
    // declaration order, so this must stay above the constants for them to resolve to anything.
    ItemTypesCache.init();
}
```

Static blocks and field initializers compile into the same `<clinit>` in source order, so this runs first and exactly once.

### Constant list reconciled with upstream

FAWE's list had drifted from WorldEdit's. This change brings it back into line by adding the 19 constants FAWE was missing:

`BLACK_HARNESS`, `BLUE_HARNESS`, `BROWN_HARNESS`, `CYAN_HARNESS`, `DRIED_GHAST`, `GRAY_HARNESS`, `GREEN_HARNESS`, `HAPPY_GHAST_SPAWN_EGG`, `LIGHT_BLUE_HARNESS`, `LIGHT_GRAY_HARNESS`, `LIME_HARNESS`, `MAGENTA_HARNESS`, `MUSIC_DISC_TEARS`, `ORANGE_HARNESS`, `PINK_HARNESS`, `PURPLE_HARNESS`, `RED_HARNESS`, `WHITE_HARNESS`, `YELLOW_HARNESS`

### Performance

This touches `<clinit>` only. It runs once per JVM, at plugin load.

The one-time startup cost does improve slightly: gone is a native metadata walk over a ~1,550-field class, one `toLowerCase(Locale.ROOT)` allocation per constant, and one namespace-concatenation allocation per constant. That's a few thousand transient allocations, all young-gen garbage, at a moment when the server is already doing far more expensive work. It is not measurable in practice.

The tradeoff: we are now adding item id strings baked into the class file, adding a modest amount of permanent memory. The old version wasn't free either. It kept a full copy of the class's fields cached in memory the whole time, which was a similar amount of memory. So the two roughly cancel out, and either way it's nothing on a server with gigabytes of heap.
