### PR TITLE
fix: Handle JSONParseException when parsing hex colors in JSON text components

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/text/serializer/gson/StyleSerializer.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/util/formatting/text/serializer/gson/StyleSerializer.java
@@ -85,12 +85,20 @@ public class StyleSerializer implements JsonDeserializer<Style>, JsonSerializer<
         final Style.Builder style = Style.builder();
 
         if (json.has(COLOR)) {
-            final TextColorWrapper color = context.deserialize(json.get(COLOR), TextColorWrapper.class);
-            if (color.color != null) {
-                style.color(color.color);
-            } else if (color.decoration != null) {
-                // I know. Setting a decoration from the color is weird. This is, unfortunately, something we need to support.
-                style.decoration(color.decoration, true);
+            TextColorWrapper color = null;
+            try {
+                color = context.deserialize(json.get(COLOR), TextColorWrapper.class);
+            } catch (final JsonParseException ignored) {
+                // Vanilla text components may carry hex colors (#RRGGBB) since 1.16, text3 cannot represent them.
+                // Drop the color instead of failing to parse the whole component.
+            }
+            if (color != null) {
+                if (color.color != null) {
+                    style.color(color.color);
+                } else if (color.decoration != null) {
+                    // I know. Setting a decoration from the color is weird. This is, unfortunately, something we need to support.
+                    style.decoration(color.decoration, true);
+                }
             }
         }
 

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/util/formatting/text/serializer/gson/StyleSerializerTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/util/formatting/text/serializer/gson/StyleSerializerTest.java
@@ -18,12 +18,7 @@ class StyleSerializerTest {
         );
         assertEquals("Gold item", ((TextComponent) hexOnly).content());
         assertNull(hexOnly.color());
-
-        Component prefixed = GsonComponentSerializer.INSTANCE.deserialize(
-                "{\"text\":\"Gold item\",\"color\":\"■ #FFD700\"}"
-        );
-        assertEquals("Gold item", ((TextComponent) prefixed).content());
-        assertNull(prefixed.color());
+    }
 
     @Test
     void namedColorStillParsed() {

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/util/formatting/text/serializer/gson/StyleSerializerTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/util/formatting/text/serializer/gson/StyleSerializerTest.java
@@ -13,12 +13,17 @@ class StyleSerializerTest {
     @Test
     void hexColorIsDroppedInsteadOfFailing() {
         // Vanilla item names may carry hex colors ("#RRGGBB") since 1.16, text3 cannot represent them.
-        Component component = GsonComponentSerializer.INSTANCE.deserialize(
+        Component hexOnly = GsonComponentSerializer.INSTANCE.deserialize(
                 "{\"text\":\"Gold item\",\"color\":\"#FFD700\"}"
         );
-        assertEquals("Gold item", ((TextComponent) component).content());
-        assertNull(component.color());
-    }
+        assertEquals("Gold item", ((TextComponent) hexOnly).content());
+        assertNull(hexOnly.color());
+
+        Component prefixed = GsonComponentSerializer.INSTANCE.deserialize(
+                "{\"text\":\"Gold item\",\"color\":\"■ #FFD700\"}"
+        );
+        assertEquals("Gold item", ((TextComponent) prefixed).content());
+        assertNull(prefixed.color());
 
     @Test
     void namedColorStillParsed() {

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/util/formatting/text/serializer/gson/StyleSerializerTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/util/formatting/text/serializer/gson/StyleSerializerTest.java
@@ -1,0 +1,31 @@
+package com.sk89q.worldedit.util.formatting.text.serializer.gson;
+
+import com.sk89q.worldedit.util.formatting.text.Component;
+import com.sk89q.worldedit.util.formatting.text.TextComponent;
+import com.sk89q.worldedit.util.formatting.text.format.TextColor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class StyleSerializerTest {
+
+    @Test
+    void hexColorIsDroppedInsteadOfFailing() {
+        // Vanilla item names may carry hex colors ("#RRGGBB") since 1.16, text3 cannot represent them.
+        Component component = GsonComponentSerializer.INSTANCE.deserialize(
+                "{\"text\":\"Gold item\",\"color\":\"#FFD700\"}"
+        );
+        assertEquals("Gold item", ((TextComponent) component).content());
+        assertNull(component.color());
+    }
+
+    @Test
+    void namedColorStillParsed() {
+        Component component = GsonComponentSerializer.INSTANCE.deserialize(
+                "{\"text\":\"Gold item\",\"color\":\"gold\"}"
+        );
+        assertEquals(TextColor.GOLD, component.color());
+    }
+
+}


### PR DESCRIPTION
Running `/repl air` command while holding an item whose custom name contains a hex
color (e.g. a menu/gadget item renamed by another plugin) kills the whole command/logs an exception:

```

[ERROR] PlatformCommandManager: An unexpected error while handling a FastAsyncWorldEdit command
com.google.gson.JsonParseException: Don't know how to parse "#FFD700"
    at com.sk89q.worldedit.util.formatting.text.serializer.gson.TextColorWrapper$Serializer.deserialize(TextColorWrapper.java:56)

```

**Cause:** The relocated text library (`net.kyori:text` 3.0.4) predates MC 1.16 — `TextColor`
is an enum of the 16 legacy color names and cannot represent hex colors at all, while vanilla
JSON text has allowed `"color": "#RRGGBB"` since 1.16. `PaperweightAdapter#getRichItemName(BaseItemStack)`
round-trips the vanilla item-name JSON through the text3 Gson serializer, so any item with a
hex-colored name fails

**Fix:** The vendored `StyleSerializer` (already copied and relocated from text3 for the 1.21.5
click/hover event updates) now catches the `JsonParseException` when the `color` field cannot be
mapped and drops the color instead of failing the whole component. The item name is still shown,
just uncolored. As the single choke point of the Gson deserializer, this also covers hover event
contents and any other component parsed through it — not just the tool-bind message.
