### PR TITLE
Fix pasting passengers

### DIFF
--- a/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v26_2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-26.2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v26_2/PaperweightGetBlocks.java
@@ -18,6 +18,7 @@ import com.fastasyncworldedit.core.util.collection.AdaptedMap;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitEntity;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.entity.BaseEntity;
 import com.sk89q.worldedit.internal.Constants;
 import com.sk89q.worldedit.internal.util.LogManagerCompat;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -25,6 +26,7 @@ import com.sk89q.worldedit.util.SideEffect;
 import com.sk89q.worldedit.util.formatting.text.TextComponent;
 import com.sk89q.worldedit.world.biome.BiomeType;
 import com.sk89q.worldedit.world.block.BlockTypesCache;
+import com.sk89q.worldedit.world.entity.EntityTypes;
 import io.papermc.paper.event.block.BeaconDeactivatedEvent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -57,6 +59,7 @@ import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.lighting.LevelLightEngine;
 import net.minecraft.world.level.storage.ValueInput;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.CraftBlock;
@@ -100,6 +103,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
     public static final Function<BlockEntity, FaweCompoundTag> NMS_TO_TILE = ((PaperweightFaweAdapter) WorldEditPlugin
             .getInstance()
             .getBukkitImplAdapter()).blockEntityToCompoundTag();
+    private static final Set<UUID> CREATED_PASSENGERS_UUIDS = new HashSet<>();
     private final PaperweightFaweAdapter adapter = ((PaperweightFaweAdapter) WorldEditPlugin
             .getInstance()
             .getBukkitImplAdapter());
@@ -619,7 +623,7 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                             if (createCopy) {
                                 copy.storeEntity(entity);
                             }
-                            removeEntity(entity);
+                            removeEntityRecursive(entity);
                             entitiesRemoved.add(uuid);
                             entityRemoves.remove(uuid);
                         }
@@ -665,46 +669,52 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                                 .getOptional(Identifier.parse(id))
                                 .orElse(null);
                         if (type != null) {
-                            Entity entity = type.create(nmsWorld, EntitySpawnReason.COMMAND);
-                            if (entity != null) {
-                                final LinCompoundTag.Builder toLoadComponentBuilder = linTag.toBuilder();
-                                for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
-                                    toLoadComponentBuilder.remove(name);
+                            Runnable onError = () -> LOGGER.warn(
+                                    "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
+                                    id,
+                                    nmsWorld.getWorld().getName(),
+                                    x,
+                                    y,
+                                    z
+                            );
+
+                            final LinCompoundTag.Builder toLoadComponentBuilder = linTag.toBuilder();
+                            for (final String name : Constants.NO_COPY_ENTITY_NBT_FIELDS) {
+                                toLoadComponentBuilder.remove(name);
+                            }
+
+                            // NEW: rewrite passenger UUIDs in the tag itself, before it's ever loaded
+                            LinListTag<LinCompoundTag> passengers = linTag.findListTag("Passengers", LinTagType.compoundTag());
+                            if (passengers != null) {
+                                List<LinCompoundTag> rewritten = new ArrayList<>();
+                                for (LinCompoundTag passengerTag : passengers.value()) {
+                                    rewritten.add(randomizePassengerUuidsInTag(passengerTag));
                                 }
-                                ValueInput input = createInput(toLoadComponentBuilder.build());
-                                entity.load(input);
-                                entity.absSnapTo(x, y, z, yaw, pitch);
-                                entity.setUUID(NbtUtils.uuid(nativeTag));
-                                Runnable onError = () -> LOGGER.warn(
-                                        "Error creating entity of type `{}` in world `{}` at location `{},{},{}`",
-                                        id,
-                                        nmsWorld.getWorld().getName(),
-                                        x,
-                                        y,
-                                        z
-                                );
+                                toLoadComponentBuilder.put("Passengers", LinListTag.of(LinTagType.compoundTag(), rewritten));
+                            }
+
+                            ValueInput input = createInput(toLoadComponentBuilder.build());
+
+                            Entity createdEntity = EntityType.loadEntityRecursive(
+                                    type,
+                                    input,
+                                    nmsWorld,
+                                    EntitySpawnReason.COMMAND,
+                                    (loadedEntity) -> {
+                                        loadedEntity.absSnapTo(x, y, z, yaw, pitch);
+                                        return loadedEntity;
+                                    }
+                            );
+
+                            if (createdEntity == null) {
+                                onError.run();
+                                iterator.remove();
+                            } else {
+                                createdEntity.setUUID(NbtUtils.uuid(nativeTag)); // NEW — restore parity with the recorded UUID
                                 if (!set.getSideEffectSet().shouldApply(SideEffect.ENTITY_EVENTS)) {
-                                    entity.spawnReason = CreatureSpawnEvent.SpawnReason.CUSTOM;
-                                    entity.generation = false;
-                                    if (PaperSupport.isPaper()) {
-                                        if (!nmsWorld.moonrise$getEntityLookup().addNewEntity(entity, false)) {
-                                            onError.run();
-                                        }
-                                        continue;
-                                    }
-                                    // Not paper
-                                    try {
-                                        PaperweightPlatformAdapter.getEntitySectionManager(nmsWorld).addNewEntity(entity);
-                                        continue;
-                                    } catch (IllegalAccessException e) {
-                                        // Fallback
-                                        LOGGER.warn("Error bypassing entity events on spawn on Spigot", e);
-                                    }
-                                }
-                                if (!nmsWorld.addFreshEntity(entity, CreatureSpawnEvent.SpawnReason.CUSTOM)) {
-                                    onError.run();
-                                    // Unsuccessful create should not be saved to history
-                                    iterator.remove();
+                                    addRecursiveNoEvents(createdEntity, nmsWorld);
+                                } else {
+                                    nmsWorld.addFreshEntityWithPassengers(createdEntity, CreatureSpawnEvent.SpawnReason.CUSTOM);
                                 }
                             }
                         }
@@ -766,6 +776,51 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
                 };
             }
             return handleCallFinalizer(syncTasks, callback, finalizer);
+        }
+    }
+
+    private void removeEntityRecursive(Entity entity) {
+        // snapshot first — removing the parent may clear/mutate its passenger list mid-iteration
+        List<Entity> passengers = new ArrayList<>(entity.getPassengers());
+        for (Entity passenger : passengers) {
+            if (CREATED_PASSENGERS_UUIDS.contains(passenger.getUUID())) {
+                removeEntityRecursive(passenger);
+            }
+        }
+        removeEntity(entity);
+    }
+
+    private LinCompoundTag randomizePassengerUuidsInTag(LinCompoundTag tag) {
+        UUID fresh = UUID.randomUUID();
+        CREATED_PASSENGERS_UUIDS.add(fresh);
+        int[] uuidInts = {
+                (int) (fresh.getMostSignificantBits() >> 32),
+                (int) fresh.getMostSignificantBits(),
+                (int) (fresh.getLeastSignificantBits() >> 32),
+                (int) fresh.getLeastSignificantBits()
+        };
+
+        LinCompoundTag.Builder builder = tag.toBuilder();
+        builder.putIntArray("UUID", uuidInts);
+
+        LinListTag<LinCompoundTag> passengers = tag.findListTag("Passengers", LinTagType.compoundTag());
+        if (passengers != null) {
+            List<LinCompoundTag> rewritten = new ArrayList<>();
+            for (LinCompoundTag passengerTag : passengers.value()) {
+                rewritten.add(randomizePassengerUuidsInTag(passengerTag)); // recurse for nested riders
+            }
+            builder.put("Passengers", LinListTag.of(LinTagType.compoundTag(), rewritten));
+        }
+
+        return builder.build();
+    }
+
+    private void addRecursiveNoEvents(Entity entity, ServerLevel nmsWorld) {
+        entity.spawnReason = CreatureSpawnEvent.SpawnReason.CUSTOM;
+        entity.generation = false;
+        nmsWorld.moonrise$getEntityLookup().addNewEntity(entity, false);
+        for (Entity passenger : entity.getPassengers()) {
+            addRecursiveNoEvents(passenger, nmsWorld);
         }
     }
 

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/IChunkExtent.java
@@ -126,6 +126,9 @@ public interface IChunkExtent<T extends IChunk> extends Extent {
     @Override
     default Entity createEntity(Location location, BaseEntity entity, UUID uuid) {
         final IChunk chunk = getOrCreateChunk(location.getBlockX() >> 4, location.getBlockZ() >> 4);
+        if (entity.getNbt() == null) {
+            return null; // don't attempt to spawn "empty" entity
+        }
         Map<String, LinTag<?>> map = new HashMap<>(entity.getNbt().value()); //do not modify original entity data
         map.put("Id", LinStringTag.of(entity.getType().getName()));
 


### PR DESCRIPTION
## Overview
Fixes #2091 
Fixes #2427 
Partially fixes #2140 

## Description
Allow copied passengers from being spawned when pasting.
I also had to modify a part of the removal so that //undo successfully removes the entities.
In this context of //undo, I introduced a new field : CREATED_PASSENGERS_UUIDS to track which entity was spawned by the //paste. 
Doing this prevents the removal of other entities riding pasted entities.

Here are the tests that I did : 
- copy/paste entities
- copy/paste entities with passengers
- copy/paste entities -> undo
- copy/paste entities with passengers -> undo

As you can see, for now, I only fixed the 26.2 version. As I am not using other versions, it would be great if someone could do it.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
